### PR TITLE
Fix layout issue when image removed

### DIFF
--- a/src/client/styles/homePage.js
+++ b/src/client/styles/homePage.js
@@ -24,12 +24,13 @@ const homePageStyle = theme => ({
   mainText: {
     marginRight: theme.spacing(-9),
     paddingLeft: theme.spacing(10),
+    paddingBottom: theme.spacing(4),
     [theme.breakpoints.up('xl')]: {
       marginRight: theme.spacing(-15),
     },
     [theme.breakpoints.down('xs')]: {
       marginRight: '0',
-      padding: theme.spacing(0, 4),
+      padding: theme.spacing(0, 4, 4, 4),
     },
   },
   mainTitle: {


### PR DESCRIPTION
## Problem

When the landing image is removed, the learn more button cuts into the text above

## Solution

Add padding to the bottom of the text

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/17681226/78874647-49741100-7a7f-11ea-976c-15ef96463df0.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/17681226/78874677-56910000-7a7f-11ea-9966-eda595c90573.png)
