### PR TITLE
Fix IE qr code generation

### DIFF
--- a/src/client/util/QRCode.js
+++ b/src/client/util/QRCode.js
@@ -126,7 +126,7 @@ export default class QRCode extends React.Component {
             svg.appendChild(image)
 
             // Display the svg
-            svgContainer.innerHTML = svg.outerHTML
+            svgContainer.innerHTML = new XMLSerializer().serializeToString(svg)
           }
         }
       }


### PR DESCRIPTION
## Problem

#7 

Currently, QR code generation is broken on Internet Explorer

## Solution

As IE does not support `svg.outerHTML`, I used `XMLSerializer` instead.

As such, QR code generation and SVG download is now working, unfortunately, PNG download is still not working, this as IE forbids downloading a canvas that has been 'tainted' with an SVG inside [(source)](https://stackoverflow.com/questions/33392591/in-browser-conversion-of-svg-to-png-image-cross-browser-including-ie)

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/17681226/78900670-c2885e00-7aa9-11ea-9501-83245a6162cd.png)


**AFTER**:
![image](https://user-images.githubusercontent.com/17681226/78900638-b8665f80-7aa9-11ea-9e1b-4bda0082f3e6.png)

