### PR TITLE
Fix the SVG

### DIFF
--- a/src/client/styles/homePage.js
+++ b/src/client/styles/homePage.js
@@ -5,7 +5,7 @@ const homePageStyle = theme => ({
     [theme.breakpoints.up('md')]: {
       // Fill whole screen
       height: `calc(100vh - ${theme.spacing(12)}px)`,
-      maxHeight: '60vw', // Upper bound for large portrait devices 
+      maxHeight: '60vw', // Upper bound for large portrait devices
     },
     minHeight: '500px',
   },

--- a/src/client/util/QRCode.js
+++ b/src/client/util/QRCode.js
@@ -1,5 +1,3 @@
-
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import qr from 'qrcode'

--- a/src/client/util/QRCode.js
+++ b/src/client/util/QRCode.js
@@ -77,6 +77,10 @@ export default class QRCode extends React.Component {
       canvas.toBlob((blob) => {
         FileSaver.saveAs(blob, `${filename}.png`, 'image/png')
       })
+
+      // Reset width and height attributes of svg,
+      svg.removeAttribute('width', svg.clientWidth)
+      svg.removeAttribute('height', svg.clientHeight)
     }
     loader.src = `data:image/svg+xml,${encodeURIComponent(svgAsXML)}`
   }

--- a/src/server/util/ga.ts
+++ b/src/server/util/ga.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import uuidv4 from 'uuid/v4'
 import request from 'request'
-import { gaTrackingId, ogUrl, logger } from '../config'
+import { gaTrackingId, logger, ogUrl } from '../config'
 import getIp from './request'
 
 type CookieData = {


### PR DESCRIPTION
## Problem

Closes #26.

## Solution

Our previous fix to render QR code in `.png` format on FireFox required us to set a specified height and width, which has caused problems to the `.svg` side. The solution is to unset the specified height and width after rendering the `.png` format QR code.

**Improvements**:

- Committed eslint format changes.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/28863045/78935315-195c5a80-7adf-11ea-96e5-6e7433915b98.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/28863045/78935322-1c574b00-7adf-11ea-89f5-a7d72cd4b22a.png)
