### PR TITLE
Enforce no-cache behaviour via Cache-Control header

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -55,6 +55,12 @@ initDb()
     // Initialise nodemailer
     initMailer()
 
+    // Site-wide cache control
+    app.use((_, res, next) => {
+      res.header('Cache-Control', 'no-store')
+      next()
+    })
+
     // To serve from build
     app.use(express.static('dist'))
 
@@ -87,7 +93,6 @@ initDb()
     // API configuration
     app.use((_, res, next) => {
       res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH')
-      res.header('Cache-Control', 'no-store')
       next()
     })
     app.use(bodyParser.urlencoded({ extended: false })) // application/x-www-form-urlencoded

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -87,6 +87,7 @@ initDb()
     // API configuration
     app.use((_, res, next) => {
       res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH')
+      res.header('Cache-Control', 'no-store')
       next()
     })
     app.use(bodyParser.urlencoded({ extended: false })) // application/x-www-form-urlencoded


### PR DESCRIPTION
## Problem

Browsers are unnecessarily caching resources and server responses.

This results in `bundle.js` being momentarily outdated on new redeployments. IE's behaviour of caching responses without revalidation also creates problems because even after signing out, it still mistakenly thinks it is still logged in due to outdated auth-check responses.

Closes #4 and closes #5 .

## Solution

Send `Cache-Control: no-store` header for every outgoing response. This is implemented using a middleware that is inserted very early in the pipeline, right before `express.static` is being used. This allows even `bundle.js` to be not be cached.
