### PR TITLE
Resolve deployment timeout issues on Elastic Beanstalk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,30 @@ script:
   - npm run build
 #TODO: test
 
-# Directly rely on presence of Dockerfile to deploy
+before_deploy:
+  # Workaround to run before_deploy only once
+  - >
+    if ! [ "$TAG" ]; then
+      pip install --user awscli
+
+      # Put AWS in path
+      export PATH=$PATH:$HOME/.local/bin
+
+      # Login to AWS ECR, credentials defined in $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY
+      $(aws ecr get-login --no-include-email --region ap-southeast-1)
+      export TAG=travis-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
+      docker build -f Dockerfile -t $REPO:$TAG .
+      docker tag $REPO:$TAG $REPO:$TRAVIS_BRANCH
+      docker push $REPO
+
+      # Edit Dockerrun from Travis environment variables
+      sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
+      sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
+      cat Dockerrun.aws.json
+      zip -r "$TAG.zip" Dockerrun.aws.json
+    fi
+  - export ELASTIC_BEANSTALK_LABEL="$TAG-$(env TZ=Asia/Singapore date "+%Y%m%d%H%M%S")"
+
 deploy:
   - provider: elasticbeanstalk
     skip_cleanup: true
@@ -35,8 +58,10 @@ deploy:
     app: $AWS_EB_APP_STAGING
     env: $AWS_EB_ENV_STAGING
     bucket_name: $AWS_EB_BUCKET_STAGING
+    zip_file: "$TAG.zip"
     on:
       branch: $STAGING_BRANCH
+
   - provider: elasticbeanstalk
     skip_cleanup: true
     access_key_id: $AWS_ACCESS_KEY_ID
@@ -45,5 +70,6 @@ deploy:
     app: $AWS_EB_APP_PRODUCTION
     env: $AWS_EB_ENV_PRODUCTION
     bucket_name: $AWS_EB_BUCKET_PRODUCTION
+    zip_file: "$TAG.zip"
     on:
       branch: $PRODUCTION_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ before_deploy:
       # Edit Dockerrun from Travis environment variables
       sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
       sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
-      cat Dockerrun.aws.json
       zip -r "$TAG.zip" Dockerrun.aws.json
     fi
   - export ELASTIC_BEANSTALK_LABEL="$TAG-$(env TZ=Asia/Singapore date "+%Y%m%d%H%M%S")"

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "@REPO:@TAG",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "8080"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The official Singapore government link shortener.
   - [Getting Started](#getting-started)
     - [Running Locally](#running-locally)
     - [Setting up the infrastructure](#setting-up-the-infrastructure)
+    - [Deploying](#deploying)
   - [Pre-release](#pre-release)
   - [Documentation](#documentation)
     - [Folder Structure](#folder-structure)
@@ -20,7 +21,6 @@ The official Singapore government link shortener.
     - [Express](#express)
     - [Concurrently](#concurrently)
     - [VSCode + ESLint](#vscode--eslint)
-  - [Contributing to GoGovSG](https://github.com/opengovsg/GoGovSG/blob/master/CONTRIBUTING.md)
 
 ## Introduction
 
@@ -99,6 +99,26 @@ After these have been set up, set the environment variables according to the tab
 Trigger the typescript compilation and webpack bundling process by calling `npm run build`.
 
 Finally, start the production server by running `npm start`.
+
+### Deploying
+
+GoGovSG uses Travis to deploy to AWS Elastic Beanstalk. We also use Sentry.io to track client-side errors.
+
+|Environment Variable|Required|Description/Value|
+|:---:|:---:|:---|
+|AWS_ACCESS_KEY_ID|Yes|AWS credential ID used to deploy to Elastic Beanstalk|
+|AWS_SECRET_ACCESS_KEY|Yes|AWS credential secret used to deploy to Elastic Beanstalk|
+|AWS_EB_ENV_PRODUCTION, AWS_EB_ENV_STAGING|Yes|Elastic Beanstalk environment name|
+|AWS_EB_APP_PRODUCTION, AWS_EB_APP_STAGING|Yes|Elastic Beanstalk application name|
+|AWS_EB_BUCKET_PRODUCTION, AWS_EB_BUCKET_STAGING|Yes|S3 bucket used to store the application bundle|
+|AWS_EB_REGION|Yes|AWS region to deploy to, e.g. `ap-southeast-1`|
+|EMAIL_RECIPIENT|Yes|Email for Travis notifications|
+|PRODUCTION_BRANCH, STAGING_BRANCH|Yes|Name of Git branches for triggerring deployments to production/staging respectively|
+|REPO|Yes|Docker container registry URI to push built images to|
+|SENTRY_ORG|No|Sentry.io organisation name|
+|SENTRY_PROJECT|No|Sentry.io project name|
+|SENTRY_URL|No|Sentry.io URL e.g. `https://sentry.io/`|
+|SENTRY_DNS|No|Sentry.io endpoint to post client-side errors to|
 
 ## Pre-release
 


### PR DESCRIPTION
## Problem

Deployments to Elastic Beanstalk were failing with an inexplicable timeout issue, preventing deployments to staging and production environments.

## Solution

The initial suspect was cast on the Elastic Beanstalk version due to certain filesystem mounting warnings in `eb-activity`. However upgrading the EB platform did not resolve this issue as discovered by @yong-jie and @kylerwsm . Further investigation revealed that EB deployments have a deployment timeout that if exceeded, would terminate a deployment.

The solution was to move the image build step out of the EB deployment pipeline into the Travis pre-deploy pipeline instead. Images would be built in Travis and pushed to the AWS Elastic Container Registry before triggering a deploy in Elastic Beanstalk. EB would only have to download the image instead of spending long periods time building it during the deployment.

## Improvements

Added a section on deploying with Travis to the README.

## Tests

Repeated deploys of this branch to `edge`.

