### PR TITLE
Release 1.13.5 - Resolve deployment timeouts by moving image build from Elastic Beanstalk to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,29 @@ script:
   - npm run build
 #TODO: test
 
-# Directly rely on presence of Dockerfile to deploy
+before_deploy:
+  # Workaround to run before_deploy only once
+  - >
+    if ! [ "$TAG" ]; then
+      pip install --user awscli
+
+      # Put AWS in path
+      export PATH=$PATH:$HOME/.local/bin
+
+      # Login to AWS ECR, credentials defined in $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY
+      $(aws ecr get-login --no-include-email --region ap-southeast-1)
+      export TAG=travis-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
+      docker build -f Dockerfile -t $REPO:$TAG .
+      docker tag $REPO:$TAG $REPO:$TRAVIS_BRANCH
+      docker push $REPO
+
+      # Edit Dockerrun from Travis environment variables
+      sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
+      sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
+      zip -r "$TAG.zip" Dockerrun.aws.json
+    fi
+  - export ELASTIC_BEANSTALK_LABEL="$TAG-$(env TZ=Asia/Singapore date "+%Y%m%d%H%M%S")"
+
 deploy:
   - provider: elasticbeanstalk
     skip_cleanup: true
@@ -35,8 +57,10 @@ deploy:
     app: $AWS_EB_APP_STAGING
     env: $AWS_EB_ENV_STAGING
     bucket_name: $AWS_EB_BUCKET_STAGING
+    zip_file: "$TAG.zip"
     on:
       branch: $STAGING_BRANCH
+
   - provider: elasticbeanstalk
     skip_cleanup: true
     access_key_id: $AWS_ACCESS_KEY_ID
@@ -45,5 +69,6 @@ deploy:
     app: $AWS_EB_APP_PRODUCTION
     env: $AWS_EB_ENV_PRODUCTION
     bucket_name: $AWS_EB_BUCKET_PRODUCTION
+    zip_file: "$TAG.zip"
     on:
       branch: $PRODUCTION_BRANCH

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "@REPO:@TAG",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "8080"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The official Singapore government link shortener.
   - [Getting Started](#getting-started)
     - [Running Locally](#running-locally)
     - [Setting up the infrastructure](#setting-up-the-infrastructure)
+    - [Deploying](#deploying)
   - [Pre-release](#pre-release)
   - [Documentation](#documentation)
     - [Folder Structure](#folder-structure)
@@ -20,7 +21,6 @@ The official Singapore government link shortener.
     - [Express](#express)
     - [Concurrently](#concurrently)
     - [VSCode + ESLint](#vscode--eslint)
-  - [Contributing to GoGovSG](https://github.com/opengovsg/GoGovSG/blob/master/CONTRIBUTING.md)
 
 ## Introduction
 
@@ -99,6 +99,26 @@ After these have been set up, set the environment variables according to the tab
 Trigger the typescript compilation and webpack bundling process by calling `npm run build`.
 
 Finally, start the production server by running `npm start`.
+
+### Deploying
+
+GoGovSG uses Travis to deploy to AWS Elastic Beanstalk. We also use Sentry.io to track client-side errors.
+
+|Environment Variable|Required|Description/Value|
+|:---:|:---:|:---|
+|AWS_ACCESS_KEY_ID|Yes|AWS credential ID used to deploy to Elastic Beanstalk|
+|AWS_SECRET_ACCESS_KEY|Yes|AWS credential secret used to deploy to Elastic Beanstalk|
+|AWS_EB_ENV_PRODUCTION, AWS_EB_ENV_STAGING|Yes|Elastic Beanstalk environment name|
+|AWS_EB_APP_PRODUCTION, AWS_EB_APP_STAGING|Yes|Elastic Beanstalk application name|
+|AWS_EB_BUCKET_PRODUCTION, AWS_EB_BUCKET_STAGING|Yes|S3 bucket used to store the application bundle|
+|AWS_EB_REGION|Yes|AWS region to deploy to, e.g. `ap-southeast-1`|
+|EMAIL_RECIPIENT|Yes|Email for Travis notifications|
+|PRODUCTION_BRANCH, STAGING_BRANCH|Yes|Name of Git branches for triggerring deployments to production/staging respectively|
+|REPO|Yes|Docker container registry URI to push built images to|
+|SENTRY_ORG|No|Sentry.io organisation name|
+|SENTRY_PROJECT|No|Sentry.io project name|
+|SENTRY_URL|No|Sentry.io URL e.g. `https://sentry.io/`|
+|SENTRY_DNS|No|Sentry.io endpoint to post client-side errors to|
 
 ## Pre-release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Link shortener for Singapore government.",
   "main": "src/server/index.js",
   "scripts": {


### PR DESCRIPTION
## Improvements

* Images are built in Travis and pushed to Amazon Elastic Container Registry
* Images are pulled from ECR by EB during deployment
*  Resolves deployment timeout issues on Elastic Beanstalk
* Add Travis deployment instructions to readme