### PR TITLE
Expose pre-signed upload url endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ After these have been set up, set the environment variables according to the tab
 |NODE_ENV|Yes|`production`|
 |DB_URI|Yes|The postgres connection string, e.g. `postgres://postgres:postgres@postgres:5432/postgres`|
 |OG_URL|Yes|The origin url, used for both google analytics and circular-redirect prevention. E.g. `https://go.gov.sg`|
+|AWS_S3_BUCKET|Yes|The bucket name used for storing file uploads.|
 |REDIS_OTP_URI|Yes|Redis connection string, e.g. `redis://redis:6379/0`|
 |REDIS_SESSION_URI|Yes|Redis connection string, e.g. `redis://redis:6379/1`|
 |REDIS_REDIRECT_URI|Yes|Redis connection string, e.g. `redis://redis:6379/2`|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - OG_URL=https://go.gov.sg
       - VALID_EMAIL_GLOB_EXPRESSION=*.gov.sg
       - LOGIN_MESSAGE=Your OTP might take awhile to get to you.
+      - AWS_S3_BUCKET=file-staging.go.gov.sg
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/package-lock.json
+++ b/package-lock.json
@@ -2016,6 +2016,58 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.658.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.658.0.tgz",
+      "integrity": "sha512-vb+CorOG2lod4ZztrVaE3hcSjTwnB9HhTOnD/2R9YJtIUGTJqL0CIDTwo0Q384GFROtDhp7j6SX7oKFwdzDEuA==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -6942,6 +6994,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -8821,8 +8878,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -11836,6 +11892,20 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/request": "^2.48.1",
     "@types/uuid": "^3.4.4",
     "@types/validator": "^10.11.0",
+    "aws-sdk": "^2.658.0",
     "babel-polyfill": "^6.26.0",
     "bcrypt": "^3.0.6",
     "body-parser": "^1.18.3",

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -108,6 +108,13 @@ function validateState(req: Express.Request, res: Express.Response, next: Expres
 
 /**
  * Make sure all parameters needed for the pre-signed url request are present.
+ *
+ * @param {string} fileType - File type of the file that is being uploaded.
+ * This must be declared here so that subsequent PUT requests to the pre-signed URL
+ * will pass header checks.
+ * @param {string} key - Name of the entry to be inserted to the S3 bucket. Ensure
+ * that the key does not collide with other files before declaring it here. Otherwise,
+ * it will cause an existing file of the same key to be overridden.
  */
 function validatePresignedUrlRequest(
   req: Express.Request,

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -115,10 +115,9 @@ function validatePresignedUrlRequest(
   next: Express.NextFunction,
 ) {
   if (!req.body.fileType || !req.body.key) {
-    res.badRequest(
+    return res.badRequest(
       jsonMessage('Some or all required arguments are missing: fileType, key.')
     )
-    return
   }
   next()
 }

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -110,8 +110,8 @@ function validateState(req: Express.Request, res: Express.Response, next: Expres
  * Make sure all parameters needed for the pre-signed url request are present.
  *
  * @param {string} fileType - File type of the file that is being uploaded.
- * This must be declared here so that subsequent PUT requests to the pre-signed URL
- * will pass header checks.
+ * This must be declared here so that subsequent PUT requests that use the
+ * Content-Type header will pass header checks.
  * @param {string} key - Name of the entry to be inserted to the S3 bucket. Ensure
  * that the key does not collide with other files before declaring it here. Otherwise,
  * it will cause an existing file of the same key to be overridden.

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -119,7 +119,7 @@ function validatePresignedUrlRequest(
       jsonMessage('Some or all required arguments are missing: fileType, key.')
     )
   }
-  next()
+  return next()
 }
 
 /**

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -111,7 +111,7 @@ function validateState(req: Express.Request, res: Express.Response, next: Expres
  *
  * @param {string} fileType - File type of the file that is being uploaded.
  * This must be declared here so that subsequent PUT requests that use the
- * Content-Type header will pass header checks.
+ * `Content-Type` header will pass header checks.
  * @param {string} key - Name of the entry to be inserted to the S3 bucket. Ensure
  * that the key does not collide with other files before declaring it here. Otherwise,
  * it will cause an existing file of the same key to be overridden.

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -27,6 +27,7 @@ const requiredVars: string[] = [
   'REDIS_STAT_URI', // Cache for statistics (user, link, and click counts)
   'SESSION_SECRET',
   'VALID_EMAIL_GLOB_EXPRESSION', // Glob pattern for valid emails
+  'AWS_S3_BUCKET', // For file.go.gov.sg uploads
 ]
 
 // AWS Simple Email Service
@@ -131,7 +132,7 @@ export const emailValidator = new minimatch.Minimatch(
   }
 )
 export const loginMessage = process.env.LOGIN_MESSAGE
-
+export const s3Bucket = process.env.AWS_S3_BUCKET as string
 
 export const databaseUri = process.env.DB_URI as string
 export const redisOtpUri = process.env.REDIS_OTP_URI as string

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -13,10 +13,15 @@ export const s3 = new S3()
  * Broadly speaking, we need to change https://s3.amazonaws.com/file.go.gov.sg/link?search
  * to https://file.go.gov.sg.s3.amazonaws.com/link?search.
  */
-const reformatPresignedUrl = (url: string) => {
+const reformatPresignedUrl = (url: string, fileName: string) => {
   const urlObj = parse(url)
-  const { pathname, protocol, search } = urlObj
-  return `${protocol}//${pathname?.substring(1)}${search}`
+  const {
+    host,
+    pathname,
+    protocol,
+    search,
+  } = urlObj
+  return `${protocol}//${pathname?.split('/')[1]}.${host}/${fileName}${search}`
 }
 
 export const generatePresignedUrl = async (fileName: string, fileType: string) => {
@@ -27,5 +32,5 @@ export const generatePresignedUrl = async (fileName: string, fileType: string) =
     Expires: 60, // 60 seconds.
   }
   const presignedUrl = await s3.getSignedUrlPromise('putObject', params)
-  return reformatPresignedUrl(presignedUrl)
+  return reformatPresignedUrl(presignedUrl, fileName)
 }

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -1,0 +1,13 @@
+import { S3 } from 'aws-sdk'
+
+export const s3 = new S3()
+
+export const generatePresignedUrl = async (fileName: string, fileType: string) => {
+  const params = {
+    Bucket: 'file-staging.go.gov.sg',
+    Key: fileName,
+    ContentType: fileType,
+    Expires: 60, // 60 seconds.
+  }
+  return s3.getSignedUrlPromise('putObject', params)
+}

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -1,6 +1,22 @@
+import { parse } from 'url'
 import { S3 } from 'aws-sdk'
 
 export const s3 = new S3()
+
+/**
+ * Reformat the pre-signed url to to one that will be accepted by S3.
+ *
+ * This is necessary because we used a gov.sg CNAME and configured S3
+ * to only accept requests that have that gov.sg CNAME as the path.
+ *
+ * Broadly speaking, we need to change https://s3.aws.com/file.go.gov.sg/link?search
+ * to https://file.go.gov.sg/link?search.
+ */
+const reformatPresignedUrl = (url: string) => {
+  const urlObj = parse(url)
+  const { pathname, protocol, search } = urlObj
+  return `${protocol}//${pathname?.substring(1)}${search}`
+}
 
 export const generatePresignedUrl = async (fileName: string, fileType: string) => {
   const params = {
@@ -9,5 +25,6 @@ export const generatePresignedUrl = async (fileName: string, fileType: string) =
     ContentType: fileType,
     Expires: 60, // 60 seconds.
   }
-  return s3.getSignedUrlPromise('putObject', params)
+  const presignedUrl = await s3.getSignedUrlPromise('putObject', params)
+  return reformatPresignedUrl(presignedUrl)
 }

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -1,4 +1,4 @@
-import { parse } from 'url'
+import { parse, URL } from 'url'
 import { S3 } from 'aws-sdk'
 import { s3Bucket } from '../config'
 
@@ -21,7 +21,12 @@ const reformatPresignedUrl = (url: string, fileName: string) => {
     protocol,
     search,
   } = urlObj
-  return `${protocol}//${pathname?.split('/')[1]}.${host}/${fileName}${search}`
+  const newUrl = new URL('https://lorem-ipsum.com')
+  newUrl.protocol = protocol as string
+  newUrl.host = `${pathname?.split('/')[1]}.${host}`
+  newUrl.pathname = fileName
+  newUrl.search = search as string
+  return newUrl.href
 }
 
 export const generatePresignedUrl = async (fileName: string, fileType: string) => {

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -5,7 +5,7 @@ import { s3Bucket } from '../config'
 export const s3 = new S3()
 
 /**
- * Reformat the pre-signed url to to one that will be accepted by S3.
+ * Reformat the pre-signed url to one that will be accepted by S3.
  *
  * This is necessary because we used a gov.sg CNAME and configured S3
  * to only accept requests that have that gov.sg CNAME as the path.

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -9,8 +9,8 @@ export const s3 = new S3()
  * This is necessary because we used a gov.sg CNAME and configured S3
  * to only accept requests that have that gov.sg CNAME as the path.
  *
- * Broadly speaking, we need to change https://s3.aws.com/file.go.gov.sg/link?search
- * to https://file.go.gov.sg/link?search.
+ * Broadly speaking, we need to change https://s3.amazonaws.com/file.go.gov.sg/link?search
+ * to https://file.go.gov.sg.s3.amazonaws.com/link?search.
  */
 const reformatPresignedUrl = (url: string) => {
   const urlObj = parse(url)

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -1,5 +1,6 @@
 import { parse } from 'url'
 import { S3 } from 'aws-sdk'
+import { s3Bucket } from '../config'
 
 export const s3 = new S3()
 
@@ -20,7 +21,7 @@ const reformatPresignedUrl = (url: string) => {
 
 export const generatePresignedUrl = async (fileName: string, fileType: string) => {
   const params = {
-    Bucket: 'file-staging.go.gov.sg',
+    Bucket: s3Bucket,
     Key: fileName,
     ContentType: fileType,
     Expires: 60, // 60 seconds.


### PR DESCRIPTION
## Feature

Expose a new endpoint that allows authenticated users to generate pre-signed urls for file uploads.

## Caveats
This feature works with user-level IAM credentials, but the pre-signed URL generated on elastic beanstalk staging does not work, pending some help regarding permission settings for the EB's role.

## Tests

Before merging, the problem of elastic beanstalk pre-signed links not working should be first fixed.

**New environment variables**:

- `AWS_S3_BUCKET` : The bucket name used for storing file uploads.

**New dependencies**:

- `aws-sdk` : Used to generate S3 pre-signed upload links

