### PR TITLE
Add `isFile` column in url table

### DIFF
--- a/src/server/db_migrations/20200427_add_isFile_column.sql
+++ b/src/server/db_migrations/20200427_add_isFile_column.sql
@@ -1,0 +1,12 @@
+-- This script should be the first to be run because it adds
+-- a nullable column isFile to both urls and url_histories
+-- tables, which is backwards-compatible with the current
+-- codebase.
+
+BEGIN TRANSACTION;
+
+ALTER TABLE urls ADD "isFile" boolean;
+
+ALTER TABLE url_histories ADD "isFile" boolean;
+
+COMMIT;

--- a/src/server/db_migrations/20200428_backfill_isFile_column.sql
+++ b/src/server/db_migrations/20200428_backfill_isFile_column.sql
@@ -1,0 +1,15 @@
+-- This migration script is to be run only after backend code
+-- has been updated to write into the isFile column. This is because
+-- the column will be made NOT NULL here.
+
+BEGIN TRANSACTION;
+
+UPDATE urls SET "isFile" = false WHERE "isFile" IS NULL;
+
+UPDATE url_histories SET "isFile" = false WHERE "isFile" IS NULL;
+
+ALTER TABLE urls ALTER COLUMN "isFile" SET NOT NULL;
+
+ALTER TABLE url_histories ALTER COLUMN "isFile" SET NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Problem

We need to introduce a column in the url table to indicate whether a shortlink is pointing to a file.go.gov.sg object.

## Solution
Create two scripts.  The first would be to add the isFile column in a backwards-compatible way. This is done by making the column nullable(already true by default). After future PRs that update the codebase to start writing into the isFile column, run the second script to backfill and set the not-null constraint.

## Follow up
I'll PR the next step which updates the url model after the migration strategy has been finalised and merged.

