### PR TITLE
Refactor /redirect endpoint in preparation for transition page

### DIFF
--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -4,6 +4,7 @@ import { Url } from '../models'
 import { ACTIVE } from '../models/types'
 import { gaTrackingId, logger, redirectExpiry } from '../config'
 import { generateCookie, sendPageViewHit } from '../util/ga'
+import { NotFoundError } from '../util/error'
 
 const error404Path = '404.error.ejs'
 
@@ -14,7 +15,7 @@ const error404Path = '404.error.ejs'
  * @param {String} shortUrl Short url of link.
  * @param {String} longUrl  Long url of link.
  */
-function gaLogging(req: Express.Request, res:Express.Response, shortUrl: string, longUrl: string) {
+function gaLogging(req: Express.Request, res:Express.Response, shortUrl: string, longUrl: string): void {
   const cookie = generateCookie(req)
   if (cookie) {
     res.cookie(...cookie)
@@ -23,11 +24,113 @@ function gaLogging(req: Express.Request, res:Express.Response, shortUrl: string,
 }
 
 /**
- *
+ * Looks up the longUrl from the cache.
+ * @param {string} shortUrl 
+ * @returns {Promise<string>}
+ * @throws {NotFoundError}
+ */
+function getLongUrlFromCache (shortUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Check if cache contains value
+    redirectClient.get(shortUrl, (cacheError, cacheLongUrl) => {
+      if (cacheError) {
+        // Log and fallback to looking in the database
+        logger.error(`Cache lookup failed unexpectedly:\t${cacheError}`)
+        reject(cacheError)
+      } else {
+        if (!cacheLongUrl) {
+          reject(new NotFoundError(`longUrl not found in cache:\tshortUrl=${shortUrl}`))
+        }
+        // Cache lookup succeeded
+        resolve(cacheLongUrl)
+      }
+    })
+  })
+}
+
+/**
+ * Looks up the longUrl from the database given a short link
+ * @param {string} shortUrl
+ * @returns {Promise<string>}
+ * @throws {NotFoundError}
+ */
+function getLongUrlFromDatabase (shortUrl: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    // Could not lookup from cache, look in database
+    Url.findOne({
+      where: {
+        shortUrl,
+        state: ACTIVE,
+      },
+    }).then((url) => {
+      // No such URL
+      if (!url) {
+        reject(new NotFoundError(`longUrl not found in database:\tshortUrl=${shortUrl}`))
+      } else {
+        resolve(url.longUrl)
+      }
+    })
+  })
+}
+
+/**
+ * Cache a link in Redis
+ * @param shortUrl The short link
+ * @param longUrl The long URL
+ * @throws {Error}
+ */
+function cacheShortUrl (shortUrl: string, longUrl: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    redirectClient.set(shortUrl, longUrl, 'EX', redirectExpiry, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}
+
+/**
+ * Looks up the longUrl given a shortUrl from the cache, falling back
+ * to the database. The cache is re-populated if the database lookup is
+ * performed successfully.
+ * @param {string} shortUrl 
+ * @returns {Promise<string>}
+ * @throws {NotFoundError}
+ */
+async function getLongUrlFromStore (shortUrl: string): Promise<string> {
+  try {
+    // Cache lookup
+    return await getLongUrlFromCache(shortUrl)
+  } catch {
+    // Cache failed, look in database
+    const longUrl = await getLongUrlFromDatabase(shortUrl)
+    try {
+      cacheShortUrl(shortUrl, longUrl)
+    } catch (err) {
+      logger.error(err)
+    }
+    return longUrl
+  }
+}
+
+/**
+ * Asynchronously increment the number of clicks in the database
+ * @param shortUrl 
+ */
+function incrementClick (shortUrl: string): void {
+  // Update clicks in database
+  Url.findOne({ where: { shortUrl } }).then((url) => {
+    if (url) {
+      url.increment('clicks')
+    }
+  })
+}
+
+/**
+ * The redirect function
  * @param {Object} req Express request object.
  * @param {Object} res Express response object.
  */
-async function redirect(req: Express.Request, res: Express.Response) {
+export default async function redirect(req: Express.Request, res: Express.Response) {
   let { shortUrl } = req.params
 
   // Short link must consist of valid characters
@@ -36,48 +139,24 @@ async function redirect(req: Express.Request, res: Express.Response) {
     return
   }
   shortUrl = shortUrl.toLowerCase()
-  // Check if cache contains value
-  redirectClient.get(shortUrl, (cacheError, cacheLongUrl) => {
-    if (cacheError) {
-      // Log and fallback to database
-      logger.error(`Access to redirect cache failed unexpectedly:\t${cacheError}`)
-    } else if (cacheLongUrl) {
-      if (gaTrackingId) gaLogging(req, res, shortUrl, cacheLongUrl)
 
-      // Redirect using cached value
-      res.status(302).redirect(cacheLongUrl)
+  try {
+    // Find longUrl and redirect
+    const longUrl = await getLongUrlFromStore(shortUrl)
 
-      // Update clicks in database
-      Url.findOne({ where: { shortUrl } }).then((url) => {
-        if (url) {
-          url.increment('clicks')
-        }
-      })
-    } else {
-      // Not cached, look in database
-      Url.findOne({
-        where: {
-          shortUrl,
-          state: ACTIVE,
-        },
-      }).then((url) => {
-        // No such URL
-        if (!url) {
-          res.status(404).render(error404Path, { shortUrl })
-        } else {
-          if (gaTrackingId) gaLogging(req, res, shortUrl, url.longUrl)
-          // Redirect user
-          res.status(302).redirect(url.longUrl)
+    // Update clicks in database
+    incrementClick(shortUrl)
 
-          // Update clicks in database
-          url.increment('clicks')
+    // Google analytics
+    if (gaTrackingId) gaLogging(req, res, shortUrl, longUrl)
 
-          // Cache URL
-          redirectClient.set(shortUrl, url.longUrl, 'EX', redirectExpiry)
-        }
-      })
-    }
-  })
+    // Redirect
+    return res.status(302).redirect(longUrl)
+  } catch (error) {
+
+    if (!(error instanceof NotFoundError))
+      logger.error(`Redirect error: ${error} ${error instanceof NotFoundError}`)
+
+    return res.status(404).render(error404Path, { shortUrl })
+  }
 }
-
-export default redirect

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -31,17 +31,14 @@ function gaLogging(req: Express.Request, res:Express.Response, shortUrl: string,
  */
 function getLongUrlFromCache (shortUrl: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Check if cache contains value
     redirectClient.get(shortUrl, (cacheError, cacheLongUrl) => {
       if (cacheError) {
-        // Log and fallback to looking in the database
         logger.error(`Cache lookup failed unexpectedly:\t${cacheError}`)
         reject(cacheError)
       } else {
         if (!cacheLongUrl) {
           reject(new NotFoundError(`longUrl not found in cache:\tshortUrl=${shortUrl}`))
         }
-        // Cache lookup succeeded
         resolve(cacheLongUrl)
       }
     })
@@ -56,14 +53,12 @@ function getLongUrlFromCache (shortUrl: string): Promise<string> {
  */
 function getLongUrlFromDatabase (shortUrl: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    // Could not lookup from cache, look in database
     Url.findOne({
       where: {
         shortUrl,
         state: ACTIVE,
       },
     }).then((url) => {
-      // No such URL
       if (!url) {
         reject(new NotFoundError(`longUrl not found in database:\tshortUrl=${shortUrl}`))
       } else {
@@ -117,7 +112,6 @@ async function getLongUrlFromStore (shortUrl: string): Promise<string> {
  * @param shortUrl 
  */
 function incrementClick (shortUrl: string): void {
-  // Update clicks in database
   Url.findOne({ where: { shortUrl } }).then((url) => {
     if (url) {
       url.increment('clicks')
@@ -141,7 +135,7 @@ export default async function redirect(req: Express.Request, res: Express.Respon
   shortUrl = shortUrl.toLowerCase()
 
   try {
-    // Find longUrl and redirect
+    // Find longUrl to redirect to
     const longUrl = await getLongUrlFromStore(shortUrl)
 
     // Update clicks in database

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -1,0 +1,7 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+    Object.setPrototypeOf(this, NotFoundError.prototype)
+  }
+}

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -1,7 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
 export class NotFoundError extends Error {
   constructor(message: string) {
-    super(message);
-    this.name = "NotFoundError";
+    super(message)
+    this.name = 'NotFoundError'
     Object.setPrototypeOf(this, NotFoundError.prototype)
   }
 }


### PR DESCRIPTION
## Problem

Prerequisite for #10 Transition Page.

## Improvements

- Extract separate functions for get/set operations against the
cache and database

- Convert callback pattern into Promise-based functions for use with
async/await (felt it was cleaner to do this than the [alternative](https://stackoverflow.com/questions/44540022/is-there-any-way-to-inherit-method-signature-with-util-promisify-on-typescript))

- Introduce custom error type with NotFoundError

## Bugfix

- Fixed a bug where redirect did not fallback to database if Redis cache
connectivity failed


## Tests

- [x] Redirects successfully on cache hit
- [x] Redirects successfully on cache miss and database hit
- [x] Serves _404 Not Found_ page when link is not found
- [x] Cache lookup failure falls back on to database

