### PR TITLE
Proposal to allow user to OTP if mailing fails in development

### DIFF
--- a/src/server/api/login.ts
+++ b/src/server/api/login.ts
@@ -29,10 +29,7 @@ function isValidGovEmail(email: string) {
  */
 router.get('/message', (_, res: Express.Response) => res.send(loginMessage))
 
-router.get(
-  '/emaildomains',
-  (_, res: Express.Response) => res.send(validEmailDomainGlobExpression),
-)
+router.get('/emaildomains', (_, res: Express.Response) => res.send(validEmailDomainGlobExpression))
 
 /**
  * Request for an OTP to be generated.
@@ -73,6 +70,13 @@ router.post('/otp', (req: Express.Request, res: Express.Response) => {
           mailOTP(email, otp, (mailError: Error) => {
             if (!mailError) {
               res.ok(jsonMessage('OTP generated and sent.'))
+            } else if (process.env.NODE_ENV === 'development') {
+              logger.warn('Allowing user to OTP even though mail errored.')
+              logger.warn(
+                'This may be an issue with your IP. More information can be found at https://support.google.com/mail/answer/10336?hl=en)',
+              )
+              logger.warn('This message should NEVER be seen in production.')
+              res.ok(jsonMessage('Error mailing OTP.'))
             } else {
               res.serverError(
                 jsonMessage('Error mailing OTP, please try again later.'),
@@ -84,7 +88,7 @@ router.post('/otp', (req: Express.Request, res: Express.Response) => {
     })
   } else {
     res.badRequest(
-      jsonMessage('Invalid email provided. Email domain is not whitelisted.')
+      jsonMessage('Invalid email provided. Email domain is not whitelisted.'),
     )
   }
 })


### PR DESCRIPTION
## Problem

In development mode, we are using `nodemailer-direct-transport` to mail OTPs. But it does not provide consistent mailing performance across different IP addresses. Some IPs addresses may be blacklisted from outbound mailing resulting in errors like [this](https://support.google.com/mail/answer/10336?hl=en). In these cases, developers may not be able to proceed to the OTP and user pages without making code changes.

Since we have a default OTP for local development, and `nodemailer-direct-transport` is a local development only issue, I thought that creating allowing users to proceed to OTP even if mailing fails in development may be appropriate and helpful.

## Solution

When there is a mail error, I added a conditional statement that checks if the environment is a development environment. If it is, the server responses with an `ok` status after printing some relevant warning logs.
