### PR TITLE
Allow S3 object ACL to be toggled when a shortlink is activated/deactivated

### DIFF
--- a/.eslintrc.ts.json
+++ b/.eslintrc.ts.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["airbnb", "plugin:import/typescript", "prettier/@typescript-eslint", "plugin:prettier/recommended"],
+  "extends": ["airbnb", "plugin:import/typescript"],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"

--- a/.eslintrc.ts.json
+++ b/.eslintrc.ts.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["airbnb", "plugin:import/typescript"],
+  "extends": ["airbnb", "plugin:import/typescript", "prettier/@typescript-eslint", "plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -11,7 +11,8 @@ import { logger } from '../config'
 import { redirectClient } from '../redis'
 import blacklist from '../resources/blacklist'
 import { isHttps, isValidShortUrl } from '../../shared/util/validation'
-import { PRIVATE, PUBLIC, generatePresignedUrl, setS3ObjectACL } from '../util/aws'
+import { FileVisibility, generatePresignedUrl, setS3ObjectACL } from '../util/aws'
+const { Public, Private } = FileVisibility
 
 const router = Express.Router()
 
@@ -313,7 +314,7 @@ router.patch('/url', validateState, async (req, res) => {
 
     if (url.isFile) {
       // Toggle the ACL of the S3 object
-      await setS3ObjectACL(url.shortUrl, state === ACTIVE ? PUBLIC : PRIVATE)
+      await setS3ObjectACL(url.shortUrl, state === ACTIVE ? Public : Private)
     }
   } catch (error) {
     logger.error(`Error rendering URL active/inactive:\t${error}`)

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -11,7 +11,7 @@ import { logger } from '../config'
 import { redirectClient } from '../redis'
 import blacklist from '../resources/blacklist'
 import { isHttps, isValidShortUrl } from '../../shared/util/validation'
-import { generatePresignedUrl } from '../util/aws'
+import { PRIVATE, PUBLIC, generatePresignedUrl, setS3ObjectACL } from '../util/aws'
 
 const router = Express.Router()
 
@@ -309,6 +309,11 @@ router.patch('/url', validateState, async (req, res) => {
           logger.error(`Short URL could not be purged from cache:\t${err}`)
         }
       })
+    }
+
+    if (url.isFile) {
+      // Toggle the ACL of the S3 object
+      await setS3ObjectACL(url.shortUrl, state === ACTIVE ? PUBLIC : PRIVATE)
     }
   } catch (error) {
     logger.error(`Error rendering URL active/inactive:\t${error}`)

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -133,7 +133,7 @@ function validatePresignedUrlRequest(
  * Endpoint for a user to create a short URL.
  */
 router.post('/url', validateUrls, async (req, res) => {
-  const { userId, longUrl, shortUrl } = req.body
+  const { isFile, userId, longUrl, shortUrl } = req.body
 
   try {
     const user = await User.findByPk(userId)
@@ -152,7 +152,7 @@ router.post('/url', validateUrls, async (req, res) => {
     // Success
     const result = await sequelize.transaction((t) => (
       Url.create(
-        { userId: user.id, longUrl, shortUrl },
+        { userId: user.id, longUrl, shortUrl, isFile: !!isFile },
         { transaction: t },
       )
     ))

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -299,7 +299,7 @@ router.patch('/url', validateState, async (req, res) => {
     }
 
     await sequelize.transaction(async (t) => {
-      url.update({ state }, { transaction: t })
+      await url.update({ state }, { transaction: t })
       if (url.isFile) {
         // Toggle the ACL of the S3 object
         await setS3ObjectACL(url.shortUrl, state === ACTIVE ? Public : Private)

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -32,6 +32,7 @@ interface UrlBaseType extends IdType {
   readonly shortUrl: string
   readonly longUrl: string
   readonly state: Sequelize.EnumDataType<string>
+  readonly isFile: boolean
 }
 
 interface UrlType extends IdType, UrlBaseType, Sequelize.Model {
@@ -86,6 +87,10 @@ export const Url = <UrlTypeStatic>sequelize.define('url', {
     type: Sequelize.INTEGER,
     allowNull: false,
     defaultValue: 0,
+  },
+  isFile: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
   },
 }, {
   hooks: {
@@ -250,6 +255,10 @@ const UrlHistory = <UrlHistoryStatic>sequelize.define('url_history', {
   // after `Url` table.
   state: {
     type: 'enum_urls_state',
+    allowNull: false,
+  },
+  isFile: {
+    type: Sequelize.BOOLEAN,
     allowNull: false,
   },
 })

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -283,6 +283,7 @@ const writeToUrlHistory = async (
     state: urlObj.state,
     urlShortUrl: urlObj.shortUrl,
     longUrl: urlObj.longUrl,
+    isFile: urlObj.isFile,
   }, {
     transaction: options.transaction,
   })

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -90,7 +90,7 @@ export const Url = <UrlTypeStatic>sequelize.define('url', {
   },
   isFile: {
     type: Sequelize.BOOLEAN,
-    allowNull: false,
+    allowNull: true, // TODO: Make this false after backfill.
   },
 }, {
   hooks: {
@@ -259,7 +259,7 @@ const UrlHistory = <UrlHistoryStatic>sequelize.define('url_history', {
   },
   isFile: {
     type: Sequelize.BOOLEAN,
-    allowNull: false,
+    allowNull: true, // TODO: Make this false after backfill.
   },
 })
 

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -45,7 +45,7 @@ export const generatePresignedUrl = async (fileName: string, fileType: string) =
   return reformatPresignedUrl(presignedUrl, fileName)
 }
 
-export const setS3ObjectACL = (key: string, acl: VisibilityType) => {
+export const setS3ObjectACL = (key: string, acl: VisibilityType): Promise<void> => {
   const params = {
     Bucket: s3Bucket,
     Key: key,

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -2,10 +2,11 @@ import { URL, parse } from 'url'
 import { S3 } from 'aws-sdk'
 import { logger, s3Bucket } from '../config'
 
-// Types for S3 object ACL toggling. Do not change string representations.
-export const PUBLIC = 'public-read'
-export const PRIVATE = 'private'
-type VisibilityType = 'public-read' | 'private'
+// Enums for S3 object ACL toggling. Do not change string representations.
+export enum FileVisibility {
+  Public = 'public-read',
+  Private = 'private',
+}
 
 export const s3 = new S3()
 
@@ -45,7 +46,7 @@ export const generatePresignedUrl = async (fileName: string, fileType: string) =
   return reformatPresignedUrl(presignedUrl, fileName)
 }
 
-export const setS3ObjectACL = (key: string, acl: VisibilityType): Promise<void> => {
+export const setS3ObjectACL = (key: string, acl: FileVisibility): Promise<void> => {
   const params = {
     Bucket: s3Bucket,
     Key: key,

--- a/src/server/util/aws.ts
+++ b/src/server/util/aws.ts
@@ -1,6 +1,6 @@
 import { URL, parse } from 'url'
 import { S3 } from 'aws-sdk'
-import { logger, s3Bucket } from '../config'
+import { s3Bucket } from '../config'
 
 // Enums for S3 object ACL toggling. Do not change string representations.
 export enum FileVisibility {
@@ -46,19 +46,11 @@ export const generatePresignedUrl = async (fileName: string, fileType: string) =
   return reformatPresignedUrl(presignedUrl, fileName)
 }
 
-export const setS3ObjectACL = (key: string, acl: FileVisibility): Promise<void> => {
+export const setS3ObjectACL = (key: string, acl: FileVisibility): Promise<any> => {
   const params = {
     Bucket: s3Bucket,
     Key: key,
     ACL: acl,
   }
-  return new Promise((res, rej) => {
-    s3.putObjectAcl(params, (err) => {
-      if (err) {
-        logger.error(err)
-        rej(err)
-      }
-      res()
-    })
-  })
+  return s3.putObjectAcl(params).promise()
 }


### PR DESCRIPTION
## Problem

We need a way to toggle the visibility of the s3 object. This is because our bucket defaults to `private`. After a short link has been reserved and the file has been uploaded to S3, the client will need to call the edit-url-state endpoint once to trigger this hook, setting the s3 object to `visible`.

## Solution

Use a hook in the active/inactive edit API endpoint to also toggle the visibility of the S3 object, if the url has `isFile` set to `true`
