### PR TITLE
fix line height bug in iPhone 6/7

### DIFF
--- a/src/client/styles/createUrlModal.js
+++ b/src/client/styles/createUrlModal.js
@@ -36,6 +36,8 @@ const createUrlStyle = (theme) => ({
     flexGrow: '1',
     width: '100px', // Override default
     padding: theme.spacing(0),
+    height: '100%',
+    lineHeight: '1.5',
   },
   startAdorment: {
     height: '100%',


### PR DESCRIPTION
## Problem

text in input are cut off in iPhone 7 and lower

Closes #3 

## Solution

specify input `height`

## Before & After Screenshots

**BEFORE**:
![before](https://user-images.githubusercontent.com/26242729/81042818-8c40d180-8ee3-11ea-9dc6-92ba9c658c29.jpg)

**AFTER**:
![after](https://user-images.githubusercontent.com/26242729/81042829-92cf4900-8ee3-11ea-8d3a-c8183c16ff56.jpg)

Notes:
Checked desktop behavior to ensure it still works.
![desktop](https://user-images.githubusercontent.com/26242729/81042989-f0fc2c00-8ee3-11ea-9e38-e0d64f603b02.png)

