### PR TITLE
Use session to store shortUrl visits, avoiding repeated transition page redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,6 +1171,16 @@
         "@types/redis": "*"
       }
     },
+    "@types/cookie-session": {
+      "version": "2.0.39",
+      "resolved": "https://registry.npmjs.org/@types/cookie-session/-/cookie-session-2.0.39.tgz",
+      "integrity": "sha512-Y35+TImpAvTAGswU89WuoWIioHUnbEgwFsR09ZC8n9qugEL18UVyIgQ0GvokspUnsWDoNtzQXD6hhDOGau38Rw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/keygrip": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1252,6 +1262,12 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
+    "@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
       "dev": true
     },
     "@types/mime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,6 +1270,12 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.150",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
+      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3460,10 +3460,51 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-session": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.4.0.tgz",
+      "integrity": "sha512-0hhwD+BUIwMXQraiZP/J7VP2YFzqo6g4WqZlWHtEHQ22t0MeZZrNBSCxC1zcaLAs8ApT3BzAKizx9gW/AP9vNA==",
+      "requires": {
+        "cookies": "0.8.0",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -7740,6 +7781,14 @@
         "object.assign": "^4.1.0"
       }
     },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -11816,6 +11865,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/bcrypt": "^3.0.0",
     "@types/bluebird": "^3.5.26",
     "@types/connect-redis": "0.0.10",
+    "@types/cookie-session": "^2.0.39",
     "@types/express": "^4.16.1",
     "@types/express-session": "^1.15.12",
     "@types/helmet": "0.0.43",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "boxicons": "^2.0.5",
     "classnames": "^2.2.6",
     "connect-redis": "^3.4.1",
+    "cookie-session": "^1.4.0",
     "copy-to-clipboard": "^3.3.1",
     "cross-fetch": "^3.0.4",
     "ejs": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/express": "^4.16.1",
     "@types/express-session": "^1.15.12",
     "@types/helmet": "0.0.43",
+    "@types/lodash": "^4.14.150",
     "@types/morgan": "^1.7.35",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -192,25 +192,20 @@ export default async function redirect(
       return
     }
 
-    // Reassure typescript that the session object exists.
-    if (!req.session) {
-      throw new Error('Session object does not exist')
-    }
-
-    if (!req.session.visits || !req.session.visits[shortUrl]) {
+    if (!req.session!.visits || !req.session!.visits[shortUrl]) {
       // This is the first time visiting a/the shortlink.
-      req.session.visits = {
-        ...req.session.visits,
+      req.session!.visits = {
+        ...req.session!.visits,
         [shortUrl]: Math.floor(Date.now()),
       }
 
       // Avoid exceeding cookie size limit by pruning
       // old entries.
-      if (_.size(req.session.visits) > MAX_SHORTURL_COUNT) {
+      if (_.size(req.session!.visits) > MAX_SHORTURL_COUNT) {
         // Build inverse dictionary
         const epochList: number[] = []
         const lookupTable: EpochToShortUrlMapping = {}
-        Object.keys(req.session.visits).forEach((url) => {
+        Object.keys(req.session!.visits).forEach((url) => {
           const epoch = req.session!.visits[url]
           lookupTable[epoch] = url
           epochList.push(epoch)
@@ -218,7 +213,7 @@ export default async function redirect(
 
         const earliestEpoch = epochList.sort()[0]
         const earliestShortUrl = lookupTable[earliestEpoch]
-        delete req.session.visits[earliestShortUrl]
+        delete req.session!.visits[earliestShortUrl]
       }
 
       // Extract root domain from long url.
@@ -234,7 +229,7 @@ export default async function redirect(
 
     // User has visited this shortlink before.
     // Update LRU cache and redirect.
-    req.session.visits[shortUrl] = Math.floor(Date.now())
+    req.session!.visits[shortUrl] = Math.floor(Date.now())
     res.status(302).redirect(longUrl)
   } catch (error) {
     if (!(error instanceof NotFoundError)) {

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -183,8 +183,8 @@ export default async function redirect(
     }
 
     // Redirect immediately if a crawler is visiting the site
-    const redirectImmediately = isCrawler(req.headers['user-agent'] || '') ||
-      req.session.visits?.[shortUrl]
+    const redirectImmediately = isCrawler(req.headers['user-agent'] || '')
+      || req.session.visits?.[shortUrl]
     if (redirectImmediately) {
       res.status(302).redirect(longUrl)
       return

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -187,7 +187,7 @@ export default async function redirect(
     if (gaTrackingId) gaLogging(req, res, shortUrl, longUrl)
 
     // Redirect immediately if a crawler is visiting the site
-    if (isCrawler(req.headers['user-agent'] || '')) {
+    if (isCrawler(req.get('user-agent') || '')) {
       res.status(302).redirect(longUrl)
       return
     }

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -17,7 +17,7 @@ const TRANSITION_PATH = 'transition-page.ejs'
 // limited by max cookie size of 4096 bytes
 const MAX_SHORTURL_COUNT = 100
 
-interface epochToShortUrlMapping {
+interface EpochToShortUrlMapping {
   [epoch: number]: string
 }
 
@@ -209,7 +209,7 @@ export default async function redirect(
       if (_.size(req.session.visits) > MAX_SHORTURL_COUNT) {
         // Build inverse dictionary
         const epochList: number[] = []
-        const lookupTable: epochToShortUrlMapping = {}
+        const lookupTable: EpochToShortUrlMapping = {}
         Object.keys(req.session.visits).forEach((url) => {
           const epoch = req.session!.visits[url]
           lookupTable[epoch] = url

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -1,6 +1,5 @@
 import Express from 'express'
 import { UAParser } from 'ua-parser-js'
-import _ from 'lodash'
 
 import { redirectClient } from '../redis'
 import { Url } from '../models'

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -185,7 +185,7 @@ export default async function redirect(
     }
 
     const cache = new LRUCache(req.session!.visits)
-    if (!req.session!.visits || cache.isEntryInCache(shortUrl)) {
+    if (cache.isEmpty() || !cache.isEntryInCache(shortUrl)) {
       // This is the first time visiting a/the shortlink.
       cache.appendEntry(shortUrl)
       req.session!.visits = cache.getData()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -74,8 +74,8 @@ initDb()
     app.set('views', path.resolve(__dirname, './views'))
     app.set('view engine', 'ejs')
 
-    // Sessions
-    app.use(
+    const apiSpecificMiddleware = [
+      // Sessions
       session({
         store: new SessionStore({
           client: sessionClient, // ttl defaults to session.cookie.maxAge
@@ -89,7 +89,11 @@ initDb()
         },
         ...sessionSettings,
       } as session.SessionOptions),
-    )
+      // application/x-www-form-urlencoded
+      bodyParser.urlencoded({ extended: false }),
+      // application/json
+      bodyParser.json(),
+    ]
 
     // Log http requests
     app.use(morgan(MORGAN_LOG_FORMAT))
@@ -99,9 +103,7 @@ initDb()
       res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH')
       next()
     })
-    app.use(bodyParser.urlencoded({ extended: false })) // application/x-www-form-urlencoded
-    app.use(bodyParser.json()) // application/json
-    app.use('/api', api) // Attach all API endpoints
+    app.use('/api', ...apiSpecificMiddleware, api) // Attach all API endpoints
     app.use('/:shortUrl([a-zA-Z0-9-]+)', redirect) // The Redirect Endpoint
     app.use((req, res) => {
       const shortUrl = req.path.slice(1)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import express from 'express'
 import helmet from 'helmet'
 import morgan from 'morgan'
 import session from 'express-session'
+import cookieSession from 'cookie-session'
 import connectRedis from 'connect-redis'
 
 // Routes
@@ -95,6 +96,14 @@ initDb()
       bodyParser.json(),
     ]
 
+    const redirectSpecificMiddleware = [
+      cookieSession({
+        name: 'visits',
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
+        secret: sessionSettings.secret,
+      }),
+    ]
+
     // Log http requests
     app.use(morgan(MORGAN_LOG_FORMAT))
 
@@ -104,7 +113,7 @@ initDb()
       next()
     })
     app.use('/api', ...apiSpecificMiddleware, api) // Attach all API endpoints
-    app.use('/:shortUrl([a-zA-Z0-9-]+)', redirect) // The Redirect Endpoint
+    app.use('/:shortUrl([a-zA-Z0-9-]+)', ...redirectSpecificMiddleware, redirect) // The Redirect Endpoint
     app.use((req, res) => {
       const shortUrl = req.path.slice(1)
       res.status(404).render('404.error.ejs', { shortUrl })

--- a/src/server/util/lrucache.ts
+++ b/src/server/util/lrucache.ts
@@ -17,8 +17,8 @@ export default class LRUCache {
 
   timestamps: number[] = []
 
-  constructor(data: CookieData) {
-    this.data = data
+  constructor(data: CookieData | null) {
+    this.data = data || {}
   }
 
   // Getters/Setters

--- a/src/server/util/lrucache.ts
+++ b/src/server/util/lrucache.ts
@@ -27,6 +27,10 @@ export default class LRUCache {
     return this.data
   }
 
+  isEmpty() {
+    return _.isEmpty(this.data)
+  }
+
   /**
    * Predicate that checks if the shortUrl exists in the cache.
    * @param {string} shortUrl The shortUrl to check.

--- a/src/server/util/lrucache.ts
+++ b/src/server/util/lrucache.ts
@@ -1,0 +1,94 @@
+import _ from 'lodash'
+
+const MAX_SIZE_BYTES = 2000
+
+interface CookieData {
+  [shortUrl: string]: number
+}
+
+interface EpochToShortUrlMapping {
+  [epoch: number]: string
+}
+
+export default class LRUCache {
+  data: CookieData
+
+  lookupTable: EpochToShortUrlMapping = {}
+
+  timestamps: number[] = []
+
+  constructor(data: CookieData) {
+    this.data = data
+  }
+
+  // Getters/Setters
+
+  getData() {
+    return this.data
+  }
+
+  /**
+   * Predicate that checks if the shortUrl exists in the cache.
+   * @param {string} shortUrl The shortUrl to check.
+   * @returns {Boolean}
+   */
+  isEntryInCache(shortUrl: string) {
+    return !!this.data[shortUrl]
+  }
+
+  // Mutation methods
+
+  /**
+   * Updates an existing entry in the LRU cache.
+   * @param {string} shortUrl The shortUrl whose epoch is
+   * to be updated.
+   */
+  updateEntry(shortUrl: string) {
+    this.data[shortUrl] = Math.floor(Date.now() / 1000)
+  }
+
+  /**
+   * Appends the shortUrl to the list of visited links.
+   * Will also trigger a pruning process if the cookie size
+   * exceeds threshold.
+   * @param {string} shortUrl The shortUrl to be added.
+   */
+  appendEntry(shortUrl: string) {
+    this.updateEntry(shortUrl)
+    while (this.computeSize() > MAX_SIZE_BYTES) {
+      this.pruneOldestEntry()
+    }
+  }
+
+  // Private methods
+
+  private computeSize() {
+    return JSON.stringify(this.data).length
+  }
+
+  private pruneOldestEntry() {
+    if (_.isEmpty(this.lookupTable)) this.hydrateLookupTable()
+    const oldestTimestamp = this.computeOldestTimestamp()
+    const oldestShortUrl = this.lookupTable[oldestTimestamp]
+    delete this.data[oldestShortUrl]
+    delete this.lookupTable[oldestTimestamp]
+    this.timestamps.splice(0, 1)
+  }
+
+  /**
+   * Lazily hydrates the lookup table only when pruning is
+   * necessary.
+   */
+  private hydrateLookupTable() {
+    this.lookupTable = {}
+    Object.keys(this.data).forEach((shortUrl) => {
+      const timestamp = this.data[shortUrl]
+      this.lookupTable[timestamp] = shortUrl
+      this.timestamps.push(timestamp)
+    })
+  }
+
+  private computeOldestTimestamp() {
+    return this.timestamps.sort()[0]
+  }
+}


### PR DESCRIPTION
## Problem

We need a way to not show the transition page multiple times for the same shortUrl.

## Solution

Use session to store the shortUrl, and read it before deciding to redirect directly or show transition page. Sessions are much easier to work with compared to cookies, as we can see how difficult parsing the cookie was with GA.

