### PR TITLE
Login graphic height fix

### DIFF
--- a/src/client/components/LoginPage/index.jsx
+++ b/src/client/components/LoginPage/index.jsx
@@ -90,6 +90,7 @@ const useStyles = makeStyles((theme) =>
       backgroundColor: theme.palette.primary.dark,
       width: '50vw',
       height: '100%',
+      maxHeight: 'calc(100vh - 28px)',
       textAlign: 'center',
       overflow: 'hidden',
     },

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -12,6 +12,7 @@ import { redirectClient } from '../redis'
 import blacklist from '../resources/blacklist'
 import { isHttps, isValidShortUrl } from '../../shared/util/validation'
 import { FileVisibility, generatePresignedUrl, setS3ObjectACL } from '../util/aws'
+
 const { Public, Private } = FileVisibility
 
 const router = Express.Router()
@@ -134,7 +135,9 @@ function validatePresignedUrlRequest(
  * Endpoint for a user to create a short URL.
  */
 router.post('/url', validateUrls, async (req, res) => {
-  const { isFile, userId, longUrl, shortUrl } = req.body
+  const {
+    isFile, userId, longUrl, shortUrl,
+  } = req.body
 
   try {
     const user = await User.findByPk(userId)
@@ -153,7 +156,9 @@ router.post('/url', validateUrls, async (req, res) => {
     // Success
     const result = await sequelize.transaction((t) => (
       Url.create(
-        { userId: user.id, longUrl, shortUrl, isFile: !!isFile },
+        {
+          userId: user.id, longUrl, shortUrl, isFile: !!isFile,
+        },
         { transaction: t },
       )
     ))


### PR DESCRIPTION
## Problem

On shorter desktop displays, the login page graphic may exceed the viewport height. The graphic does not look optimal this way. Furthermore, this affects the placement of the login form on the right as it is vertically aligned by percentage margins.

## Solution

Added an additional style to limit the maximum height of the graphic.

**Improvements**:

- Eslint code formatting.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/28863045/81843214-dbd86a80-957f-11ea-872b-3f837d357020.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/28863045/81843225-e135b500-957f-11ea-9820-ff7832d7c690.png)
