### PR TITLE
Fix GovTech link typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following is a set of guidelines for contributing GoGovSG. These are mostly 
 Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project. 
 Head over [here](https://go.gov.sg/ogp-cla) to submit one. 
 
-You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project owned by [Govtech](www.tech.gov.sg)), you probably don't need to do it again.
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project owned by [GovTech](https://www.tech.gov.sg)), you probably don't need to do it again.
 
 # How can I contribute?
 


### PR DESCRIPTION
As described. Just a typo fix to the CONTRIBUTING document, so no need for detailed PR