### PR TITLE
Add additional tests on redirect middleware

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   coverageThreshold: {
     global: {
-      statements: 23,
+      statements: 24,
     },
   },
   collectCoverageFrom: ['./src/server/**/*.{ts,js}'],

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -35,11 +35,9 @@ async function getLongUrlFromStore(shortUrl: string): Promise<string> {
   } catch {
     // Cache failed, look in database
     const longUrl = await getLongUrlFromDatabase(shortUrl)
-    try {
-      await cacheShortUrl(shortUrl, longUrl)
-    } catch (err) {
-      logger.error(err)
-    }
+    cacheShortUrl(shortUrl, longUrl).catch((error) =>
+      logger.error(`Unable to cache short URL: ${error}`),
+    )
     return longUrl
   }
 }

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -36,7 +36,7 @@ async function getLongUrlFromStore(shortUrl: string): Promise<string> {
     // Cache failed, look in database
     const longUrl = await getLongUrlFromDatabase(shortUrl)
     try {
-      cacheShortUrl(shortUrl, longUrl)
+      await cacheShortUrl(shortUrl, longUrl)
     } catch (err) {
       logger.error(err)
     }
@@ -99,7 +99,9 @@ export default async function redirect(
     const longUrl = await getLongUrlFromStore(shortUrl)
 
     // Update clicks in database
-    incrementClick(shortUrl)
+    incrementClick(shortUrl).catch((error) =>
+      logger.error(`Unable to increment click count: ${error}`),
+    )
 
     // Google analytics
     logRedirectAnalytics(req, res, shortUrl, longUrl)

--- a/test/server/api/mocks/transitionPage.ts
+++ b/test/server/api/mocks/transitionPage.ts
@@ -3,7 +3,7 @@ import { injectable } from 'inversify'
 import { CookieReducer } from '../../../../src/server/util/transitionPage'
 
 @injectable()
-export class CookieArrayReducerMock implements CookieReducer {
+export class CookieArrayReducerMockVisited implements CookieReducer {
   userHasVisitedShortlink(_: string[] | null, __: string): boolean {
     return true
   }
@@ -13,4 +13,13 @@ export class CookieArrayReducerMock implements CookieReducer {
   }
 }
 
-export default CookieArrayReducerMock
+@injectable()
+export class CookieArrayReducerMockUnvisited implements CookieReducer {
+  userHasVisitedShortlink(_: string[] | null, __: string): boolean {
+    return false
+  }
+
+  writeShortlinkToCookie(_: string[] | null, __: string): string[] {
+    return []
+  }
+}

--- a/test/server/api/redirect.test.ts
+++ b/test/server/api/redirect.test.ts
@@ -25,8 +25,8 @@ import {
 import redirect from '../../../src/server/api/redirect'
 import { CookieReducer } from '../../../src/server/util/transitionPage'
 import {
-  CookieArrayReducerMockVisited,
   CookieArrayReducerMockUnvisited,
+  CookieArrayReducerMockVisited,
 } from './mocks/transitionPage'
 import { logger } from '../config'
 
@@ -42,29 +42,6 @@ describe('redirect API tests', () => {
   afterEach(() => {
     container.unbindAll()
     loggerErrorSpy.mockClear()
-  })
-
-  test('url exists in cache and db, real user visited', async () => {
-    container.bind<UrlCache>(DependencyIds.urlCache).to(UrlCacheMockFilled)
-    container
-      .bind<UrlRepository>(DependencyIds.urlRepository)
-      .to(UrlRepositoryMockFilled)
-    container
-      .bind<AnalyticsLogger>(DependencyIds.analyticsLogging)
-      .to(AnalyticsLoggerMock)
-    const req = createRequestWithShortUrl('Aaa')
-    const res = httpMocks.createResponse()
-    req.headers['user-agent'] =
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
-    await redirect(req, res)
-
-    const repo = getUrlRepository() as UrlRepositoryMockFilled
-    expect(repo.clicks.get('aaa')).toBe(1)
-    expect(repo.clicks.size).toBe(1)
-    expect(res.statusCode).toBe(302)
-    expect(res._getRedirectUrl()).toBe('aaa')
-
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aaa')).toBeTruthy()
   })
 
   test('url exists in cache and db, real user unvisited', async () => {

--- a/test/server/api/redirect.test.ts
+++ b/test/server/api/redirect.test.ts
@@ -24,7 +24,10 @@ import {
 } from './util'
 import redirect from '../../../src/server/api/redirect'
 import { CookieReducer } from '../../../src/server/util/transitionPage'
-import { CookieArrayReducerMock } from './mocks/transitionPage'
+import {
+  CookieArrayReducerMockVisited,
+  CookieArrayReducerMockUnvisited,
+} from './mocks/transitionPage'
 import { logger } from '../config'
 
 const loggerErrorSpy = jest.spyOn(logger, 'error')
@@ -33,7 +36,7 @@ describe('redirect API tests', () => {
   beforeEach(() => {
     container
       .bind<CookieReducer>(DependencyIds.cookieReducer)
-      .to(CookieArrayReducerMock)
+      .to(CookieArrayReducerMockVisited)
   })
 
   afterEach(() => {
@@ -41,7 +44,7 @@ describe('redirect API tests', () => {
     loggerErrorSpy.mockClear()
   })
 
-  test('url exists in cache and db', async () => {
+  test('url exists in cache and db, real user visited', async () => {
     container.bind<UrlCache>(DependencyIds.urlCache).to(UrlCacheMockFilled)
     container
       .bind<UrlRepository>(DependencyIds.urlRepository)
@@ -51,6 +54,102 @@ describe('redirect API tests', () => {
       .to(AnalyticsLoggerMock)
     const req = createRequestWithShortUrl('Aaa')
     const res = httpMocks.createResponse()
+    req.headers['user-agent'] =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
+    await redirect(req, res)
+
+    const repo = getUrlRepository() as UrlRepositoryMockFilled
+    expect(repo.clicks.get('aaa')).toBe(1)
+    expect(repo.clicks.size).toBe(1)
+    expect(res.statusCode).toBe(302)
+    expect(res._getRedirectUrl()).toBe('aaa')
+
+    expect(isAnalyticsLogged(req, res, 'aaa', 'aaa')).toBeTruthy()
+  })
+
+  test('url exists in cache and db, real user unvisited', async () => {
+    const cookieReducer = new CookieArrayReducerMockUnvisited()
+    container.unbind(DependencyIds.cookieReducer)
+    container.bind<UrlCache>(DependencyIds.urlCache).to(UrlCacheMockFilled)
+    container
+      .bind<UrlRepository>(DependencyIds.urlRepository)
+      .to(UrlRepositoryMockFilled)
+    container
+      .bind<AnalyticsLogger>(DependencyIds.analyticsLogging)
+      .to(AnalyticsLoggerMock)
+    container
+      .bind<CookieReducer>(DependencyIds.cookieReducer)
+      .toConstantValue(cookieReducer)
+    const req = createRequestWithShortUrl('Aaa')
+    const res = httpMocks.createResponse()
+    req.headers['user-agent'] =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
+
+    const cookieSpy = jest.spyOn(cookieReducer, 'writeShortlinkToCookie')
+
+    await redirect(req, res)
+
+    const repo = getUrlRepository() as UrlRepositoryMockFilled
+    expect(repo.clicks.get('aaa')).toBe(1)
+    expect(repo.clicks.size).toBe(1)
+    expect(res.statusCode).toBe(200)
+    expect(res._getRedirectUrl()).toBe('')
+    expect(cookieReducer.writeShortlinkToCookie).toHaveBeenCalledWith(
+      undefined,
+      'aaa',
+    )
+
+    expect(isAnalyticsLogged(req, res, 'aaa', 'aaa')).toBeTruthy()
+    cookieSpy.mockClear()
+  })
+
+  test('url exists in cache and db, real user visited', async () => {
+    const cookieReducer = new CookieArrayReducerMockVisited()
+    container.unbind(DependencyIds.cookieReducer)
+    container.bind<UrlCache>(DependencyIds.urlCache).to(UrlCacheMockFilled)
+    container
+      .bind<UrlRepository>(DependencyIds.urlRepository)
+      .to(UrlRepositoryMockFilled)
+    container
+      .bind<AnalyticsLogger>(DependencyIds.analyticsLogging)
+      .to(AnalyticsLoggerMock)
+    container
+      .bind<CookieReducer>(DependencyIds.cookieReducer)
+      .toConstantValue(cookieReducer)
+    const req = createRequestWithShortUrl('Aaa')
+    const res = httpMocks.createResponse()
+    req.headers['user-agent'] =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
+
+    const cookieSpy = jest.spyOn(cookieReducer, 'writeShortlinkToCookie')
+
+    await redirect(req, res)
+
+    const repo = getUrlRepository() as UrlRepositoryMockFilled
+    expect(repo.clicks.get('aaa')).toBe(1)
+    expect(repo.clicks.size).toBe(1)
+    expect(res.statusCode).toBe(302)
+    expect(res._getRedirectUrl()).toBe('aaa')
+    expect(cookieReducer.writeShortlinkToCookie).toHaveBeenCalledWith(
+      undefined,
+      'aaa',
+    )
+
+    expect(isAnalyticsLogged(req, res, 'aaa', 'aaa')).toBeTruthy()
+    cookieSpy.mockClear()
+  })
+
+  test('url exists in cache and db crawler', async () => {
+    container.bind<UrlCache>(DependencyIds.urlCache).to(UrlCacheMockFilled)
+    container
+      .bind<UrlRepository>(DependencyIds.urlRepository)
+      .to(UrlRepositoryMockFilled)
+    container
+      .bind<AnalyticsLogger>(DependencyIds.analyticsLogging)
+      .to(AnalyticsLoggerMock)
+    const req = createRequestWithShortUrl('Aaa')
+    const res = httpMocks.createResponse()
+
     await redirect(req, res)
 
     const repo = getUrlRepository() as UrlRepositoryMockFilled


### PR DESCRIPTION
## Problem

With the addition of coveralls, we're able to easily identify untested branches. There were untested branches in the redirect middleware arising from the addition of transition pages.

## Solution

Add tests with differing results from cookie reducer and user agent string.

**Improvements**:

- Backend test coverage +1% 🎉
- Resolve uncaught promise rejections in `redirect.ts`
