### PR TITLE
User page table footer

### DIFF
--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
@@ -3,15 +3,26 @@ import { Grid, IconButton, createStyles, makeStyles } from '@material-ui/core'
 import arrowLeftIcon from '../../../assets/arrow-left-icon.svg'
 import arrowRightIcon from '../../../assets/arrow-right-icon.svg'
 
-const useStyles = makeStyles((theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
     pageSelectGrid: {
       fontWeight: 500,
       color: '#767676',
-      width: 'auto',
-      marginRight: '-139px',
-      [theme.breakpoints.up('sm')]: {
-        marginLeft: 'auto',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      display: 'flex',
+      justifyContent: 'center',
+      width: '100%',
+      height: '100%',
+      zIndex: 1,
+    },
+    gridItemHorizontalPadding: {
+      '&:first-child': {
+        paddingRight: 34,
+      },
+      '&:last-child': {
+        paddingLeft: 34,
       },
     },
   }),
@@ -20,14 +31,8 @@ const useStyles = makeStyles((theme) =>
 export default ({ pageCount, onChangePage, page }) => {
   const classes = useStyles()
   return (
-    <Grid
-      container
-      item
-      alignItems="center"
-      spacing={5}
-      className={classes.pageSelectGrid}
-    >
-      <Grid item>
+    <Grid container item alignItems="center" className={classes.pageSelectGrid}>
+      <Grid item className={classes.gridItemHorizontalPadding}>
         <IconButton
           onClick={(event) => onChangePage(event, page - 1)}
           disabled={page <= 0}
@@ -35,8 +40,10 @@ export default ({ pageCount, onChangePage, page }) => {
           <img src={arrowLeftIcon} alt="Previous page" draggable={false} />
         </IconButton>
       </Grid>
-      <Grid item>{`Page ${page + 1} of ${pageCount}`}</Grid>
-      <Grid item>
+      <Grid item className={classes.gridItemHorizontalPadding}>{`Page ${
+        page + 1
+      } of ${pageCount}`}</Grid>
+      <Grid item className={classes.gridItemHorizontalPadding}>
         <IconButton
           onClick={(event) => onChangePage(event, page + 1)}
           disabled={pageCount <= page + 1}

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Grid, IconButton, createStyles, makeStyles } from '@material-ui/core'
+import arrowLeftIcon from '../../../assets/arrow-left-icon.svg'
+import arrowRightIcon from '../../../assets/arrow-right-icon.svg'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    pageSelectGrid: {
+      fontWeight: 500,
+      color: '#767676',
+      width: 'auto',
+      marginRight: '-139px',
+      [theme.breakpoints.up('sm')]: {
+        marginLeft: 'auto',
+      },
+    },
+  }),
+)
+
+export default ({ pageCount, onChangePage, page }) => {
+  const classes = useStyles()
+  return (
+    <Grid
+      container
+      item
+      alignItems="center"
+      spacing={5}
+      className={classes.pageSelectGrid}
+    >
+      <Grid item>
+        <IconButton
+          onClick={(event) => onChangePage(event, page - 1)}
+          disabled={page <= 0}
+        >
+          <img src={arrowLeftIcon} alt="Previous page" />
+        </IconButton>
+      </Grid>
+      <Grid item>{`Page ${page + 1} of ${pageCount}`}</Grid>
+      <Grid item>
+        <IconButton
+          onClick={(event) => onChangePage(event, page + 1)}
+          disabled={pageCount <= page + 1}
+        >
+          <img src={arrowRightIcon} alt="Next page" />
+        </IconButton>
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/PaginationActionComponent/index.jsx
@@ -32,7 +32,7 @@ export default ({ pageCount, onChangePage, page }) => {
           onClick={(event) => onChangePage(event, page - 1)}
           disabled={page <= 0}
         >
-          <img src={arrowLeftIcon} alt="Previous page" />
+          <img src={arrowLeftIcon} alt="Previous page" draggable={false} />
         </IconButton>
       </Grid>
       <Grid item>{`Page ${page + 1} of ${pageCount}`}</Grid>
@@ -41,7 +41,7 @@ export default ({ pageCount, onChangePage, page }) => {
           onClick={(event) => onChangePage(event, page + 1)}
           disabled={pageCount <= page + 1}
         >
-          <img src={arrowRightIcon} alt="Next page" />
+          <img src={arrowRightIcon} alt="Next page" draggable={false} />
         </IconButton>
       </Grid>
     </Grid>

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
@@ -58,7 +58,6 @@ const MemoTablePagination = React.memo(
           toolbar: classes.toolbar,
           caption: classes.caption,
           select: classes.select,
-          root: classes.root,
           selectIcon: classes.selectIcon,
         }}
         labelDisplayedRows={() => {}}

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
@@ -1,43 +1,9 @@
 import React from 'react'
-import { TablePagination, createStyles, makeStyles } from '@material-ui/core'
+import { TablePagination } from '@material-ui/core'
 import isMatch from 'lodash/isMatch'
 import useAppMargins from '../../../../AppMargins/appMargins'
 import PaginationActionComponent from './PaginationActionComponent'
-
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    root: {
-      display: 'inline',
-    },
-    toolbar: {
-      paddingLeft: 0,
-      paddingRight: 0,
-      width: '50%',
-    },
-    spacer: {
-      flex: 0,
-      paddingLeft: (props) => props.appMargins,
-    },
-    caption: {
-      fontWeight: 400,
-      marginRight: '4px',
-      [theme.breakpoints.down('sm')]: {
-        display: 'none',
-      },
-    },
-    select: {
-      border: 'solid 1px #d8d8d8',
-      [theme.breakpoints.down('sm')]: {
-        display: 'none',
-      },
-    },
-    selectIcon: {
-      [theme.breakpoints.down('sm')]: {
-        display: 'none',
-      },
-    },
-  }),
-)
+import useStyles from './styles'
 
 // Prevents re-render if pagination did not change.
 const paginationInputIsEqual = (prev, next) =>

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/index.jsx
@@ -1,6 +1,43 @@
 import React from 'react'
-import { TablePagination } from '@material-ui/core'
+import { TablePagination, createStyles, makeStyles } from '@material-ui/core'
 import isMatch from 'lodash/isMatch'
+import useAppMargins from '../../../../AppMargins/appMargins'
+import PaginationActionComponent from './PaginationActionComponent'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      display: 'inline',
+    },
+    toolbar: {
+      paddingLeft: 0,
+      paddingRight: 0,
+      width: '50%',
+    },
+    spacer: {
+      flex: 0,
+      paddingLeft: (props) => props.appMargins,
+    },
+    caption: {
+      fontWeight: 400,
+      marginRight: '4px',
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+    select: {
+      border: 'solid 1px #d8d8d8',
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+    selectIcon: {
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+  }),
+)
 
 // Prevents re-render if pagination did not change.
 const paginationInputIsEqual = (prev, next) =>
@@ -10,6 +47,9 @@ const paginationInputIsEqual = (prev, next) =>
 
 const MemoTablePagination = React.memo(
   ({ urlCount, tableConfig, updateUrlTableConfig }) => {
+    const appMargins = useAppMargins()
+    const classes = useStyles({ appMargins })
+
     const updateTableIfChanged = (newConfig) => {
       if (!isMatch(tableConfig, newConfig)) {
         updateUrlTableConfig(newConfig)
@@ -22,8 +62,18 @@ const MemoTablePagination = React.memo(
       updateTableIfChanged({ numberOfRows: event.target.value, pageNumber: 0 })
     }
 
+    const pageCount = Math.ceil(urlCount / tableConfig.numberOfRows)
+
     return (
       <TablePagination
+        ActionsComponent={({ onChangePage, page }) => (
+          <PaginationActionComponent
+            pageCount={pageCount}
+            onChangePage={onChangePage}
+            page={page}
+          />
+        )}
+        labelRowsPerPage="Links per page"
         rowsPerPageOptions={[10, 25, 100]}
         component="div"
         count={urlCount}
@@ -37,6 +87,15 @@ const MemoTablePagination = React.memo(
         }}
         onChangePage={changePageHandler}
         onChangeRowsPerPage={changeRowsPerPageHandler}
+        classes={{
+          spacer: classes.spacer,
+          toolbar: classes.toolbar,
+          caption: classes.caption,
+          select: classes.select,
+          root: classes.root,
+          selectIcon: classes.selectIcon,
+        }}
+        labelDisplayedRows={() => {}}
       />
     )
   },

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/styles.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/styles.jsx
@@ -1,0 +1,36 @@
+import { createStyles, makeStyles } from '@material-ui/core'
+
+export default makeStyles((theme) =>
+  createStyles({
+    root: {
+      display: 'inline',
+    },
+    toolbar: {
+      paddingLeft: 0,
+      paddingRight: 0,
+      width: '50%',
+    },
+    spacer: {
+      flex: 0,
+      paddingLeft: (props) => props.appMargins,
+    },
+    caption: {
+      fontWeight: 400,
+      marginRight: '4px',
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+    select: {
+      border: 'solid 1px #d8d8d8',
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+    selectIcon: {
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    },
+  }),
+)

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/styles.ts
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/MemoTablePagination/styles.ts
@@ -1,18 +1,17 @@
 import { createStyles, makeStyles } from '@material-ui/core'
 
+type StyleProps = {
+  appMargins: number
+}
+
 export default makeStyles((theme) =>
   createStyles({
-    root: {
-      display: 'inline',
-    },
     toolbar: {
-      paddingLeft: 0,
-      paddingRight: 0,
-      width: '50%',
+      paddingLeft: (props: StyleProps) => props.appMargins,
+      paddingRight: (props: StyleProps) => props.appMargins,
     },
     spacer: {
       flex: 0,
-      paddingLeft: (props) => props.appMargins,
     },
     caption: {
       fontWeight: 400,
@@ -23,11 +22,13 @@ export default makeStyles((theme) =>
     },
     select: {
       border: 'solid 1px #d8d8d8',
+      zIndex: 2,
       [theme.breakpoints.down('sm')]: {
         display: 'none',
       },
     },
     selectIcon: {
+      zIndex: 2,
       [theme.breakpoints.down('sm')]: {
         display: 'none',
       },

--- a/src/client/components/UserPage/UserLinkTable/assets/arrow-left-icon.svg
+++ b/src/client/components/UserPage/UserLinkTable/assets/arrow-left-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20">
+    <path fill="#BBB" d="M12 15.707L6.293 10 12 4.293l1.414 1.414L9.121 10l4.293 4.293L12 15.707z"/>
+    <mask id="prefix__a" width="8" height="12" x="6" y="4" maskUnits="userSpaceOnUse">
+        <path fill="#fff" d="M12 15.707L6.293 10 12 4.293l1.414 1.414L9.121 10l4.293 4.293L12 15.707z"/>
+    </mask>
+</svg>

--- a/src/client/components/UserPage/UserLinkTable/assets/arrow-right-icon.svg
+++ b/src/client/components/UserPage/UserLinkTable/assets/arrow-right-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20">
+    <path fill="#BBB" d="M7.707 15.707L13.414 10 7.707 4.293 6.293 5.707 10.586 10l-4.293 4.293 1.414 1.414z"/>
+    <mask id="prefix__a" width="8" height="12" x="6" y="4" maskUnits="userSpaceOnUse">
+        <path fill="#fff" d="M7.707 15.707L13.414 10 7.707 4.293 6.293 5.707 10.586 10l-4.293 4.293 1.414 1.414z"/>
+    </mask>
+</svg>


### PR DESCRIPTION
## Problem

The footer of the user page table has not been updated to the latest design

## Solution

Updated user page table.
- The position of elements provided by material's footer does not match the design. This was solved by hiding some of the elements and replacing them with our own in ActionComponents.
- To center the page selector, I made the container width 50% and pushed the selector to the right with `margin-left: auto` and then shifted it to the right by half its width to centralize it on the screen.

## Before & After Screenshots

**AFTER**:
[Desktop](https://user-images.githubusercontent.com/35889982/82580634-f5059a80-9bc1-11ea-96b0-2c7e239938be.png)
![Mobile](https://user-images.githubusercontent.com/35889982/82580990-79581d80-9bc2-11ea-8c04-c032ff060160.png)

