### PR TITLE
User page table mobile header text

### DIFF
--- a/src/client/components/UserPage/UserLinkTable/ToolBar/LinkCountHeader/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/ToolBar/LinkCountHeader/index.jsx
@@ -4,31 +4,34 @@ import { Typography, createStyles, makeStyles } from '@material-ui/core'
 
 import useMinifiedActions from '../util/minifiedActions'
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles((theme) =>
   createStyles({
     linkCountHeader: {
       flex: 1,
       alignSelf: 'center',
       marginRight: 20,
       whiteSpace: 'nowrap',
+      [theme.breakpoints.down('sm')]: {
+        order: 10,
+        flexBasis: '100%',
+        marginTop: theme.spacing(3),
+      },
     },
   }),
 )
 
 export default function LinkCountHeader() {
   const urlCount = useSelector((state) => state.user.urlCount)
-  const showHeader = !useMinifiedActions()
+  const isMinified = useMinifiedActions()
   const classes = useStyles()
   return (
-    showHeader && (
-      <Typography
-        className={classes.linkCountHeader}
-        variant="h3"
-        color="primary"
-      >
-        {urlCount}
-        {' links'}
-      </Typography>
-    )
+    <Typography
+      className={classes.linkCountHeader}
+      variant={isMinified ? 'h4' : 'h3'}
+      color="primary"
+    >
+      {urlCount}
+      {' links'}
+    </Typography>
   )
 }

--- a/src/client/components/UserPage/UserLinkTable/ToolBar/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/ToolBar/index.jsx
@@ -13,6 +13,10 @@ const useStyles = makeStyles((theme) =>
       marginTop: theme.spacing(3),
       marginBottom: theme.spacing(2),
       width: '100%',
+      [theme.breakpoints.down('sm')]: {
+        flexWrap: 'wrap',
+        marginBottom: theme.spacing(1),
+      },
     },
   }),
 )


### PR DESCRIPTION
## Problem

The mobile header text for the user page table was missing.

## Solution

Enabled the header text on mobile and changed its order to place it on a second row.

## Before & After Screenshots

**AFTER**:
[insert screenshot here]
![Mobile](https://user-images.githubusercontent.com/35889982/82632026-ad1a5e00-9c29-11ea-9eaa-88b4fbb687e8.png)
(PC unchanged)
