### PR TITLE
Revert email notifications from Travis to default settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ cache:
   directories:
     - 'node_modules'
 
-notifications:
-  email:
-    recipients:
-      - $EMAIL_RECIPIENT
-    on_success: change
-    on_failure: always
-
 install:
   - npm install
 


### PR DESCRIPTION
## Problem

Specifying the email recipient via environment variable [doesn't actually work](https://docs.travis-ci.com/user/notifications/#how-is-the-build-email-receiver-determined) because notification is determined prior to build, when environment variables are not available.

## Solution

Revert to default settings where the notification email will be sent to the committer.
