### PR TITLE
Fix inconsistent errors sent out by Joi

### DIFF
--- a/src/server/api/login/index.ts
+++ b/src/server/api/login/index.ts
@@ -11,7 +11,7 @@ import { otpGenerationSchema, otpVerificationSchema } from './validators'
 
 const router: Express.Router = Express.Router()
 
-const validator = createValidator()
+const validator = createValidator({ passError: true })
 
 /**
  * For the Login message banner.

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -42,7 +42,7 @@ const fileUploadMiddleware = fileUpload({
   },
 })
 
-const validator = createValidator()
+const validator = createValidator({ passError: true })
 
 const urlRetrievalSchema = Joi.object({
   userId: Joi.number().required(),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import morgan from 'morgan'
 import session from 'express-session'
 import cookieSession from 'cookie-session'
 import connectRedis from 'connect-redis'
+import jsonMessage from './util/json'
 import bindInversifyDependencies from './inversify.config'
 
 // Happens at the top so all imports will have
@@ -132,11 +133,17 @@ initDb()
     })
 
     const errorHandler: express.ErrorRequestHandler = (
-      _err,
+      err,
       _req,
       res,
       _next,
     ) => {
+      // Catch Joi validation errors and pass them as properly-formatted
+      // messages.
+      if (err?.error?.isJoi) {
+        res.badRequest(jsonMessage(err.error.toString()))
+        return
+      }
       res.status(500).render('500.error.ejs')
     }
     app.use(errorHandler)


### PR DESCRIPTION
## Problem

Joi sends validation errors as a string, which breaks some frontend error handlers that require it to be a specifically-formatted json.

## Solution

Specify the validator to pass the error to the error-handling middleware. From there, detect whether the error caught was a Joi error, and then format it properly before sending it back to the user.

## Resources used
- Express Joi validator allowing a [passError config](https://www.npmjs.com/package/express-joi-validation#createvalidatorconfig) to be set
- [Custom express error handling](https://www.npmjs.com/package/express-joi-validation#custom-express-error-handler) for Joi

