### PR TITLE
File client tweaks

### DIFF
--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -433,13 +433,14 @@ const transferOwnership = (
         dispatch<SetSuccessMessageAction>(
           rootActions.setSuccessMessage(successMessage),
         )
+      } else {
+        // Otherwise, show error toast with relevant error message.
+        response.json().then((json) => {
+          dispatch<SetErrorMessageAction>(
+            rootActions.setErrorMessage(json.message),
+          )
+        })
       }
-      // Otherwise, show error toast with relevant error message.
-      response.json().then((json) => {
-        dispatch<SetErrorMessageAction>(
-          rootActions.setErrorMessage(json.message),
-        )
-      })
     },
   )
 

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -217,6 +217,7 @@ export default function CreateLinkForm({
                         variant="contained"
                         className={classes.uploadFileButton}
                         component="span"
+                        color="primary"
                         disabled={isUploading}
                       >
                         Browse

--- a/src/client/components/UserPage/CreateUrlModal/styles/createLinkForm.ts
+++ b/src/client/components/UserPage/CreateUrlModal/styles/createLinkForm.ts
@@ -150,7 +150,6 @@ const useCreateLinkFormStyles = makeStyles((theme) =>
       width: '81px',
       height: '100%',
       borderRadius: 0,
-      backgroundColor: '#8ca6ad',
       color: '#f9f9f9',
       [theme.breakpoints.up('sm')]: {
         width: '146px',

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.jsx
@@ -6,6 +6,7 @@ import {
   TableBody,
   TableCell,
   TableRow,
+  Tooltip,
   Typography,
 } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
@@ -100,6 +101,9 @@ const useStyles = makeStyles((theme) => {
         width: '20%',
         minWidth: '100px',
       },
+    },
+    clicksCellContent: {
+      width: 'fit-content',
     },
     rightCell: {
       [theme.breakpoints.up('md')]: {
@@ -221,14 +225,18 @@ export default function EnhancedTableBody() {
               </Typography>
             </TableCell>
             <TableCell className={classes.clicksCell}>
-              <img
-                className={classes.clicksIcon}
-                src={clickCountIcon}
-                alt="Clicks"
-              />
-              <Typography variant="caption" className={classes.clicksText}>
-                {numberUnitFormatter(row.clicks)}
-              </Typography>
+              <Tooltip title={row.clicks} placement="top" arrow>
+                <div className={classes.clicksCellContent}>
+                  <img
+                    className={classes.clicksIcon}
+                    src={clickCountIcon}
+                    alt="Clicks"
+                  />
+                  <Typography variant="caption" className={classes.clicksText}>
+                    {numberUnitFormatter(row.clicks)}
+                  </Typography>
+                </div>
+              </Tooltip>
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
## Problem

- [x] Color of upload file button to align to the rest of the buttons
- [x] On hover - show exact link clicks on dashboard
- [x] Toaster alert when transferring link to other users

## Solution

- Upload file button: I have modified the button to use our default themed button, which then provides it a similar background color and hovered background color.
- Link clicks: I have modified the clicks count cell to fit its content. Subsequently, I added an arrowed tooltip on the top-center of this modified cell.
- Toaster for link transfer: There was a double dispatch of snackbar messages for successful link transfers. The solution is to add an `else` statement, so that error messages are only set if the transfer fails.

## After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/28863045/83504418-11290600-a4f7-11ea-93a3-9a8c9987db7a.png)
![image](https://user-images.githubusercontent.com/28863045/83504522-2e5dd480-a4f7-11ea-8943-b8d2f5cfd340.png)
![image](https://user-images.githubusercontent.com/28863045/83504628-4d5c6680-a4f7-11ea-8e02-f33c29e76dcc.png)

