### PR TITLE
Display date created rather than date updated in user table

### DIFF
--- a/src/client/actions/user.js
+++ b/src/client/actions/user.js
@@ -88,7 +88,7 @@ const getUrlsForUser = () => async (dispatch, getState) => {
 
   if (isOk) {
     json.urls.forEach((url) => {
-      url.updatedAt = moment(url.updatedAt) // eslint-disable-line no-param-reassign
+      url.createdAt = moment(url.createdAt) // eslint-disable-line no-param-reassign
         .tz('Singapore')
         .format('D MMM YYYY')
       // eslint-disable-next-line no-param-reassign

--- a/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.jsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme) => {
         paddingLeft: (props) => props.appMargins,
       },
     },
-    updatedAtCell: {
+    createdAtCell: {
       [theme.breakpoints.up('md')]: {
         minWidth: '125px',
       },
@@ -130,7 +130,7 @@ const useStyles = makeStyles((theme) => {
     longUrl: {
       color: '#767676',
     },
-    updatedAt: {
+    createdAt: {
       color: '#767676',
     },
     clicksIcon: {
@@ -209,9 +209,9 @@ export default function EnhancedTableBody() {
                 {row.state.toLowerCase()}
               </Typography>
             </TableCell>
-            <TableCell className={classes.updatedAtCell}>
-              <Typography variant="caption" className={classes.updatedAt}>
-                {row.updatedAt}
+            <TableCell className={classes.createdAtCell}>
+              <Typography variant="caption" className={classes.createdAt}>
+                {row.createdAt}
               </Typography>
             </TableCell>
             <TableCell className={classes.clicksCell}>

--- a/src/client/reducers/user.js
+++ b/src/client/reducers/user.js
@@ -25,7 +25,7 @@ const initialState = {
     numberOfRows: 10,
     pageNumber: 0,
     sortDirection: 'desc',
-    orderBy: 'updatedAt',
+    orderBy: 'createdAt',
     searchText: '',
     filter: {},
   },


### PR DESCRIPTION
## Problem

The `updatedAt` column is always updated when clicks are incremented. A change was made in the UI that caused the table to display this column instead of `createdAt`. This created confusion for users.

## Solution

Revert to displaying the createdAt column instead of updatedAt.

