### PR TITLE
Fix filtering bug on multiple pages

### DIFF
--- a/src/client/components/UserPage/UserLinkTable/ToolBar/FilterSortPanel/index.jsx
+++ b/src/client/components/UserPage/UserLinkTable/ToolBar/FilterSortPanel/index.jsx
@@ -19,6 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
           state,
           isFile,
         },
+        pageNumber: 0,
       }),
     )
     dispatch(userActions.getUrlsForUser())


### PR DESCRIPTION
## Problem

When filtering with custom queries, a bug occurs when it fetches the page number beyond the max number of entries.

## Solution

Set the pageNumber to 0 so that we wont go out of bounds.

