### PR TITLE
Fix download CSV on IE

### DIFF
--- a/src/client/util/download.js
+++ b/src/client/util/download.js
@@ -1,6 +1,7 @@
 import { saveAs } from 'file-saver'
 import rootActions from '~/actions/root'
 import userActions from '~/actions/user'
+import { useIsIE } from '../components/BaseLayout/util/ie'
 
 export const downloadUrls = async (urlCount, tableConfig) => {
   const urlsArr = []
@@ -58,8 +59,15 @@ export const downloadUrls = async (urlCount, tableConfig) => {
     })
   })
 
-  const blob = new Blob(urlsArr, { type: 'text/plain;charset=utf-8' })
-  saveAs(blob, 'urls.csv')
+  const blob = new Blob([urlsArr.join('')], {
+    type: 'text/csv;charset=utf-8',
+  })
+
+  if (useIsIE) {
+    navigator.msSaveBlob(blob, 'urls.csv')
+  } else {
+    saveAs(blob, 'urls.csv')
+  }
   return null
 }
 


### PR DESCRIPTION
## Problem

Downloading links as CSV does not work on IE as `saveAs` with a blob input does not work on IE11.

Closes [#134]

## Solution

By changing the blob constructor input into csv  type and changing the string into something recognizable by both IE11 and modern browsers and using msSaveBlob for IE, all supported browsers should be able to download links with the same behavior as before.

## Tests

1. Download Links on Chrome on develop branch
1. Download Links on Chrome on this branch
2. Download links on IE11 on this branch
3. Both downloads should work. Run a diff between the files from steps 1, 2 and 3, there should be no output.

