### PR TITLE
Front-end implementation for editing file links

### DIFF
--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -297,17 +297,20 @@ const replaceFile = (
   dispatch: ThunkDispatch<
     GoGovReduxState,
     void,
-    SetErrorMessageAction | SetSuccessMessageAction
+    SetErrorMessageAction | SetSuccessMessageAction | SetIsUploadingAction
   >,
 ) => {
+  dispatch<SetIsUploadingAction>(setIsUploading(true))
   const data = new FormData()
   data.append('file', file, file.name)
   data.append('shortUrl', shortUrl)
 
   const response = await patchFormData('/api/user/url/edit', data)
+  dispatch<SetIsUploadingAction>(setIsUploading(false))
   if (!response.ok) {
     const json = await response.json()
     onError(json.message)
+    return
   }
 
   dispatch<void>(getUrlsForUser())

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -51,9 +51,9 @@ import {
 import {
   get,
   patch,
+  patchFormData,
   postFormData,
   postJson,
-  patchFormData,
 } from '../../util/requests'
 import rootActions from '../root'
 import { generateShortUrl, removeHttpsProtocol } from '../../util/url'

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -48,7 +48,13 @@ import {
   SetErrorMessageAction,
   SetSuccessMessageAction,
 } from '../root/types'
-import { get, patch, postFormData, postJson } from '../../util/requests'
+import {
+  get,
+  patch,
+  postFormData,
+  postJson,
+  patchFormData,
+} from '../../util/requests'
 import rootActions from '../root'
 import { generateShortUrl, removeHttpsProtocol } from '../../util/url'
 import { isValidUrl } from '../../../shared/util/validation'
@@ -280,6 +286,34 @@ const updateLongUrl = (shortUrl: string, longUrl: string) => (
       return null
     })
   })
+}
+
+// API call to replace file
+const replaceFile = (
+  shortUrl: string,
+  file: File,
+  onError: (error: string) => void,
+) => async (
+  dispatch: ThunkDispatch<
+    GoGovReduxState,
+    void,
+    SetErrorMessageAction | SetSuccessMessageAction
+  >,
+) => {
+  const data = new FormData()
+  data.append('file', file, file.name)
+  data.append('shortUrl', shortUrl)
+
+  const response = await patchFormData('/api/user/url/edit', data)
+  if (!response.ok) {
+    const json = await response.json()
+    onError(json.message)
+  }
+
+  dispatch<void>(getUrlsForUser())
+  dispatch<SetSuccessMessageAction>(
+    rootActions.setSuccessMessage('Your link has been updated.'),
+  )
 }
 
 // For setting short link value in the input box
@@ -515,4 +549,5 @@ export default {
   setUploadFileError,
   setCreateShortLinkError,
   setUrlFilter,
+  replaceFile,
 }

--- a/src/client/components/CollapsibleMessage/index.tsx
+++ b/src/client/components/CollapsibleMessage/index.tsx
@@ -1,14 +1,15 @@
 import React, { FunctionComponent } from 'react'
 import { Collapse } from '@material-ui/core'
 import useStyles from './styles'
-import { CollapsibleMessageProps } from './types'
+import { CollapsibleMessageProps, CollapsibleMessagePosition } from './types'
 
 const CollapsibleMessage: FunctionComponent<CollapsibleMessageProps> = ({
   type,
   visible,
   children,
+  position = CollapsibleMessagePosition.Static,
 }) => {
-  const classes = useStyles({ type })
+  const classes = useStyles({ type, position })
   return (
     <Collapse className={classes.root} in={visible}>
       <div className={classes.message}>{children}</div>

--- a/src/client/components/CollapsibleMessage/styles.ts
+++ b/src/client/components/CollapsibleMessage/styles.ts
@@ -5,6 +5,9 @@ export default makeStyles((theme) =>
   createStyles({
     root: {
       width: '100%',
+      position: ({ position }: CollapsibleMessageStyles) => position,
+      top: '100%',
+      left: 0,
     },
     message: {
       width: '100%',

--- a/src/client/components/CollapsibleMessage/types.ts
+++ b/src/client/components/CollapsibleMessage/types.ts
@@ -6,9 +6,15 @@ export enum CollapsibleMessageType {
 export type CollapsibleMessageProps = {
   type: CollapsibleMessageType
   visible: boolean
-  message: string
+  position?: CollapsibleMessagePosition
 }
 
 export type CollapsibleMessageStyles = {
   type: CollapsibleMessageType
+  position: CollapsibleMessagePosition
+}
+
+export enum CollapsibleMessagePosition {
+  Static = 'static',
+  Absolute = 'absolute',
 }

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -26,6 +26,7 @@ import { formatBytes } from '../../../util/format'
 import CollapsibleMessage from '../../CollapsibleMessage'
 import { CollapsibleMessageType } from '../../CollapsibleMessage/types'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
+import FileInputField from '../Widgets/FileInputField'
 
 // Height of the text field in the create link dialog.
 const TEXT_FIELD_HEIGHT = 44
@@ -162,6 +163,35 @@ export default function CreateLinkForm({
                   </Typography>
                 </div>
               </div>
+              <FileInputField
+                textFieldHeight={TEXT_FIELD_HEIGHT}
+                file={file}
+                uploadFileError={uploadFileError}
+                inputId="file"
+                setFile={setFile}
+                setUploadFileError={setUploadFileError}
+                endAdornment={
+                  <div className={classes.uploadFileInputEndWrapper}>
+                    <Typography
+                      variant="body2"
+                      className={classes.fileSizeText}
+                    >
+                      {file ? formatBytes(file.size) : ''}
+                    </Typography>
+                    <label htmlFor="file">
+                      <Button
+                        variant="contained"
+                        className={classes.uploadFileButton}
+                        component="span"
+                        color="primary"
+                        disabled={isUploading}
+                      >
+                        Browse
+                      </Button>
+                    </label>
+                  </div>
+                }
+              />
               <div className={classes.fileInputWrapper}>
                 <Hidden smDown>
                   <div className={classes.leftFileIcon}>
@@ -193,25 +223,6 @@ export default function CreateLinkForm({
                       setFile(chosenFile)
                     }}
                   />
-                  <div className={classes.uploadFileInputEndWrapper}>
-                    <Typography
-                      variant="body2"
-                      className={classes.fileSizeText}
-                    >
-                      {file ? formatBytes(file.size) : ''}
-                    </Typography>
-                    <label htmlFor="file">
-                      <Button
-                        variant="contained"
-                        className={classes.uploadFileButton}
-                        component="span"
-                        color="primary"
-                        disabled={isUploading}
-                      >
-                        Browse
-                      </Button>
-                    </label>
-                  </div>
                 </div>
               </div>
               <CollapsibleMessage

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -21,11 +21,9 @@ import ModalMargins from './ModalMargins'
 import refreshIcon from './assets/refresh-icon.svg'
 import LinkIcon from '../Widgets/LinkIcon'
 import FileIcon from '../Widgets/FileIcon'
-import FileIconLarge from '../Widgets/FileIconLarge'
 import { formatBytes } from '../../../util/format'
 import CollapsibleMessage from '../../CollapsibleMessage'
 import { CollapsibleMessageType } from '../../CollapsibleMessage/types'
-import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
 import FileInputField from '../Widgets/FileInputField'
 
 // Height of the text field in the create link dialog.
@@ -165,7 +163,7 @@ export default function CreateLinkForm({
               </div>
               <FileInputField
                 textFieldHeight={TEXT_FIELD_HEIGHT}
-                file={file}
+                text={file ? file.name : 'No file selected'}
                 uploadFileError={uploadFileError}
                 inputId="file"
                 setFile={setFile}
@@ -192,39 +190,6 @@ export default function CreateLinkForm({
                   </div>
                 }
               />
-              <div className={classes.fileInputWrapper}>
-                <Hidden smDown>
-                  <div className={classes.leftFileIcon}>
-                    <FileIconLarge color="#f9f9f9" />
-                  </div>
-                </Hidden>
-                <div className={classes.fileInput}>
-                  <Typography variant="body2" className={classes.fileNameText}>
-                    {file ? file.name : 'No file selected'}
-                  </Typography>
-                  <input
-                    type="file"
-                    id="file"
-                    className={classes.fileInputInvis}
-                    disabled={isUploading}
-                    onChange={(event) => {
-                      const chosenFile = event.target.files[0]
-                      if (!chosenFile) {
-                        return
-                      }
-                      if (chosenFile.size > MAX_FILE_UPLOAD_SIZE) {
-                        setFile(null)
-                        setUploadFileError(
-                          'File too large, please upload a file smaller than 10mb',
-                        )
-                        return
-                      }
-                      setUploadFileError(null)
-                      setFile(chosenFile)
-                    }}
-                  />
-                </div>
-              </div>
               <CollapsibleMessage
                 visible={!!uploadFileError}
                 type={CollapsibleMessageType.Error}

--- a/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
@@ -19,8 +19,8 @@ const useStyles = makeStyles((theme) =>
       display: 'flex',
       alignItems: 'flex-end',
       justifyContent: 'space-between',
-      marginBottom: 44,
-      marginTop: '12px',
+      marginBottom: theme.spacing(6.5),
+      marginTop: theme.spacing(1.5),
       [theme.breakpoints.up('md')]: {
         alignItems: 'center',
         marginTop: 0,

--- a/src/client/components/UserPage/Drawer/ControlPanel/helpers/reducers.ts
+++ b/src/client/components/UserPage/Drawer/ControlPanel/helpers/reducers.ts
@@ -2,17 +2,19 @@ export type State = {
   controlPanelIsOpen: boolean
   relevantShortLink: string | null
   qrCodeModalIsOpen: boolean
+  uploadFileError: string | null
 }
 
 export const initialState: State = {
   controlPanelIsOpen: false,
   relevantShortLink: null,
   qrCodeModalIsOpen: false,
+  uploadFileError: null,
 }
 
 export type Action = {
   type: string
-  payload?: string
+  payload?: string | null
 }
 
 export const DrawerActions = {
@@ -20,6 +22,7 @@ export const DrawerActions = {
   closeControlPanel: 'CLOSE_CONTROL_PANEL',
   openQrCodeModal: 'OPEN_QR_CODE_MODAL',
   closeQrCodeModal: 'CLOSE_QR_CODE_MODAL',
+  setUploadFileError: 'SET_UPLOAD_FILE_ERROR',
 }
 
 export function drawerReducer(state: State, action: Action) {
@@ -39,6 +42,9 @@ export function drawerReducer(state: State, action: Action) {
       break
     case DrawerActions.closeQrCodeModal:
       newState.qrCodeModalIsOpen = false
+      break
+    case DrawerActions.setUploadFileError:
+      newState.uploadFileError = action.payload
       break
     default:
       throw new Error(`Undefined modal action: ${action.type}`)

--- a/src/client/components/UserPage/Drawer/ControlPanel/helpers/shortlink.ts
+++ b/src/client/components/UserPage/Drawer/ControlPanel/helpers/shortlink.ts
@@ -2,22 +2,11 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import userActions from '../../../../../actions/user'
 import { isValidLongUrl } from '../../../../../../shared/util/validation'
-import { UrlState } from '../../../../../reducers/user/types'
-
-export type LinkState = {
-  clicks: number
-  createdAt: string
-  editedLongUrl: string
-  isFile: boolean
-  longUrl: string
-  shortUrl: string
-  state: UrlState
-  updatedAt: string
-  userId: number
-}
+import { UrlType } from '../../../../../reducers/user/types'
+import { GoGovReduxState } from '../../../../../reducers/types'
 
 export type ShortLinkState = [
-  LinkState | undefined,
+  UrlType | undefined,
   ShortLinkDispatch | undefined,
 ]
 
@@ -30,10 +19,13 @@ export type ShortLinkDispatch = {
 }
 
 export default function useShortLink(shortLink: string) {
-  const urls: LinkState[] = useSelector((state: any) => state.user.urls)
-  const urlState = urls.filter(
-    (url: LinkState) => url.shortUrl === shortLink,
-  )[0]
+  const urls: UrlType[] = useSelector<GoGovReduxState, UrlType[]>(
+    (state) => state.user.urls,
+  )
+  const urlState = urls.filter((url: UrlType) => url.shortUrl === shortLink)[0]
+  const isUploading = useSelector<GoGovReduxState, boolean>(
+    (state) => state.user.isUploading,
+  )
   const dispatch = useDispatch()
   const dispatchOptions = {
     toggleStatus: () =>
@@ -50,10 +42,17 @@ export default function useShortLink(shortLink: string) {
     applyNewOwner: (newOwner: string, onSuccess: () => void) => {
       dispatch(userActions.transferOwnership(shortLink, newOwner, onSuccess))
     },
+    replaceFile: (newFile: File | null, onError: (error: string) => void) => {
+      if (!newFile) {
+        return
+      }
+      dispatch(userActions.replaceFile(shortLink, newFile, onError))
+    },
   }
 
   return {
     shortLinkState: shortLink ? urlState : undefined,
     shortLinkDispatch: shortLink ? dispatchOptions : undefined,
+    isUploading,
   }
 }

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -101,6 +101,12 @@ const useStyles = makeStyles((theme) =>
     originalFileLabel: {
       marginBottom: theme.spacing(1),
     },
+    fileInputField: {
+      marginBottom: theme.spacing(3),
+      [theme.breakpoints.up('md')]: {
+        marginBottom: 0,
+      },
+    },
   }),
 )
 
@@ -288,6 +294,7 @@ export default function ControlPanel() {
               leading={
                 <>
                   <FileInputField
+                    className={classes.fileInputField}
                     uploadFileError={uploadFileError}
                     textFieldHeight="44px"
                     inputId="replace-file-input"

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   useTheme,
   useMediaQuery,
+  CircularProgress,
 } from '@material-ui/core'
 
 import DrawerActions from './helpers/reducers'
@@ -325,7 +326,11 @@ export default function ControlPanel() {
                     fullWidth={isMobileView}
                     component="span"
                   >
-                    Replace File
+                    {isUploading ? (
+                      <CircularProgress color="primary" size={20} />
+                    ) : (
+                      'Replace file'
+                    )}
                   </TrailingButton>
                 </label>
               }

--- a/src/client/components/UserPage/Drawer/ControlPanel/widgets/ConfigOption.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/widgets/ConfigOption.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) =>
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
-      marginBottom: 30,
+      marginBottom: theme.spacing(3.5),
       flexWrap: (props: StylesProps) =>
         props.wrapTrailing ? 'wrap' : 'nowrap',
     },
@@ -26,6 +26,7 @@ const useStyles = makeStyles((theme) =>
         marginBottom: 0,
         marginRight: 19,
       },
+      position: 'relative',
     },
     trailingContainer: {
       marginTop: (props: StylesProps) =>

--- a/src/client/components/UserPage/Drawer/ControlPanel/widgets/TrailingButton.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/widgets/TrailingButton.tsx
@@ -21,7 +21,9 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-export default function TrailingButton(props: ButtonProps) {
+export default function TrailingButton(
+  props: ButtonProps & { component?: string },
+) {
   const classes = useStyles(props)
   return (
     <Button

--- a/src/client/components/UserPage/Widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/Widgets/FileInputField.tsx
@@ -77,7 +77,7 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
 }) => {
   const classes = useStyles({ textFieldHeight, uploadFileError })
   return (
-    <div className={`classes.fileInputWrapper ${className}`}>
+    <div className={`${classes.fileInputWrapper} ${className}`}>
       <Hidden smDown>
         <div className={classes.leftFileIcon}>
           <FileIconLarge color="#f9f9f9" />

--- a/src/client/components/UserPage/Widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/Widgets/FileInputField.tsx
@@ -1,14 +1,7 @@
 import React, { FunctionComponent } from 'react'
-import {
-  Hidden,
-  Typography,
-  Button,
-  makeStyles,
-  createStyles,
-} from '@material-ui/core'
+import { Hidden, Typography, makeStyles, createStyles } from '@material-ui/core'
 import FileIconLarge from './FileIconLarge'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
-import { formatBytes } from '../../../util/format'
 
 type FileInputFieldStyleProps = {
   uploadFileError: string | null
@@ -18,7 +11,7 @@ type FileInputFieldStyleProps = {
 type FileInputFieldProps = {
   uploadFileError: string | null
   textFieldHeight: number | string
-  file?: File
+  text: string
   endAdornment?: JSX.Element
   inputId: string
   setFile: (file: File | null) => void
@@ -73,7 +66,7 @@ const useStyles = makeStyles((theme) =>
 
 export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   textFieldHeight,
-  file,
+  text,
   uploadFileError,
   endAdornment,
   inputId,
@@ -90,7 +83,7 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
       </Hidden>
       <div className={classes.fileInput}>
         <Typography variant="body2" className={classes.fileNameText}>
-          {file ? file.name : 'No file selected'}
+          {text}
         </Typography>
         <input
           type="file"
@@ -120,3 +113,5 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
     </div>
   )
 }
+
+export default FileInputField

--- a/src/client/components/UserPage/Widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/Widgets/FileInputField.tsx
@@ -16,6 +16,7 @@ type FileInputFieldProps = {
   inputId: string
   setFile: (file: File | null) => void
   setUploadFileError: (error: string | null) => void
+  className?: string
 }
 
 const useStyles = makeStyles((theme) =>
@@ -72,10 +73,11 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   inputId,
   setFile,
   setUploadFileError,
+  className,
 }) => {
   const classes = useStyles({ textFieldHeight, uploadFileError })
   return (
-    <div className={classes.fileInputWrapper}>
+    <div className={`classes.fileInputWrapper ${className}`}>
       <Hidden smDown>
         <div className={classes.leftFileIcon}>
           <FileIconLarge color="#f9f9f9" />

--- a/src/client/components/UserPage/Widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/Widgets/FileInputField.tsx
@@ -1,0 +1,122 @@
+import React, { FunctionComponent } from 'react'
+import {
+  Hidden,
+  Typography,
+  Button,
+  makeStyles,
+  createStyles,
+} from '@material-ui/core'
+import FileIconLarge from './FileIconLarge'
+import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
+import { formatBytes } from '../../../util/format'
+
+type FileInputFieldStyleProps = {
+  uploadFileError: string | null
+  textFieldHeight: number | string
+}
+
+type FileInputFieldProps = {
+  uploadFileError: string | null
+  textFieldHeight: number | string
+  file?: File
+  endAdornment?: JSX.Element
+  inputId: string
+  setFile: (file: File | null) => void
+  setUploadFileError: (error: string | null) => void
+}
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    fileInputWrapper: {
+      width: '100%',
+      display: 'flex',
+      alignItems: 'stretch',
+      borderRadius: '3px',
+      overflow: 'hidden',
+      border: (props: FileInputFieldStyleProps) =>
+        props.uploadFileError ? '2px solid #C85151' : '',
+    },
+    fileNameText: {
+      fontWeight: 400,
+      paddingLeft: '16px',
+      display: 'flex',
+      alignItems: 'center',
+    },
+    fileInputInvis: {
+      display: 'none',
+    },
+    leftFileIcon: {
+      width: '44px',
+      backgroundColor: '#456682',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    fileInput: {
+      flexGrow: 1,
+      height: '100%',
+      minHeight: (props: FileInputFieldStyleProps) => props.textFieldHeight,
+      padding: theme.spacing(0),
+      lineHeight: 1.5,
+      backgroundColor: '#d8d8d8',
+      display: 'flex',
+      alignItems: 'stretch',
+      overflow: 'hidden',
+      justifyContent: 'space-between',
+      borderRadius: '3px',
+      [theme.breakpoints.up('sm')]: {
+        backgroundColor: '#e8e8e8',
+      },
+    },
+  }),
+)
+
+export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
+  textFieldHeight,
+  file,
+  uploadFileError,
+  endAdornment,
+  inputId,
+  setFile,
+  setUploadFileError,
+}) => {
+  const classes = useStyles({ textFieldHeight, uploadFileError })
+  return (
+    <div className={classes.fileInputWrapper}>
+      <Hidden smDown>
+        <div className={classes.leftFileIcon}>
+          <FileIconLarge color="#f9f9f9" />
+        </div>
+      </Hidden>
+      <div className={classes.fileInput}>
+        <Typography variant="body2" className={classes.fileNameText}>
+          {file ? file.name : 'No file selected'}
+        </Typography>
+        <input
+          type="file"
+          id={inputId}
+          className={classes.fileInputInvis}
+          onChange={(event) => {
+            if (!event.target.files) {
+              return
+            }
+            const chosenFile = event.target.files[0]
+            if (!chosenFile) {
+              return
+            }
+            if (chosenFile.size > MAX_FILE_UPLOAD_SIZE) {
+              setFile(null)
+              setUploadFileError(
+                'File too large, please upload a file smaller than 10mb',
+              )
+              return
+            }
+            setUploadFileError(null)
+            setFile(chosenFile)
+          }}
+        />
+        {endAdornment}
+      </div>
+    </div>
+  )
+}

--- a/src/client/reducers/user/types.ts
+++ b/src/client/reducers/user/types.ts
@@ -1,9 +1,13 @@
 export type UrlType = {
-  shortUrl: string
-  longUrl: string
-  updatedAt: string
+  clicks: number
   createdAt: string
   editedLongUrl: string
+  isFile: boolean
+  longUrl: string
+  shortUrl: string
+  state: UrlState
+  updatedAt: string
+  userId: number
 }
 
 export type UserState = {

--- a/src/client/theme/index.js
+++ b/src/client/theme/index.js
@@ -105,6 +105,9 @@ export default responsiveFontSizes(
             boxShadow: 'none',
           },
         },
+        outlinedPrimary: {
+          border: `1px solid #456682`,
+        },
       },
       MuiAppBar: {
         colorPrimary: {

--- a/src/client/util/requests.ts
+++ b/src/client/util/requests.ts
@@ -52,6 +52,22 @@ export const patch = (
   return crossFetch(url, opts)
 }
 
+export const patchFormData = (
+  url: string = '',
+  data: FormData,
+  options?: RequestInit,
+) => {
+  const opts = options || {
+    method: 'PATCH',
+    mode: 'cors',
+    cache: 'no-cache',
+    credentials: 'include',
+    body: data,
+  }
+
+  return crossFetch(url, opts)
+}
+
 export const get = (url: string, options?: RequestInit) => {
   const opts = options || {
     method: 'GET',


### PR DESCRIPTION
## Problem

Users might want to replace their uploaded files. This PR implements the front-end for replacing files.

## Solution

**Improvements**:

- Fixed margins on url drawer
- Fixed url drawer button border colors
- Extend CollapsibleMessage to be able to be absolute positioned if needed

## Before & After Screenshots

**AFTER**:
[Desktop](https://user-images.githubusercontent.com/35889982/83769599-a4f30180-a6b2-11ea-82ee-ffbaa0a273b8.png)
[iPhone X](https://user-images.githubusercontent.com/35889982/83770202-614cc780-a6b3-11ea-8afa-d817403ef099.png)


## Tests

1. Replace file with same extension, it should be replaced with the new file
2. Replace file with different extension, long url should change to reflect new extension. Old file should be set to private and new file should be accessible


