### PR TITLE
Add unit tests for logout middleware

### DIFF
--- a/src/server/api/logout/handlers.ts
+++ b/src/server/api/logout/handlers.ts
@@ -2,11 +2,11 @@ import Express from 'express'
 import jsonMessage from '../../util/json'
 
 export function logOut(req: Express.Request, res: Express.Response) {
-  if (req.session) {
-    req.session.destroy(() => res.ok(jsonMessage('Logged out')))
+  if (!req.session) {
+    res.serverError(jsonMessage('No session found'))
     return
   }
-  res.serverError(jsonMessage('No session found'))
+  req.session.destroy(() => res.ok(jsonMessage('Logged out')))
 }
 
 export default logOut

--- a/src/server/api/logout/handlers.ts
+++ b/src/server/api/logout/handlers.ts
@@ -1,14 +1,12 @@
 import Express from 'express'
-import jsonMessage from '../util/json'
+import jsonMessage from '../../util/json'
 
-const router = Express.Router()
-
-router.get('/', (req, res) => {
+export function logOut(req: Express.Request, res: Express.Response) {
   if (req.session) {
     req.session.destroy(() => res.ok(jsonMessage('Logged out')))
     return
   }
   res.serverError(jsonMessage('No session found'))
-})
+}
 
-export = router
+export default logOut

--- a/src/server/api/logout/index.ts
+++ b/src/server/api/logout/index.ts
@@ -1,0 +1,8 @@
+import Express from 'express'
+import { logOut } from './handlers'
+
+const router = Express.Router()
+
+router.get('/', logOut)
+
+export = router

--- a/test/server/api/logout.test.ts
+++ b/test/server/api/logout.test.ts
@@ -19,7 +19,7 @@ describe('logout api tests', () => {
     expect(res.ok.called).toBeTruthy()
   })
 
-  it('should destroy session', () => {
+  it('should send server error when no session', () => {
     const serverErrorSpy = sinon.fake()
     const okSpy = sinon.fake()
     const req = httpMocks.createRequest()

--- a/test/server/api/logout.test.ts
+++ b/test/server/api/logout.test.ts
@@ -1,6 +1,6 @@
-import { logOut } from '../../../src/server/api/logout/handlers'
 import httpMocks from 'node-mocks-http'
 import sinon from 'sinon'
+import { logOut } from '../../../src/server/api/logout/handlers'
 
 describe('logout api tests', () => {
   it('should destroy session', () => {

--- a/test/server/api/logout.test.ts
+++ b/test/server/api/logout.test.ts
@@ -1,0 +1,33 @@
+import { logOut } from '../../../src/server/api/logout/handlers'
+import httpMocks from 'node-mocks-http'
+import sinon from 'sinon'
+
+describe('logout api tests', () => {
+  it('should destroy session', () => {
+    const destroySpy = sinon.fake()
+    const okSpy = sinon.fake()
+    const req = httpMocks.createRequest({
+      session: {
+        destroy: destroySpy as any,
+      },
+    })
+    const res = httpMocks.createResponse() as any
+    res.ok = okSpy
+    logOut(req, res)
+    expect(destroySpy.called).toBeTruthy()
+    destroySpy.getCalls()[0].args[0]()
+    expect(res.ok.called).toBeTruthy()
+  })
+
+  it('should destroy session', () => {
+    const serverErrorSpy = sinon.fake()
+    const okSpy = sinon.fake()
+    const req = httpMocks.createRequest()
+    const res = httpMocks.createResponse() as any
+    res.serverError = serverErrorSpy
+    res.ok = okSpy
+    logOut(req, res)
+    expect(serverErrorSpy.called).toBeTruthy()
+    expect(res.ok.called).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Problem

Logout middleware has no unit tests

[Closes #85]

## Solution

Refactor logout middleware to be seperated into the routes and handler functions so that handlers can be unit tested. Add unit tests for handlers.
