### PR TITLE
Modify Dockerfile to use alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12-alpine3.9
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 
@@ -11,6 +11,8 @@ EXPOSE 8080
 
 # For dev webpack server only, proxies to localhost:8080
 EXPOSE 3000
+
+RUN apk update && apk add python g++ make && rm -rf /var/cache/apk/*
 
 # Install libraries
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Problem

The current Docker image Node v10 is built upon an unmaintained Debian distribution, which can cause security issues.

Closes #155.

## Solution

Modify Dockerfile to use alpine image. Node version has also been upgraded to 12.

So far, not experiencing any compatibility issues based on testing the core features of GoGovSG. Will test with release checklist tomorrow on staging to confirm it's 100% working.


