### PR TITLE
[master] Release 1.17.1 - Patch transition page to allow single-quote links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Link shortener for Singapore government.",
   "main": "src/server/index.js",
   "scripts": {

--- a/src/server/api/redirect.ts
+++ b/src/server/api/redirect.ts
@@ -65,6 +65,17 @@ function isCrawler(ua: string): boolean {
 }
 
 /**
+ * Encodes the long URL to be template safe. Currently this function
+ * only templates the double-quote character as it is invalid according
+ * to [RFC 3986](https://tools.ietf.org/html/rfc3986#appendix-C).
+ * @param {string} longUrl The long URL before templating.
+ * @return {string} The template-safe URL.
+ */
+function encodeLongUrl(longUrl: string) {
+  return longUrl.replace(/["]/g, encodeURIComponent)
+}
+
+/**
  * The redirect function.
  * @param {Object} req Express request object.
  * @param {Object} res Express response object.
@@ -121,7 +132,7 @@ export default async function redirect(
       const rootDomain: string = parseDomain(longUrl)
 
       res.status(200).render(TRANSITION_PATH, {
-        longUrl,
+        escapedLongUrl: encodeLongUrl(longUrl),
         rootDomain,
       })
       return

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -42,7 +42,7 @@
     </div>
     <script>
         function proceedToDestination() {
-            window.location = '<%- longUrl %>'
+            window.location = "<%- escapedLongUrl %>" // Use double-quotes to avoid templating issue as per RFC3986 (https://tools.ietf.org/html/rfc3986#appendix-C)
         }
     </script>
 </body>


### PR DESCRIPTION
## Problem

- The presence of single-quotes breaks the templating of the long link in Javascript
- Users were only able to visit the link when the refresh button is clicked, as the server interprets teh request as a subsequent visit thereby bypassing the transition page.

Closes #160

## Solution

- According to RFC3986, single-quotes are reserved in the URI, but
double-quotes are considered invalid, therefore we replace single-quotes
around the template string to double-quotes
- URI-encode the presence of all double-quotes in longUrls during
HTML templating

**Bug Fixes**:

- Resolves an issue where the transition page may not work if the link contains single-quote characters.

