### PR TITLE
fix(docker-compose): expose port 4566, the edge server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     image: localstack/localstack:latest
     container_name: gogovsg-localstack
     ports:
-      - '4567-4584:4567-4584'
+      - '4566-4584:4566-4584'
       - '8055:8080' # View deployed resources @ http://localhost:8055/#!/infra.
     environment:
       - SERVICES=s3 # AWS services to emulate.


### PR DESCRIPTION
This is a follow up to #166 , which switches to using port 4566 for localstack