### PR TITLE
Install ttf-freefont in alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8080
 # For dev webpack server only, proxies to localhost:8080
 EXPOSE 3000
 
-RUN apk update && apk add python g++ make && rm -rf /var/cache/apk/*
+RUN apk update && apk add python g++ make ttf-freefont && rm -rf /var/cache/apk/*
 
 # Install libraries
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Problem

Rendering of fonts for SVG and PNG is not working when we switched to an alpine base image.

## Solution

The alpine documentation on fonts gives a good list of fonts that we can install to achieve what we need, I'm using GNU FreeFont, with the main reason being that it was what worked with formsg so we've at least tested that it solves font-rendering problems there. 

## Screenshot

![image](https://user-images.githubusercontent.com/16982839/84233271-98dcc900-ab24-11ea-9e84-e2711ff54eaa.png)


