### PR TITLE
Unify URL edit patch endpoints

### DIFF
--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -272,7 +272,7 @@ const updateLongUrl = (shortUrl: string, longUrl: string) => (
     return null
   }
 
-  return patch('/api/user/url/edit', { longUrl, shortUrl }).then((response) => {
+  return patch('/api/user/url', { longUrl, shortUrl }).then((response) => {
     if (response.ok) {
       dispatch<void>(getUrlsForUser())
       dispatch<SetSuccessMessageAction>(
@@ -305,7 +305,7 @@ const replaceFile = (
   data.append('file', file, file.name)
   data.append('shortUrl', shortUrl)
 
-  const response = await patchFormData('/api/user/url/edit', data)
+  const response = await patchFormData('/api/user/url', data)
   dispatch<SetIsUploadingAction>(setIsUploading(false))
   if (!response.ok) {
     const json = await response.json()

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -20,9 +20,9 @@ import { UserRepositoryInterface } from '../../repositories/interfaces/UserRepos
 import { NotFoundError } from '../../util/error'
 import {
   ownershipTransferSchema,
-  stateEditSchema,
   urlRetrievalSchema,
   urlSchema,
+  urlEditSchema,
 } from './validators'
 
 const router = Express.Router()
@@ -229,7 +229,7 @@ router.patch(
 /**
  * Endpoint for user to render a URL active/inactive.
  */
-router.patch('/url', validator.body(stateEditSchema), async (req, res) => {
+router.patch('/url', validator.body(urlEditSchema), async (req, res) => {
   const { userId, shortUrl, state }: ShorturlStateEditRequest = req.body
 
   try {

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -165,7 +165,6 @@ router.patch(
       }
 
       // Success
-      // TODO: Remove force cast once UserRepository has been made
       const result = await urlRepository.update(url, {
         userId: newUserId,
       })
@@ -215,7 +214,6 @@ router.patch(
           }
         : undefined
 
-      // TODO: Remove force cast once UserRepository has been made
       await urlRepository.update(url, { longUrl }, storableFile)
 
       res.ok(jsonMessage(`Short link "${shortUrl}" has been updated`))

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -229,6 +229,7 @@ router.patch(
  */
 router.patch(
   '/url',
+  fileUploadMiddleware,
   preprocessPotentialIncomingFile,
   validator.body(urlEditSchema),
   async (req, res) => {

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -33,12 +33,6 @@ export const urlSchema = Joi.object({
   }),
 }).xor('longUrl', 'files')
 
-export const stateEditSchema = Joi.object({
-  userId: Joi.number().required(),
-  shortUrl: Joi.string().required(),
-  state: Joi.string().allow(ACTIVE, INACTIVE).only().required(),
-})
-
 export const urlEditSchema = Joi.object({
   userId: Joi.number().required(),
   shortUrl: Joi.string().required(),
@@ -57,7 +51,7 @@ export const urlEditSchema = Joi.object({
     file: Joi.object().keys().required(),
   }),
   state: Joi.string().allow(ACTIVE, INACTIVE).only(),
-}).xor('longUrl', 'files')
+}).oxor('longUrl', 'files')
 
 export const ownershipTransferSchema = Joi.object({
   userId: Joi.number().required(),

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -1,0 +1,66 @@
+import * as Joi from '@hapi/joi'
+import { ACTIVE, INACTIVE } from '../../models/types'
+import blacklist from '../../resources/blacklist'
+import { isHttps, isValidShortUrl } from '../../../shared/util/validation'
+
+export const urlRetrievalSchema = Joi.object({
+  userId: Joi.number().required(),
+})
+
+export const urlSchema = Joi.object({
+  userId: Joi.number().required(),
+  shortUrl: Joi.string()
+    .custom((url: string, helpers) => {
+      if (!isValidShortUrl(url)) {
+        return helpers.message({ custom: 'Short url format is invalid.' })
+      }
+      return url
+    })
+    .required(),
+  longUrl: Joi.string().custom((url: string, helpers) => {
+    if (!isHttps(url)) {
+      return helpers.message({ custom: 'Long url must start with https://' })
+    }
+    if (blacklist.some((bl) => url.includes(bl))) {
+      return helpers.message({
+        custom: 'Creation of URLs to link shortener sites prohibited.',
+      })
+    }
+    return url
+  }),
+  files: Joi.object({
+    file: Joi.object().keys().required(),
+  }),
+}).xor('longUrl', 'files')
+
+export const stateEditSchema = Joi.object({
+  userId: Joi.number().required(),
+  shortUrl: Joi.string().required(),
+  state: Joi.string().allow(ACTIVE, INACTIVE).only().required(),
+})
+
+export const urlEditSchema = Joi.object({
+  userId: Joi.number().required(),
+  shortUrl: Joi.string().required(),
+  longUrl: Joi.string().custom((url: string, helpers) => {
+    if (!isHttps(url)) {
+      return helpers.message({ custom: 'Long url must start with https://' })
+    }
+    if (blacklist.some((bl) => url.includes(bl))) {
+      return helpers.message({
+        custom: 'Creation of URLs to link shortener sites prohibited.',
+      })
+    }
+    return url
+  }),
+  files: Joi.object({
+    file: Joi.object().keys().required(),
+  }),
+  state: Joi.string().allow(ACTIVE, INACTIVE).only(),
+}).xor('longUrl', 'files')
+
+export const ownershipTransferSchema = Joi.object({
+  userId: Joi.number().required(),
+  shortUrl: Joi.string().required(),
+  newUserEmail: Joi.string().required(),
+})

--- a/src/types/server/api/user.d.ts
+++ b/src/types/server/api/user.d.ts
@@ -16,16 +16,19 @@ type NewUserEmailProperty = {
   newUserEmail: string
 }
 
-type StateProperty = {
-  state: 'ACTIVE' | 'INACTIVE'
+type OptionalStateProperty = {
+  state?: 'ACTIVE' | 'INACTIVE'
 }
 
 export type UrlCreationRequest = ShortUrlOperationProperty &
   OptionalLongUrlProperty
 
-export type UrlEditRequest = ShortUrlOperationProperty & OptionalLongUrlProperty
+export type OldUrlEditRequest = ShortUrlOperationProperty &
+  OptionalLongUrlProperty
 
 export type OwnershipTransferRequest = ShortUrlOperationProperty &
   NewUserEmailProperty
 
-export type ShorturlStateEditRequest = ShortUrlOperationProperty & StateProperty
+export type UrlEditRequest = ShortUrlOperationProperty &
+  OptionalStateProperty &
+  OptionalLongUrlProperty


### PR DESCRIPTION
## Problem

At present, two endpoints exist for editing links in GoGovSG. The first allows one to modify the longUrl, and another to toggle the `ACTIVE` or `INACTIVE` state of the link. This can be achieved more efficiently with just one PATCH endpoint.

Closes #121 

## Solution

- [x] Unify the validators for both state-edit and longUrl-edit endpoints
- [x] Merge logic of the longUrl-edit endpoint into the state-edit one. The reason is because we want to take the `/url` endpoint rather than the `/url/edit` one.
- [x] Modify frontend API call code to make longUrl/file edit requests to the /url endpoint rather than /url/edit

## Backwards compatibility

To cater to the possibility of old client code being run by some browsers, currently opting to keep the old /url/edit endpoint there for this release, and then remove it in the subsequent one.

