### PR TITLE
Update db migration scripts to include isFile column

### DIFF
--- a/scripts/migrate_url_to_user.sql
+++ b/scripts/migrate_url_to_user.sql
@@ -10,6 +10,8 @@
 --
 -- Change History:
 --   31 July 2019 github.com/jeantanzj: Function created
+--   12 June 2020 Foo Yong Jie:         Update function's url_history insertion step to include compulsory
+--                                      isFile column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_url_to_user(short_url_value text, to_user_email text) RETURNS void AS
 $BODY$
@@ -41,8 +43,8 @@ BEGIN
         RAISE EXCEPTION 'No transferring of links to the same user';
     END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "shortUrl" = short_url LIMIT 1;
 -- Update the link in the URL table

--- a/scripts/migrate_user_links.sql
+++ b/scripts/migrate_user_links.sql
@@ -12,6 +12,8 @@
 --
 -- Change History:
 --   11 July 2019 Yuanruo Liang: Function created
+--   12 June 2020 Foo Yong Jie: Update function's url_history insertion step to include
+--                              compulsory isFile column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS void AS
 $BODY$
@@ -37,8 +39,8 @@ BEGIN
 		RAISE EXCEPTION 'No transferring of links to the same user';
 	END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "userId" = from_user_id;
 -- Update the links in the URL table


### PR DESCRIPTION
## Problem

The DB schema for both the url and url_history tables have had a compulsory "isFile" column added, but the helper SQL scripts that allow us to migrate short links to users has not been updated to reflect this change. 

Closes #130 

## Solution

Only the url_history table insertion step needs to be updated to include "isFile", as the actual url table update step only changes the "userId" column.

