### PR TITLE
Refactor RotatingLinksController and SentryController

### DIFF
--- a/src/server/api/links.ts
+++ b/src/server/api/links.ts
@@ -1,11 +1,17 @@
 import Express from 'express'
-import { linksToRotate } from '../config'
+import { container } from '../util/inversify'
+import { RotatingLinksControllerInterface } from '../controllers/interfaces/RotatingLinksControllerInterface'
+import { DependencyIds } from '../constants'
 
 const router = Express.Router()
+
+const linksController = container.get<RotatingLinksControllerInterface>(
+  DependencyIds.linksController,
+)
 
 /**
  * Requests for the array of links to rotate.
  */
-router.get('/', (_, res) => res.send(linksToRotate))
+router.get('/', linksController.getRotatingLinks)
 
 module.exports = router

--- a/src/server/api/sentry.ts
+++ b/src/server/api/sentry.ts
@@ -1,11 +1,17 @@
 import Express from 'express'
-import { sentryDns } from '../config'
+import { container } from '../util/inversify'
+import { SentryControllerInterface } from '../controllers/interfaces/SentryControllerInterface'
+import { DependencyIds } from '../constants'
 
 const router = Express.Router()
+
+const sentryController = container.get<SentryControllerInterface>(
+  DependencyIds.sentryController,
+)
 
 /**
  * Requests for the Sentry DNS.
  */
-router.get('/', (_, res) => res.send(sentryDns))
+router.get('/', sentryController.getSentryDns)
 
 module.exports = router

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -19,6 +19,8 @@ export const DependencyIds = {
   statisticsRepository: Symbol.for('statisticsRepository'),
   statisticsService: Symbol.for('repositoryService'),
   statisticsController: Symbol.for('statisticsController'),
+  sentryController: Symbol.for('sentryController'),
+  linksController: Symbol.for('linksController'),
 }
 
 export default DependencyIds

--- a/src/server/controllers/RotatingLinksController.ts
+++ b/src/server/controllers/RotatingLinksController.ts
@@ -1,0 +1,15 @@
+/* eslint-disable class-methods-use-this */
+import Express from 'express'
+import { injectable } from 'inversify'
+import { RotatingLinksControllerInterface } from './interfaces/RotatingLinksControllerInterface'
+import { linksToRotate } from '../config'
+
+@injectable()
+export class RotatingLinksController
+  implements RotatingLinksControllerInterface {
+  getRotatingLinks(_: Express.Request, res: Express.Response): void {
+    res.send(linksToRotate)
+  }
+}
+
+export default RotatingLinksController

--- a/src/server/controllers/SentryController.ts
+++ b/src/server/controllers/SentryController.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import Express from 'express'
+import { injectable } from 'inversify'
+import { sentryDns } from '../config'
+import { SentryControllerInterface } from './interfaces/SentryControllerInterface'
+
+@injectable()
+export class SentryController implements SentryControllerInterface {
+  getSentryDns(_: Express.Request, res: Express.Response) {
+    res.send(sentryDns)
+  }
+}
+
+export default SentryController

--- a/src/server/controllers/interfaces/RotatingLinksControllerInterface.ts
+++ b/src/server/controllers/interfaces/RotatingLinksControllerInterface.ts
@@ -1,0 +1,5 @@
+import Express from 'express'
+
+export interface RotatingLinksControllerInterface {
+  getRotatingLinks(req: Express.Request, res: Express.Response): void
+}

--- a/src/server/controllers/interfaces/SentryControllerInterface.ts
+++ b/src/server/controllers/interfaces/SentryControllerInterface.ts
@@ -1,0 +1,8 @@
+import Express from 'express'
+
+export interface SentryControllerInterface {
+  /**
+   * Requests for the Sentry DNS.
+   */
+  getSentryDns(req: Express.Request, res: Express.Response): void
+}

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -21,6 +21,8 @@ import { CrawlerCheckService } from './services/CrawlerCheckService'
 import { StatisticsRepository } from './repositories/StatisticsRepository'
 import { StatisticsService } from './services/StatisticsService'
 import { StatisticsController } from './controllers/StatisticsController'
+import { RotatingLinksController } from './controllers/RotatingLinksController'
+import { SentryController } from './controllers/SentryController'
 
 function bindIfUnbound<T>(
   dependencyId: symbol,
@@ -47,6 +49,8 @@ export default () => {
   bindIfUnbound(DependencyIds.statisticsController, StatisticsController)
   bindIfUnbound(DependencyIds.statisticsRepository, StatisticsRepository)
   bindIfUnbound(DependencyIds.statisticsService, StatisticsService)
+  bindIfUnbound(DependencyIds.linksController, RotatingLinksController)
+  bindIfUnbound(DependencyIds.sentryController, SentryController)
 
   container.bind(DependencyIds.s3Bucket).toConstantValue(s3Bucket)
 

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -42,4 +42,5 @@ jest.mock('../../src/server/config', () => ({
   redirectExpiry,
   otpExpiry: 10,
   s3Bucket: 'file-staging.go.gov.sg',
+  linksToRotate: 'testlink1,testlink2,testlink3',
 }))

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -43,4 +43,5 @@ jest.mock('../../src/server/config', () => ({
   otpExpiry: 10,
   s3Bucket: 'file-staging.go.gov.sg',
   linksToRotate: 'testlink1,testlink2,testlink3',
+  sentryDns: 'mocksentry.com',
 }))

--- a/test/server/controllers/RotatingLinksController.test.ts
+++ b/test/server/controllers/RotatingLinksController.test.ts
@@ -1,0 +1,13 @@
+import httpMocks from 'node-mocks-http'
+import { RotatingLinksController } from '../../../src/server/controllers/RotatingLinksController'
+
+describe('RotatingLinksController tests', () => {
+  it('Should return rotating links defined in the application configurations', () => {
+    const controller = new RotatingLinksController()
+    const { req, res } = httpMocks.createMocks()
+    jest.spyOn(res, 'send')
+    controller.getRotatingLinks(req, res)
+
+    expect(res.send).toBeCalledWith('testlink1,testlink2,testlink3')
+  })
+})

--- a/test/server/controllers/SentryController.test.ts
+++ b/test/server/controllers/SentryController.test.ts
@@ -1,0 +1,13 @@
+import httpMocks from 'node-mocks-http'
+import { SentryController } from '../../../src/server/controllers/SentryController'
+
+describe('SentryController tests', () => {
+  it('Should return rotating links defined in the application configurations', () => {
+    const controller = new SentryController()
+    const { req, res } = httpMocks.createMocks()
+    jest.spyOn(res, 'send')
+    controller.getSentryDns(req, res)
+
+    expect(res.send).toBeCalledWith('mocksentry.com')
+  })
+})


### PR DESCRIPTION
## Problem

Some API endpoints have not been refactored to use the Controller pattern

#156 

## Solution

This PR continues the refactoring process by refactoring some of the simpler endpoints in the repository.
