### PR TITLE
fix(localstack): corrected whitelist, test, and compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     image: localstack/localstack:latest
     container_name: gogovsg-localstack
     ports:
-      - '4566-4584:4566-4584'
+      - '4566:4566'
       - '8055:8080' # View deployed resources @ http://localhost:8055/#!/infra.
     environment:
       - SERVICES=s3 # AWS services to emulate.

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -3,7 +3,7 @@ import { parse } from 'url'
 
 import blacklist from '../../server/resources/blacklist'
 
-export const WHITELIST = [new RegExp('^http://localhost:4572')]
+export const WHITELIST = [new RegExp('^http://localhost:4566')]
 
 export const URL_OPTS: ValidatorJS.IsURLOptions = {
   protocols: ['https'],

--- a/test/shared/util/validation.test.ts
+++ b/test/shared/util/validation.test.ts
@@ -3,14 +3,14 @@ import { ogHostname } from '../../../src/server/config'
 
 describe('Test whiteliste check', () => {
   test('localstack url is whitelisted', () => {
-    const url = 'http://localhost:4572'
+    const url = 'http://localhost:4566'
     expect(validation.isWhitelisted(url)).toBe(true)
   })
 })
 
 describe('Test blacklist check', () => {
   test('localstack url is not blacklisted', () => {
-    const url = 'http://localhost:4572'
+    const url = 'http://localhost:4566'
     expect(validation.isBlacklisted(url)).toBe(false)
   })
 
@@ -32,12 +32,12 @@ describe('Test https check', () => {
   })
 
   test('localstack url fails check by default', () => {
-    const url = 'http://localhost:4572/local-bucket/file1.pdf'
+    const url = 'http://localhost:4566/local-bucket/file1.pdf'
     expect(validation.isHttps(url)).toBe(false)
   })
 
   test('localstack url passes check with whitelist', () => {
-    const url = 'http://localhost:4572/local-bucket/file1.pdf'
+    const url = 'http://localhost:4566/local-bucket/file1.pdf'
     expect(validation.isHttps(url, true)).toBe(true)
   })
 })
@@ -59,12 +59,12 @@ describe('Test valid url check', () => {
   })
 
   test('localstack url fails check by default', () => {
-    const url = 'http://localhost:4572/local-bucket/file1.pdf'
+    const url = 'http://localhost:4566/local-bucket/file1.pdf'
     expect(validation.isValidUrl(url)).toBe(false)
   })
 
   test('localstack url passes check with whitelist', () => {
-    const url = 'http://localhost:4572/local-bucket/file1.pdf'
+    const url = 'http://localhost:4566/local-bucket/file1.pdf'
     expect(validation.isValidUrl(url, true)).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

In earlier PRs, we have simplified the localstack endpoint. However, the whitelist is not updated. This prevents the upload of files in development, as localstack urls are not considered valid urls. In addition, our tests and docker-compose file can also be updated or simplified.

## Solution

- Corrected the whitelist url to `http://localhost:4566`.
- Update tests for whitelist validation to use `http://localhost:4566`.
- Expose only port 4566 for localstack in our compose file.