### PR TITLE
feat: disallow non-ascii characters in desc field

### DIFF
--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -25,7 +25,10 @@ import TrailingButton from './widgets/TrailingButton'
 import GoSwitch from './widgets/GoSwitch'
 import useShortLink from './util/shortlink'
 import { removeHttpsProtocol } from '../../../../util/url'
-import { isValidLongUrl } from '../../../../../shared/util/validation'
+import {
+  isValidLongUrl,
+  isPrintableAscii,
+} from '../../../../../shared/util/validation'
 import DownloadButton from './widgets/DownloadButton'
 import helpIcon from '../../../../assets/help-icon.svg'
 import FileInputField from '../../Widgets/FileInputField'
@@ -186,6 +189,9 @@ export default function ControlPanel() {
   const originalContactEmail = shortLinkState?.contactEmail || ''
   const isContactEmailValid =
     !editedContactEmail || emailValidator.match(editedContactEmail)
+  const isDescriptionValid =
+    editedDescription.length <= LINK_DESCRIPTION_MAX_LENGTH &&
+    isPrintableAscii(editedDescription)
 
   // Disposes any current unsaved changes and closes the modal.
   const handleClose = () => {
@@ -509,10 +515,10 @@ export default function ControlPanel() {
                       event.target.value.replace(/(\r\n|\n|\r)/gm, ''),
                     )
                   }
-                  error={editedDescription.length > LINK_DESCRIPTION_MAX_LENGTH}
+                  error={!isDescriptionValid}
                   placeholder=""
                   helperText={
-                    editedDescription.length <= LINK_DESCRIPTION_MAX_LENGTH
+                    isDescriptionValid
                       ? `${editedDescription.length}/${LINK_DESCRIPTION_MAX_LENGTH}`
                       : undefined
                   }
@@ -523,13 +529,13 @@ export default function ControlPanel() {
                 />
                 <CollapsibleMessage
                   type={CollapsibleMessageType.Error}
-                  visible={
-                    editedDescription.length > LINK_DESCRIPTION_MAX_LENGTH
-                  }
+                  visible={!isDescriptionValid}
                   position={CollapsibleMessagePosition.Static}
                   timeout={0}
                 >
-                  {`${editedDescription.length}/200`}
+                  {isPrintableAscii(editedDescription)
+                    ? `${editedDescription.length}/200`
+                    : 'Only ASCII characters are allowed.'}
                 </CollapsibleMessage>
               </>
             }
@@ -540,7 +546,7 @@ export default function ControlPanel() {
           <div className={classes.saveLinkInformationButtonWrapper}>
             <TrailingButton
               disabled={
-                editedDescription.length > LINK_DESCRIPTION_MAX_LENGTH ||
+                !isDescriptionValid ||
                 (editedContactEmail === originalContactEmail &&
                   editedDescription === originalDescription) ||
                 !isContactEmailValid

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -535,7 +535,7 @@ export default function ControlPanel() {
                 >
                   {isPrintableAscii(editedDescription)
                     ? `${editedDescription.length}/200`
-                    : 'Only ASCII characters are allowed.'}
+                    : 'Description should only contain alphanumeric characters and symbols.'}
                 </CollapsibleMessage>
               </>
             }

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -60,5 +60,6 @@ export function isCircularRedirects(url: string, hostname?: string): boolean {
 }
 
 export function isPrintableAscii(string: string): boolean {
+  // Only accepts characters from 0x20 to 0x7F
   return /^[\x20-\x7F]*$/.test(string)
 }

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -58,3 +58,7 @@ export function isCircularRedirects(url: string, hostname?: string): boolean {
   if (!hostname) return false
   return parse(url).hostname === hostname
 }
+
+export function isPrintableAscii(string: string): boolean {
+  return /^[\x20-\x7F]*$/.test(string)
+}

--- a/test/shared/util/validation.test.ts
+++ b/test/shared/util/validation.test.ts
@@ -131,3 +131,21 @@ describe('Test circular directs check', () => {
     expect(validation.isCircularRedirects(url)).toBe(false)
   })
 })
+
+describe('test isPrintableAscii', () => {
+  it('should return false on non-english language characters', () => {
+    expect(validation.isPrintableAscii('在一个风和日丽的早上')).toBeFalsy()
+    expect(validation.isPrintableAscii('விக்சன')).toBeFalsy()
+    expect(
+      validation.isPrintableAscii('在一个风和日丽的早上, test'),
+    ).toBeFalsy()
+  })
+
+  it('should return true on printable ascii characters', () => {
+    expect(validation.isPrintableAscii('test description')).toBeTruthy()
+    expect(
+      validation.isPrintableAscii("!@#$%^&*()~`-=[];',./\\/*-+"),
+    ).toBeTruthy()
+    expect(validation.isPrintableAscii('aAbBcC')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Problem

When users input descriptions, they're allowed to enter non-ascii characters such as chinese characters. Characters from other languages are not effectively indexed for search. Furthermore, GoGovSg is monolingual at the moment and visitors are unlikely to not know English.

## Solution

Disallow non-ascii characters on both the input field and backend API validation.

## Before & After Screenshots

**AFTER**:

![image](https://user-images.githubusercontent.com/35889982/85521346-b470c500-b636-11ea-829f-648f4052f44a.png)

## Tests

There should be an error message and the save button greyed out when a non-english character (e.g chinese) is inputted in the description field.
