### PR TITLE
refactor: append return statements after response callback

### DIFF
--- a/.eslintrc.ts.json
+++ b/.eslintrc.ts.json
@@ -18,6 +18,7 @@
     "newline-per-chained-call": ["error"],
     "no-console": "off",
     "no-unused-vars": "off",
+    "no-useless-return": "off",
     "semi": [2, "never"],
     "sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "jsdoc/require-description-complete-sentence": "error",

--- a/src/server/api/qrcode.ts
+++ b/src/server/api/qrcode.ts
@@ -71,6 +71,7 @@ router.get(
       res.set('Filename', goShortLink)
       res.contentType(format)
       res.end(buffer)
+      return
     })
   },
 )

--- a/src/server/controllers/LoginController.ts
+++ b/src/server/controllers/LoginController.ts
@@ -26,6 +26,7 @@ export class LoginController implements LoginControllerInterface {
     res: Express.Response,
   ) => void = (_, res) => {
     res.send(loginMessage)
+    return
   }
 
   public getEmailDomains: (
@@ -33,6 +34,7 @@ export class LoginController implements LoginControllerInterface {
     res: Express.Response,
   ) => void = (_, res) => {
     res.send(validEmailDomainGlobExpression)
+    return
   }
 
   public generateOtp: (
@@ -49,6 +51,7 @@ export class LoginController implements LoginControllerInterface {
     }
 
     res.ok(jsonMessage('OTP generated and sent.'))
+    return
   }
 
   public verifyOtp: (
@@ -69,11 +72,14 @@ export class LoginController implements LoginControllerInterface {
             `OTP hash verification failed, ${error.retries} attempt(s) remaining.`,
           ),
         )
-      } else if (error instanceof NotFoundError) {
-        res.unauthorized(jsonMessage('OTP expired/not found.'))
-      } else {
-        res.serverError(jsonMessage(error.message))
+        return
       }
+      if (error instanceof NotFoundError) {
+        res.unauthorized(jsonMessage('OTP expired/not found.'))
+        return
+      }
+      res.serverError(jsonMessage(error.message))
+      return
     }
   }
 
@@ -86,9 +92,10 @@ export class LoginController implements LoginControllerInterface {
     if (user) {
       const response = { ...jsonMessage('Logged in'), user }
       res.ok(response)
-    } else {
-      res.notFound(jsonMessage('User session not found'))
+      return
     }
+    res.notFound(jsonMessage('User session not found'))
+    return
   }
 }
 

--- a/src/server/controllers/LoginController.ts
+++ b/src/server/controllers/LoginController.ts
@@ -45,6 +45,7 @@ export class LoginController implements LoginControllerInterface {
       await this.authService.generateOtp(email)
     } catch (error) {
       res.serverError(jsonMessage(error.message))
+      return
     }
 
     res.ok(jsonMessage('OTP generated and sent.'))
@@ -60,6 +61,7 @@ export class LoginController implements LoginControllerInterface {
       const user = await this.authService.verifyOtp(email, otp)
       req.session!.user = user
       res.ok(jsonMessage('OTP hash verification ok.'))
+      return
     } catch (error) {
       if (error instanceof InvalidOtpError) {
         res.unauthorized(

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -81,9 +81,10 @@ export class RedirectController implements RedirectControllerInterface {
           gaOnLoad: EventAction.LOADED,
           gaOnProceed: EventAction.PROCEEDED,
         })
-      } else {
-        res.status(302).redirect(longUrl)
+        return
       }
+      res.status(302).redirect(longUrl)
+      return
     } catch (error) {
       if (!(error instanceof NotFoundError)) {
         logger.error(

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -93,6 +93,7 @@ export class RedirectController implements RedirectControllerInterface {
       }
 
       res.status(404).render(ERROR_404_PATH, { shortUrl })
+      return
     }
   }
 

--- a/src/server/controllers/RotatingLinksController.ts
+++ b/src/server/controllers/RotatingLinksController.ts
@@ -9,6 +9,7 @@ export class RotatingLinksController
   implements RotatingLinksControllerInterface {
   getRotatingLinks(_: Express.Request, res: Express.Response): void {
     res.send(linksToRotate)
+    return
   }
 }
 

--- a/src/server/controllers/SentryController.ts
+++ b/src/server/controllers/SentryController.ts
@@ -8,6 +8,7 @@ import { SentryControllerInterface } from './interfaces/SentryControllerInterfac
 export class SentryController implements SentryControllerInterface {
   getSentryDns(_: Express.Request, res: Express.Response) {
     res.send(sentryDns)
+    return
   }
 }
 

--- a/src/server/controllers/StatisticsController.ts
+++ b/src/server/controllers/StatisticsController.ts
@@ -19,7 +19,7 @@ export class StatisticsController implements StatisticsControllerInterface {
     req: Express.Request,
     res: Express.Response,
   ) => Promise<void> = async (_, res) => {
-    res.json(await this.statisticsService.getGlobalStatistics())
+    res.status(200).json(await this.statisticsService.getGlobalStatistics())
   }
 }
 

--- a/src/server/controllers/StatisticsController.ts
+++ b/src/server/controllers/StatisticsController.ts
@@ -20,6 +20,7 @@ export class StatisticsController implements StatisticsControllerInterface {
     res: Express.Response,
   ) => Promise<void> = async (_, res) => {
     res.status(200).json(await this.statisticsService.getGlobalStatistics())
+    return
   }
 }
 

--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -44,6 +44,7 @@ export class UserController implements UserControllerInterface {
     try {
       await this.urlManagementService.createUrl(userId, shortUrl, longUrl, file)
       res.ok(jsonMessage(`Short link "${shortUrl}" has been updated`))
+      return
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
@@ -80,6 +81,7 @@ export class UserController implements UserControllerInterface {
         file,
       })
       res.ok(url)
+      return
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
@@ -107,6 +109,7 @@ export class UserController implements UserControllerInterface {
         newUserEmail,
       )
       res.ok(url)
+      return
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
@@ -151,6 +154,7 @@ export class UserController implements UserControllerInterface {
         count,
       } = await this.urlManagementService.getUrlsWithConditions(queryConditions)
       res.ok({ urls, count })
+      return
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(error.message)

--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -48,12 +48,15 @@ export class UserController implements UserControllerInterface {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
-      } else if (error instanceof AlreadyExistsError) {
-        res.badRequest(jsonMessage(error.message, MessageType.ShortUrlError))
-      } else {
-        logger.error(`Error creating short URL:\t${error}`)
-        res.badRequest(jsonMessage('Server error.'))
+        return
       }
+      if (error instanceof AlreadyExistsError) {
+        res.badRequest(jsonMessage(error.message, MessageType.ShortUrlError))
+        return
+      }
+      logger.error(`Error creating short URL:\t${error}`)
+      res.badRequest(jsonMessage('Server error.'))
+      return
     }
   }
 
@@ -85,10 +88,11 @@ export class UserController implements UserControllerInterface {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
-      } else {
-        logger.error(`Error editing URL:\t${error}`)
-        res.badRequest(jsonMessage(`Unable to edit short link "${shortUrl}"`))
+        return
       }
+      logger.error(`Error editing URL:\t${error}`)
+      res.badRequest(jsonMessage(`Unable to edit short link "${shortUrl}"`))
+      return
     }
   }
 
@@ -113,12 +117,15 @@ export class UserController implements UserControllerInterface {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(jsonMessage(error.message))
-      } else if (error instanceof AlreadyOwnLinkError) {
-        res.badRequest(jsonMessage(error.message))
-      } else {
-        logger.error(`Error transferring ownership of short URL:\t${error}`)
-        res.badRequest(jsonMessage('An error has occured'))
+        return
       }
+      if (error instanceof AlreadyOwnLinkError) {
+        res.badRequest(jsonMessage(error.message))
+        return
+      }
+      logger.error(`Error transferring ownership of short URL:\t${error}`)
+      res.badRequest(jsonMessage('An error has occured'))
+      return
     }
   }
 
@@ -158,9 +165,10 @@ export class UserController implements UserControllerInterface {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.notFound(error.message)
-      } else {
-        res.serverError(jsonMessage('Error retrieving URLs for user'))
+        return
       }
+      res.serverError(jsonMessage('Error retrieving URLs for user'))
+      return
     }
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -132,6 +132,7 @@ initDb()
     app.use((req, res) => {
       const shortUrl = req.path.slice(1)
       res.status(404).render('404.error.ejs', { shortUrl })
+      return
     })
 
     const errorHandler: express.ErrorRequestHandler = (
@@ -147,6 +148,7 @@ initDb()
         return
       }
       res.status(500).render('500.error.ejs')
+      return
     }
     app.use(errorHandler)
 


### PR DESCRIPTION
## Problem

Some of the response statements are not followed by a return statement.

## Solution

- Append return statements to the next line of response statements.
- Also added explicit status code to the existing `res.json` statement.
- Disabled an Eslint rule that removes return statements which it deems unnecessary.
