### PR TITLE
feat: include helpful description placeholder and tooltip

### DIFF
--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -258,7 +258,7 @@ export default function ControlPanel() {
     <>
       Link description{' '}
       <Tooltip
-        title="Link descriptions have a maximum character count of 200."
+        title="Write a description that will help users understand what your short link is for."
         arrow
         placement="top"
         classes={{ tooltip: classes.drawerTooltip }}
@@ -516,7 +516,7 @@ export default function ControlPanel() {
                     )
                   }
                   error={!isDescriptionValid}
-                  placeholder=""
+                  placeholder="Tip: Include your agency name to tell users who this link belongs to."
                   helperText={
                     isDescriptionValid
                       ? `${editedDescription.length}/${LINK_DESCRIPTION_MAX_LENGTH}`

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -516,7 +516,7 @@ export default function ControlPanel() {
                     )
                   }
                   error={!isDescriptionValid}
-                  placeholder="Tip: Include your agency name to tell users who this link belongs to."
+                  placeholder="Tip: Include your agency name to inform the public who this link belongs to."
                   helperText={
                     isDescriptionValid
                       ? `${editedDescription.length}/${LINK_DESCRIPTION_MAX_LENGTH}`

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -258,7 +258,7 @@ export default function ControlPanel() {
     <>
       Link description{' '}
       <Tooltip
-        title="Write a description that will help users understand what your short link is for."
+        title="Write a description that will help the public understand what your short link is for."
         arrow
         placement="top"
         classes={{ tooltip: classes.drawerTooltip }}


### PR DESCRIPTION
## Problem

Users might not understand what description field is for and write information which is not as useful for search.

## Solution

Include helpful placeholders and tooltips to nudge users to write descriptions which are useful for members of the public.

![image](https://user-images.githubusercontent.com/35889982/85660287-07ef1b80-b6e8-11ea-9345-b40c3bb13d82.png)
