### PR TITLE
CSRF protection

### DIFF
--- a/src/client/util/requests.ts
+++ b/src/client/util/requests.ts
@@ -7,7 +7,7 @@ export const postJson = (
 ) => {
   const opts = options || {
     method: 'POST',
-    mode: 'cors',
+    mode: 'same-origin',
     cache: 'no-cache',
     headers: {
       'Content-Type': 'application/json',
@@ -25,7 +25,7 @@ export const postFormData = (
 ) => {
   const opts = options || {
     method: 'POST',
-    mode: 'cors',
+    mode: 'same-origin',
     cache: 'no-cache',
     credentials: 'include',
     body: data,
@@ -40,7 +40,7 @@ export const patch = (
 ) => {
   const opts = options || {
     method: 'PATCH',
-    mode: 'cors',
+    mode: 'same-origin',
     cache: 'no-cache',
     headers: {
       'Content-Type': 'application/json',
@@ -59,7 +59,7 @@ export const patchFormData = (
 ) => {
   const opts = options || {
     method: 'PATCH',
-    mode: 'cors',
+    mode: 'same-origin',
     cache: 'no-cache',
     credentials: 'include',
     body: data,
@@ -71,7 +71,7 @@ export const patchFormData = (
 export const get = (url: string, options?: RequestInit) => {
   const opts = options || {
     method: 'GET',
-    mode: 'cors',
+    mode: 'same-origin',
     cache: 'no-cache',
     credentials: 'include',
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -97,6 +97,7 @@ initDb()
         saveUninitialized: false, // do not save new sessions that have not been modified
         cookie: {
           httpOnly: true,
+          sameSite: 'strict',
           ...cookieSettings,
         },
         ...sessionSettings,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -117,10 +117,6 @@ initDb()
     app.use(morgan(MORGAN_LOG_FORMAT))
 
     // API configuration
-    app.use((_, res, next) => {
-      res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH')
-      next()
-    })
     app.use('/api', ...apiSpecificMiddleware, api) // Attach all API endpoints
     app.use(
       '/:shortUrl([a-zA-Z0-9-]+)',


### PR DESCRIPTION
## Problem

Application is vulnerable to CSRF.

## Solution

Ensure that the session cookie is not sent when the user visits other domains, by setting the _SameSite_ attribute to `strict`.

Additionally, removed unnecessary custom middleware setting `Access-Control-Allow-Methods` and set `cross-fetch` options from `cors` to `same-origin`.

## Tests

- [x] Link shortening creation and modification
- [x] File upload creation and modification
- [x] Session cookie is no longer attached from cross-domain requests