### PR TITLE
fix: new link highlighting

### DIFF
--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -42,8 +42,13 @@ export class UserController implements UserControllerInterface {
     }
 
     try {
-      await this.urlManagementService.createUrl(userId, shortUrl, longUrl, file)
-      res.ok(jsonMessage(`Short link "${shortUrl}" has been updated`))
+      const result = await this.urlManagementService.createUrl(
+        userId,
+        shortUrl,
+        longUrl,
+        file,
+      )
+      res.ok(result)
       return
     } catch (error) {
       if (error instanceof NotFoundError) {


### PR DESCRIPTION
## Problem

As of release 1.19, new links are not highlighted on users' url table. This is due to changes in backend response that were incompatible with the frontend implementation

## Solution

Revert change in behavior in backend response.

Fixes #231 
