### PR TITLE
Use HTTP 401 Unauthorized for invalid login attempts

### DIFF
--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -178,6 +178,14 @@ const getOTPEmail = () => (
         successAction()
         return null
       }
+      if (response.status === 401) {
+        // Unauthorized
+        errorAction()
+        dispatch<SetErrorMessageAction>(
+          rootActions.setErrorMessage(response.statusText),
+        )
+        return null
+      }
       return response.json().then((json) => {
         const { message } = json
         errorAction()

--- a/src/server/api/login/index.ts
+++ b/src/server/api/login/index.ts
@@ -7,7 +7,7 @@ import { DependencyIds } from '../../constants'
 
 const router: Express.Router = Express.Router()
 
-const validator = createValidator({ passError: true })
+const authValidator = createValidator({ passError: false, statusCode: 401 })
 
 const loginController = container.get<LoginControllerInterface>(
   DependencyIds.loginController,
@@ -25,7 +25,7 @@ router.get('/emaildomains', loginController.getEmailDomains)
  */
 router.post(
   '/otp',
-  validator.body(otpGenerationSchema),
+  authValidator.body(otpGenerationSchema),
   loginController.generateOtp,
 )
 
@@ -34,7 +34,7 @@ router.post(
  */
 router.post(
   '/verify',
-  validator.body(otpVerificationSchema),
+  authValidator.body(otpVerificationSchema),
   loginController.verifyOtp,
 )
 


### PR DESCRIPTION
## Problem

When an invalid email is used to attempt login, a _HTTP 401 Unauthorized_ should be returned instead of the default _HTTP 400 Bad Request_.

## Solution

Configure the validation middleware to return _HTTP 401_ if custom Joi email validation fails, instead of handing the error off to Express's `next(error)` as is the default.

## Deploy Notes

This is technically a breaking change, but necessary as we proceed to configure Cloudwatch alerts.
