### PR TITLE
refactor(stats): rework sequelize queries

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -168,4 +168,6 @@ export const bucketEndpoint =
 export const accessEndpoint =
   process.env.ACCESS_ENDPOINT || 'http://localhost:4566'
 
+export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 20
+
 export const sentryDns: string | undefined = process.env.SENTRY_DNS

--- a/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
@@ -14,42 +14,45 @@ export interface LinkStatisticsRepositoryInterface {
    * Asynchronously increment the number of clicks in the database.
    *
    * @param {string} shortUrl
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
-  incrementClick: (shortUrl: string, transaction?: Transaction) => Promise<void>
+  incrementClick: (
+    shortUrl: string,
+    transaction?: Transaction,
+  ) => Promise<boolean>
 
   /**
    * Asynchronously upserts the relevant short link's statistics.
    *
    * @param shortUrl The relevant short url.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateDailyStatistics: (
     shortUrl: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 
   /**
    * Asynchronously updates the relevant short link's week map statistics.
    *
    * @param shortUrl The relevant short url.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateWeekdayStatistics: (
     shortUrl: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 
   /**
    * Asynchronously updates the relevant short link's device statistics.
    *
    * @param shortUrl The relevant short url.
    * @param userAgent The relevant user agent string to parse device type.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateDeviceStatistics: (
     shortUrl: string,
     userAgent: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 }

--- a/src/server/services/LinkStatisticsService.ts
+++ b/src/server/services/LinkStatisticsService.ts
@@ -7,7 +7,6 @@ import { LinkStatisticsInterface } from '../../shared/interfaces/link-statistics
 import { UserRepositoryInterface } from '../repositories/interfaces/UserRepositoryInterface'
 import { NotFoundError } from '../util/error'
 import { logger } from '../config'
-import { sequelize } from '../util/sequelize'
 
 @injectable()
 export class LinkStatisticsService implements LinkStatisticsServiceInterface {
@@ -29,22 +28,14 @@ export class LinkStatisticsService implements LinkStatisticsServiceInterface {
     shortUrl: string,
     userAgent: string,
   ) => Promise<void> = async (shortUrl, userAgent) => {
-    sequelize
-      .transaction((t) => {
-        return Promise.all([
-          this.linkStatisticsRepository.incrementClick(shortUrl, t),
-          this.linkStatisticsRepository.updateDailyStatistics(shortUrl, t),
-          this.linkStatisticsRepository.updateWeekdayStatistics(shortUrl, t),
-          this.linkStatisticsRepository.updateDeviceStatistics(
-            shortUrl,
-            userAgent,
-            t,
-          ),
-        ])
-      })
-      .catch((error) =>
-        logger.error(`Unable to update link statistics: ${error}`),
-      )
+    Promise.all([
+      this.linkStatisticsRepository.incrementClick(shortUrl),
+      this.linkStatisticsRepository.updateDailyStatistics(shortUrl),
+      this.linkStatisticsRepository.updateWeekdayStatistics(shortUrl),
+      this.linkStatisticsRepository.updateDeviceStatistics(shortUrl, userAgent),
+    ]).catch((error) =>
+      logger.error(`Unable to update link statistics: ${error}`),
+    )
   }
 
   getLinkStatistics: (

--- a/src/server/util/sequelize.ts
+++ b/src/server/util/sequelize.ts
@@ -1,10 +1,13 @@
 import Sequelize, { Transaction } from 'sequelize'
-import { databaseUri, logger } from '../config'
+import { databaseUri, dbPoolSize, logger } from '../config'
 
 export const sequelize = new Sequelize.Sequelize(databaseUri, {
   dialect: 'postgres',
   timezone: '+08:00',
   logging: logger.info.bind(logger),
+  pool: {
+    max: dbPoolSize,
+  },
 })
 
 export function transaction<T>(

--- a/test/server/mocks/repositories/LinkStatisticsRepository.ts
+++ b/test/server/mocks/repositories/LinkStatisticsRepository.ts
@@ -25,23 +25,23 @@ export class MockLinkStatisticsRepository
   incrementClick: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateDailyStatistics: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateWeekdayStatistics: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateDeviceStatistics: (
     shortUrl: string,
     userAgent: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 }
 
 export default MockLinkStatisticsRepository

--- a/test/server/services/LinkStatisticsService.test.ts
+++ b/test/server/services/LinkStatisticsService.test.ts
@@ -1,10 +1,10 @@
 import { MockSequelizeTransaction } from '../api/util'
 
-const sequelize = new MockSequelizeTransaction()
-
 import { MockLinkStatisticsRepository } from '../mocks/repositories/LinkStatisticsRepository'
 import { MockUserRepository } from '../mocks/repositories/UserRepository'
 import { LinkStatisticsService } from '../../../src/server/services/LinkStatisticsService'
+
+const sequelize = new MockSequelizeTransaction()
 
 jest.mock('../../../src/server/util/sequelize', () => ({
   sequelize,
@@ -64,14 +64,10 @@ describe('LinkStatisticService tests', () => {
       const transactionItem = 'hello'
       if (sequelize.fn) sequelize.fn(transactionItem)
 
-      expect(incrementClickSpy).toBeCalledWith('a', transactionItem)
-      expect(updateDailyStatisticsSpy).toBeCalledWith('a', transactionItem)
-      expect(updateWeekdayStatisticsSpy).toBeCalledWith('a', transactionItem)
-      expect(updateDeviceStatisticsSpy).toBeCalledWith(
-        'a',
-        userAgent,
-        transactionItem,
-      )
+      expect(incrementClickSpy).toBeCalledWith('a')
+      expect(updateDailyStatisticsSpy).toBeCalledWith('a')
+      expect(updateWeekdayStatisticsSpy).toBeCalledWith('a')
+      expect(updateDeviceStatisticsSpy).toBeCalledWith('a', userAgent)
     })
   })
 })


### PR DESCRIPTION
LinkStatisticsRepository updates click stats by finding the instance,
then incrementing. This may result in larger transactions than needed,
given that the increment can be done in a single statement. Rework
the implementation so that we update, and if not present, we insert.

Attempts to implement using `Model.upsert()` were not successful, due
to Sequelize creating temporary functions which fail to reference the
target table:

```
app_1         | [0] 2020-07-01 01:57:13 info: Executing (d33178af-410c-46cc-9422-b7565265d17b): CREATE OR REPLACE FUNCTION pg_temp.sequelize_upsert(OUT created boolean, OUT primary_key text)  AS $func$ BEGIN INSERT INTO "weekday_stats" ("shortUrl","weekday","hours","clicks","createdAt","updatedAt") VALUES ('lol',3,9,clicks + 1,'2020-07-01 09:57:13.857 +08:00','2020-07-01 09:57:13.857 +08:00'); created := true; EXCEPTION WHEN unique_violation THEN UPDATE "weekday_stats" SET "shortUrl"='lol',"weekday"=3,"hours"=9,"clicks"=clicks + 1,"updatedAt"='2020-07-01 09:57:13.857 +08:00' WHERE (("shortUrl" = 'lol' AND "weekday" = 3 AND "hours" = 9)); created := false; END; $func$ LANGUAGE plpgsql; SELECT * FROM pg_temp.sequelize_upsert();
postgres_1    | 2020-07-01 01:57:13.933 UTC [1201] ERROR:  column "clicks" does not exist at character 107
postgres_1    | 2020-07-01 01:57:13.933 UTC [1201] HINT:  There is a column named "clicks" in table "daily_stats", but it cannot be referenced from this part of the query.
```

- interface - rework jsdoc, change return type to boolean
- impl - use `Model.update()` and `Sequelize.literal`, if not found,
  `Model.insert()` or throw not found error
- allow db pool max to be controlled, default 20