### PR TITLE
Log invalid emails in otp requests

### DIFF
--- a/src/server/api/login/validators.ts
+++ b/src/server/api/login/validators.ts
@@ -7,7 +7,7 @@ export const otpVerificationSchema = Joi.object({
     .custom((email: string, helpers) => {
       if (!isValidGovEmail(email)) {
         logger.error(
-          `OTP generation request rejected due to invalid email:\t${email}`,
+          `OTP verification request rejected due to invalid email:\t${email}`,
         )
         return helpers.message({ custom: 'Not a valid gov email' })
       }
@@ -22,7 +22,7 @@ export const otpGenerationSchema = Joi.object({
     .custom((email: string, helpers) => {
       if (!isValidGovEmail(email)) {
         logger.error(
-          `OTP verification request rejected due to invalid email:\t${email}`,
+          `OTP generation request rejected due to invalid email:\t${email}`,
         )
         return helpers.message({
           custom: 'Invalid email provided. Email domain is not whitelisted.',

--- a/src/server/api/login/validators.ts
+++ b/src/server/api/login/validators.ts
@@ -1,10 +1,14 @@
 import * as Joi from '@hapi/joi'
+import { logger } from '../../config'
 import { isValidGovEmail } from '../../util/email'
 
 export const otpVerificationSchema = Joi.object({
   email: Joi.string()
     .custom((email: string, helpers) => {
       if (!isValidGovEmail(email)) {
+        logger.error(
+          `OTP generation request rejected due to invalid email:\t${email}`,
+        )
         return helpers.message({ custom: 'Not a valid gov email' })
       }
       return email
@@ -17,6 +21,9 @@ export const otpGenerationSchema = Joi.object({
   email: Joi.string()
     .custom((email: string, helpers) => {
       if (!isValidGovEmail(email)) {
+        logger.error(
+          `OTP verification request rejected due to invalid email:\t${email}`,
+        )
         return helpers.message({
           custom: 'Invalid email provided. Email domain is not whitelisted.',
         })


### PR DESCRIPTION
## Problem

Requests to generate/verify OTPs do not log the emails submitted. This information could potentially be important in signalling any malicious activity, and should not be omitted.

## Solution

Include a log statement right before returning a response to the client.

## Before & After

Logs for the email in question will appear as such:

```bash
app_1         | [0] 2020-07-01 06:04:29 error: OTP verification request rejected due to invalid email:  esanutheous.com
app_1         | [0] ::ffff:172.20.0.1 - [01/Jul/2020:06:04:29 +0000] "POST /api/login/verify HTTP/1.1" 401 "-" "-" - "-" "PostmanRuntime/7.24.1" 119.290 ms
app_1         | [0] 2020-07-01 06:04:42 error: OTP generation request rejected due to invalid email:    esanutheous.com
app_1         | [0] ::ffff:172.20.0.1 - [01/Jul/2020:06:04:42 +0000] "POST /api/login/otp HTTP/1.1" 401 "-" "-" - "-" "PostmanRuntime/7.24.1" 13.388 ms

```
