### PR TITLE
fix: render 404 page even on non-existent pages in /api 

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -47,4 +47,10 @@ router.use('/user', userGuard, preprocess, require('./user'))
 router.use('/qrcode', userGuard, require('./qrcode'))
 router.use('/link-stats', userGuard, require('./link-statistics'))
 
+const ERROR_404_PATH = '404.error.ejs'
+
+router.use((_, res) => {
+  res.status(404).render(ERROR_404_PATH)
+})
+
 export default router

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,5 +1,6 @@
 import Express from 'express'
 import jsonMessage from '../util/json'
+import { ERROR_404_PATH } from '../constants'
 
 const router = Express.Router()
 
@@ -46,8 +47,6 @@ function preprocess(
 router.use('/user', userGuard, preprocess, require('./user'))
 router.use('/qrcode', userGuard, require('./qrcode'))
 router.use('/link-stats', userGuard, require('./link-statistics'))
-
-const ERROR_404_PATH = '404.error.ejs'
 
 router.use((_, res) => {
   res.status(404).render(ERROR_404_PATH)

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -35,4 +35,4 @@ export const DependencyIds = {
   deviceCheckService: Symbol.for('deviceCheckService'),
 }
 
-export default DependencyIds
+export const ERROR_404_PATH = '404.error.ejs'

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'inversify'
 import { gaTrackingId, logger } from '../config'
 import { NotFoundError } from '../util/error'
 import parseDomain from '../util/domain'
-import { DependencyIds } from '../constants'
+import { DependencyIds, ERROR_404_PATH } from '../constants'
 import { AnalyticsLogger } from '../services/analyticsLogger'
 import { RedirectControllerInterface } from './interfaces/RedirectControllerInterface'
 import { RedirectService } from '../services/RedirectService'
@@ -13,7 +13,6 @@ import {
   EventCategory,
 } from '../services/googleAnalytics/types/enum'
 
-const ERROR_404_PATH = '404.error.ejs'
 const TRANSITION_PATH = 'transition-page.ejs'
 
 @injectable()

--- a/src/server/views/404.error.ejs
+++ b/src/server/views/404.error.ejs
@@ -7,8 +7,9 @@
     <meta http-equiv="Content-Language" content="en">
     <meta charset="UTF-8">
     <title>Go.gov.sg: Page not found</title>
+    <base href="~/" />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <link href="./assets/not-found-page/styles/not-found-page.css" rel="stylesheet">
+    <link href="/assets/not-found-page/styles/not-found-page.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 </head>
 
@@ -23,11 +24,11 @@
         <div id="divider" class="divider"></div>
         <div id="graphics-container">
             <div id="graphic-div">
-                <img src="./assets/not-found-page/images/not-found-graphic.svg" draggable="false" />
+                <img src="/assets/not-found-page/images/not-found-graphic.svg" draggable="false" />
             </div>
             <div id="go-logo-div">
                 <!-- go logo -->
-                <img src="./assets/not-found-page/icons/go-logo.svg" draggable="false" />
+                <img src="/assets/not-found-page/icons/go-logo.svg" draggable="false" />
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Problem

The `/api` route has no default handler. This causes a `504` error to be shown to users when erroneously accessing a link under the `/api` route. Even though this is not a common mistake, it should still show the normal 404 page.

Closes #236 

## Solution

Add a default handler to `/api` that renders the 404 page.

