### PR TITLE
fix: remove unnecessary info from search api

### DIFF
--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -47,7 +47,10 @@ export type UrlsPublicPaginated = {
   urls: Array<UrlPublic>
 }
 
-export type UrlPublic = Omit<StorableUrl, 'clicks'>
+export type UrlPublic = Pick<
+  StorableUrl,
+  'shortUrl' | 'longUrl' | 'description' | 'contactEmail'
+>
 
 export type UrlsPaginated = {
   count: number

--- a/src/server/services/UrlSearchService.ts
+++ b/src/server/services/UrlSearchService.ts
@@ -27,7 +27,14 @@ export class UrlSearchService {
 
     return {
       // Specific click counts are classified for certain government links
-      urls: privateUrls.map(({ clicks, ...url }) => url),
+      urls: privateUrls.map(
+        ({ longUrl, shortUrl, contactEmail, description }) => ({
+          longUrl,
+          shortUrl,
+          contactEmail,
+          description,
+        }),
+      ),
       count,
     }
   }

--- a/test/server/services/UrlSearchService.test.ts
+++ b/test/server/services/UrlSearchService.test.ts
@@ -1,9 +1,6 @@
 import { UrlSearchService } from '../../../src/server/services/UrlSearchService'
 import { UrlRepositoryMock } from '../mocks/repositories/UrlRepository'
-import {
-  SearchResultsSortOrder,
-  StorableUrlState,
-} from '../../../src/server/repositories/enums'
+import { SearchResultsSortOrder } from '../../../src/server/repositories/enums'
 
 /**
  * Unit tests for UrlSearchService.
@@ -25,13 +22,8 @@ describe('UrlSearchService tests', () => {
           {
             shortUrl: 'test-moh',
             longUrl: 'https://www.moh.gov.sg/covid-19',
-            state: StorableUrlState.Active,
-            isFile: false,
-            createdAt: '2020-04-17T09:10:07.491Z',
-            updatedAt: '2020-06-09T10:07:07.557Z',
             description: '',
             contactEmail: null,
-            // No clicks property
           },
         ],
         count: 0,


### PR DESCRIPTION
## Problem

The search API returns some properties that are unnecessary for search.

[Closes #235]

## Solution

Change the api such that only info necessary are returned. i.e `shortUrl`, `longUrl`, `description`, `contactEmail`.
