### PR TITLE
feat: user message banner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - OG_URL=https://go.gov.sg
       - VALID_EMAIL_GLOB_EXPRESSION=*.gov.sg
       - LOGIN_MESSAGE=Your OTP might take awhile to get to you.
+      - USER_MESSAGE=User message test
       - AWS_S3_BUCKET=local-bucket
       - ROTATED_LINKS=whatsapp,passport,spsc,sppr
       - AWS_ACCESS_KEY_ID=foobar

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -27,6 +27,7 @@ import {
   SET_UPLOAD_FILE_ERROR,
   SET_URL_FILTER,
   SET_URL_TABLE_CONFIG,
+  SET_USER_MESSAGE,
   SetCreateShortLinkErrorAction,
   SetEditedContactEmailAction,
   SetEditedDescriptionAction,
@@ -39,6 +40,7 @@ import {
   SetUploadFileErrorAction,
   SetUrlFilterAction,
   SetUrlTableConfigAction,
+  SetUserMessageAction,
   TOGGLE_URL_STATE_SUCCESS,
   ToggleUrlStateSuccessAction,
   UPDATE_URL_COUNT,
@@ -163,6 +165,23 @@ const updateUrlCount: (urlCount: number) => UpdateUrlCountAction = (
   type: UPDATE_URL_COUNT,
   payload: urlCount,
 })
+
+const setUserMessage: (payload: string) => SetUserMessageAction = (
+  payload,
+) => ({ type: SET_USER_MESSAGE, payload })
+
+const getUserMessage = (): ThunkAction<
+  void,
+  GoGovReduxState,
+  void,
+  UserActionType
+> => async (dispatch: Dispatch<SetUserMessageAction>) => {
+  const response = await get('/api/user/message')
+  if (response.ok) {
+    const text = await response.text()
+    if (text) dispatch(setUserMessage(text))
+  }
+}
 
 async function handleError(
   dispatch: Dispatch<
@@ -621,5 +640,6 @@ export default {
   replaceFile,
   setEditedContactEmail,
   setEditedDescription,
+  getUserMessage,
   updateUrlInformation,
 }

--- a/src/client/actions/user/types.ts
+++ b/src/client/actions/user/types.ts
@@ -27,6 +27,12 @@ export const SET_CREATE_SHORT_LINK_ERROR = 'SET_CREATE_SHORT_LINK_ERROR'
 export const SET_LAST_CREATED_LINK = 'SET_LAST_CREATED_LINK'
 export const SET_EDITED_CONTACT_EMAIL = 'SET_EDITED_CONTACT_EMAIL'
 export const SET_EDITED_DESCRIPTION = 'SET_EDITED_DESCRIPTION'
+export const SET_USER_MESSAGE = 'SET_USER_MESSAGE'
+
+export type SetUserMessageAction = {
+  type: typeof SET_USER_MESSAGE
+  payload: string
+}
 
 export type SetEditedContactEmailAction = {
   type: typeof SET_EDITED_CONTACT_EMAIL
@@ -163,3 +169,4 @@ export type UserActionType =
   | SetUrlFilterAction
   | SetEditedContactEmailAction
   | SetEditedDescriptionAction
+  | SetUserMessageAction

--- a/src/client/components/BaseLayout/BannerForIE.tsx
+++ b/src/client/components/BaseLayout/BannerForIE.tsx
@@ -1,58 +1,24 @@
 import React from 'react'
-import { makeStyles, createStyles, Typography } from '@material-ui/core'
+import { makeStyles, createStyles } from '@material-ui/core'
 
-import { ApplyAppMargins } from '../AppMargins'
 import cautionLogo from './assets/ie-banner-caution.svg'
+import Banner from './widgets/Banner'
 
 const BANNER_TEXT =
   'Go.gov.sg is not supported on Internet Explorer. Some features may not work correctly.'
 
-const useStyles = makeStyles((theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
-    bannerContainer: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      width: '100%',
-      minHeight: 50,
-      backgroundColor: theme.palette.primary.main,
-      color: '#F9F9F9',
-      paddingTop: 15,
-      paddingBottom: 15,
-    },
-    appMargins: {
-      width: '100%',
-    },
-    bannerContent: {
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'flex-start',
-      width: '100%',
-    },
     icon: {
       marginRight: 6.67,
-    },
-    typography: {
-      fontSize: 13,
-      fontWeight: 400,
-      [theme.breakpoints.up('xs')]: {
-        fontSize: 14,
-      },
     },
   }),
 )
 
 export default function BannerForIE() {
   const classes = useStyles()
-  return (
-    <div className={classes.bannerContainer}>
-      <ApplyAppMargins className={classes.appMargins}>
-        <div className={classes.bannerContent}>
-          <img className={classes.icon} src={cautionLogo} draggable={false} />
-          <Typography className={classes.typography}>{BANNER_TEXT}</Typography>
-        </div>
-      </ApplyAppMargins>
-    </div>
+  const icon = (
+    <img className={classes.icon} src={cautionLogo} draggable={false} />
   )
+  return <Banner icon={icon} text={BANNER_TEXT} />
 }

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types'
 import { useLocation } from 'react-router-dom'
 import { CssBaseline, createStyles, makeStyles } from '@material-ui/core'
 
+import { useSelector } from 'react-redux'
 import Masthead from './Masthead'
 import BaseLayoutHeader from './BaseLayoutHeader'
 import BaseLayoutFooter from './BaseLayoutFooter'
 import useIsIE from './util/ie'
 import BannerForIE from './BannerForIE'
 import { USER_PAGE } from '../../util/types'
+import Banner from './widgets/Banner'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -47,11 +49,13 @@ const BaseLayout = ({
   const classes = useStyles()
   const path = useLocation().pathname
   const isIE = useIsIE()
+  const message = useSelector((state) => state.user.message)
   return (
     <>
       <CssBaseline />
       <Masthead />
       {path === USER_PAGE && isIE && <BannerForIE />}
+      {path === USER_PAGE && message && <Banner text={message} />}
       {withHeader && <BaseLayoutHeader backgroundType={headerBackgroundType} />}
       <div className={classes.layout}>{children}</div>
       {withFooter && <BaseLayoutFooter />}

--- a/src/client/components/BaseLayout/widgets/Banner.tsx
+++ b/src/client/components/BaseLayout/widgets/Banner.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { makeStyles, createStyles, Typography } from '@material-ui/core'
+
+import { ApplyAppMargins } from '../../AppMargins'
+
+type BannerForIEProps = {
+  text: string
+  icon?: React.ReactElement
+}
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    bannerContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      minHeight: 50,
+      backgroundColor: theme.palette.primary.main,
+      color: '#F9F9F9',
+      paddingTop: 15,
+      paddingBottom: 15,
+    },
+    appMargins: {
+      width: '100%',
+    },
+    bannerContent: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'flex-start',
+      width: '100%',
+    },
+    typography: {
+      fontSize: 13,
+      fontWeight: 400,
+      [theme.breakpoints.up('xs')]: {
+        fontSize: 14,
+      },
+    },
+  }),
+)
+
+export default function Banner({ text, icon }: BannerForIEProps) {
+  const classes = useStyles()
+  return (
+    <div className={classes.bannerContainer}>
+      <ApplyAppMargins className={classes.appMargins}>
+        <div className={classes.bannerContent}>
+          {icon}
+          <Typography className={classes.typography}>{text}</Typography>
+        </div>
+      </ApplyAppMargins>
+    </div>
+  )
+}

--- a/src/client/components/UserPage/index.jsx
+++ b/src/client/components/UserPage/index.jsx
@@ -27,6 +27,7 @@ const mapDispatchToProps = (dispatch) => ({
   getUrlsForUser: () => dispatch(userActions.getUrlsForUser()),
   getEmailValidator: () =>
     dispatch(loginActions.getEmailValidationGlobExpression()),
+  getUserMessage: () => dispatch(userActions.getUserMessage()),
 })
 
 /**
@@ -41,9 +42,11 @@ const UserPage = ({
   getUrlsForUser,
   getEmailValidator,
   emailValidator,
+  getUserMessage,
 }) => {
   const fetchingUrls = useSelector((state) => state.user.isFetchingUrls)
   const urlCount = useSelector((state) => state.user.urlCount)
+  const message = useSelector((state) => state.user.message)
   const urlsFiltered = useIsFiltered()
 
   useEffect(() => {
@@ -51,6 +54,9 @@ const UserPage = ({
       getUrlsForUser()
       if (!emailValidator) {
         getEmailValidator()
+      }
+      if (message === null) {
+        getUserMessage()
       }
     }
   }, [])

--- a/src/client/reducers/user/index.ts
+++ b/src/client/reducers/user/index.ts
@@ -16,6 +16,7 @@ import {
   SET_UPLOAD_FILE_ERROR,
   SET_URL_FILTER,
   SET_URL_TABLE_CONFIG,
+  SET_USER_MESSAGE,
   TOGGLE_URL_STATE_SUCCESS,
   UPDATE_URL_COUNT,
   UserActionType,
@@ -40,6 +41,7 @@ const initialState: UserState = {
     ...initialSortConfig,
   },
   urlCount: 0,
+  message: null,
 }
 
 const user: (state: UserState, action: UserActionType) => UserState = (
@@ -49,6 +51,11 @@ const user: (state: UserState, action: UserActionType) => UserState = (
   let nextState: Partial<UserState> = {}
 
   switch (action.type) {
+    case SET_USER_MESSAGE:
+      nextState = {
+        message: action.payload,
+      }
+      break
     case SET_LAST_CREATED_LINK:
       nextState = {
         lastCreatedLink: action.payload,

--- a/src/client/reducers/user/types.ts
+++ b/src/client/reducers/user/types.ts
@@ -27,6 +27,7 @@ export type UserState = {
   createShortLinkError?: string | null
   uploadFileError?: string | null
   lastCreatedLink?: string
+  message: string | null
 }
 
 export type UrlTableConfig = {

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -90,4 +90,6 @@ router.get(
   userController.getUrlsWithConditions,
 )
 
+router.get('/message', userController.getUserMessage)
+
 export = router

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -136,6 +136,7 @@ export const emailValidator = new minimatch.Minimatch(
   },
 )
 export const loginMessage = process.env.LOGIN_MESSAGE
+export const userMessage = process.env.USER_MESSAGE
 export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
 

--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -15,7 +15,7 @@ import {
   NotFoundError,
 } from '../util/error'
 import { MessageType } from '../../shared/util/messages'
-import { logger } from '../config'
+import { logger, userMessage } from '../config'
 import { StorableUrlState } from '../repositories/enums'
 
 @injectable()
@@ -191,6 +191,14 @@ export class UserController implements UserControllerInterface {
       res.serverError(jsonMessage('Error retrieving URLs for user'))
       return
     }
+  }
+
+  public getUserMessage: (
+    req: Express.Request,
+    res: Express.Response,
+  ) => Promise<void> = async (_, res) => {
+    res.send(userMessage)
+    return
   }
 }
 

--- a/src/server/controllers/interfaces/UserControllerInterface.ts
+++ b/src/server/controllers/interfaces/UserControllerInterface.ts
@@ -11,4 +11,6 @@ export interface UserControllerInterface {
     req: Express.Request,
     res: Express.Response,
   ): Promise<void>
+
+  getUserMessage(req: Express.Request, res: Express.Response): Promise<void>
 }


### PR DESCRIPTION
## Problem

We need an additional way to notify link owners of any service degradation or any other important messages.

## Solution

A banner for the user page that shows important messages to users.

The message is read from the USER_MESSAGE env_var.

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/35889982/86237226-f4532180-bbcd-11ea-96b7-87b9785fd550.png)
![image](https://user-images.githubusercontent.com/35889982/86237290-1482e080-bbce-11ea-8c60-f57a83f142fc.png)
![image](https://user-images.githubusercontent.com/35889982/86326991-15bb1880-bc75-11ea-8ebd-8178785eb68b.png)


## Deploy Notes

**New environment variables**:

- `USER_MESSAGE` : user message to be shown. It is optional and the banner will not be shown if this is empty or not supplied.
