### PR TITLE
fix: remove link statistics and ga served events

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -168,4 +168,6 @@ export const bucketEndpoint =
 export const accessEndpoint =
   process.env.ACCESS_ENDPOINT || 'http://localhost:4566'
 
+export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 20
+
 export const sentryDns: string | undefined = process.env.SENTRY_DNS

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -168,6 +168,6 @@ export const bucketEndpoint =
 export const accessEndpoint =
   process.env.ACCESS_ENDPOINT || 'http://localhost:4566'
 
-export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 20
+export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 40
 
 export const sentryDns: string | undefined = process.env.SENTRY_DNS

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -41,8 +41,8 @@ export class RedirectController implements RedirectControllerInterface {
       return
     }
 
+    // Find longUrl to redirect to.
     try {
-      // Find longUrl to redirect to
       const {
         longUrl,
         visitedUrls,
@@ -53,24 +53,20 @@ export class RedirectController implements RedirectControllerInterface {
         req.get('user-agent') || '',
       )
 
-      req.session!.visits = visitedUrls
+      const logRedirect = () => {
+        this.analyticsLogger.logRedirectAnalytics(
+          req,
+          res,
+          shortUrl.toLowerCase(),
+          longUrl,
+        )
+      }
 
-      this.analyticsLogger.logRedirectAnalytics(
-        req,
-        res,
-        shortUrl.toLowerCase(),
-        longUrl,
-      )
+      req.session!.visits = visitedUrls
 
       if (redirectType === RedirectType.TransitionPage) {
         // Extract root domain from long url.
         const rootDomain: string = parseDomain(longUrl)
-
-        this.analyticsLogger.logTransitionPageServed(
-          req,
-          res,
-          shortUrl.toLowerCase(),
-        )
 
         res.status(200).render(TRANSITION_PATH, {
           escapedLongUrl: RedirectController.encodeLongUrl(longUrl),
@@ -80,9 +76,11 @@ export class RedirectController implements RedirectControllerInterface {
           gaOnLoad: EventAction.LOADED,
           gaOnProceed: EventAction.PROCEEDED,
         })
+        logRedirect()
         return
       }
       res.status(302).redirect(longUrl)
+      logRedirect()
       return
     } catch (error) {
       if (!(error instanceof NotFoundError)) {

--- a/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
@@ -14,42 +14,45 @@ export interface LinkStatisticsRepositoryInterface {
    * Asynchronously increment the number of clicks in the database.
    *
    * @param {string} shortUrl
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
-  incrementClick: (shortUrl: string, transaction?: Transaction) => Promise<void>
+  incrementClick: (
+    shortUrl: string,
+    transaction?: Transaction,
+  ) => Promise<boolean>
 
   /**
    * Asynchronously upserts the relevant short link's statistics.
    *
    * @param shortUrl The relevant short url.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateDailyStatistics: (
     shortUrl: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 
   /**
    * Asynchronously updates the relevant short link's week map statistics.
    *
    * @param shortUrl The relevant short url.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateWeekdayStatistics: (
     shortUrl: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 
   /**
    * Asynchronously updates the relevant short link's device statistics.
    *
    * @param shortUrl The relevant short url.
    * @param userAgent The relevant user agent string to parse device type.
-   * @returns Promise that resolves to be empty.
+   * @returns {Promise<boolean>} Indicates if the update was successful.
    */
   updateDeviceStatistics: (
     shortUrl: string,
     userAgent: string,
     transaction?: Transaction,
-  ) => Promise<void>
+  ) => Promise<boolean>
 }

--- a/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/LinkStatisticsRepositoryInterface.ts
@@ -13,46 +13,11 @@ export interface LinkStatisticsRepositoryInterface {
   /**
    * Asynchronously increment the number of clicks in the database.
    *
-   * @param {string} shortUrl
-   * @returns {Promise<boolean>} Indicates if the update was successful.
+   * @param shortUrl
+   * @returns Indicates if the update was successful.
    */
   incrementClick: (
     shortUrl: string,
-    transaction?: Transaction,
-  ) => Promise<boolean>
-
-  /**
-   * Asynchronously upserts the relevant short link's statistics.
-   *
-   * @param shortUrl The relevant short url.
-   * @returns {Promise<boolean>} Indicates if the update was successful.
-   */
-  updateDailyStatistics: (
-    shortUrl: string,
-    transaction?: Transaction,
-  ) => Promise<boolean>
-
-  /**
-   * Asynchronously updates the relevant short link's week map statistics.
-   *
-   * @param shortUrl The relevant short url.
-   * @returns {Promise<boolean>} Indicates if the update was successful.
-   */
-  updateWeekdayStatistics: (
-    shortUrl: string,
-    transaction?: Transaction,
-  ) => Promise<boolean>
-
-  /**
-   * Asynchronously updates the relevant short link's device statistics.
-   *
-   * @param shortUrl The relevant short url.
-   * @param userAgent The relevant user agent string to parse device type.
-   * @returns {Promise<boolean>} Indicates if the update was successful.
-   */
-  updateDeviceStatistics: (
-    shortUrl: string,
-    userAgent: string,
     transaction?: Transaction,
   ) => Promise<boolean>
 }

--- a/src/server/services/LinkStatisticsService.ts
+++ b/src/server/services/LinkStatisticsService.ts
@@ -24,15 +24,11 @@ export class LinkStatisticsService implements LinkStatisticsServiceInterface {
     this.linkStatisticsRepository = linkStatisticsRepository
   }
 
-  updateLinkStatistics: (
-    shortUrl: string,
-    userAgent: string,
-  ) => Promise<void> = async (shortUrl, userAgent) => {
+  updateLinkStatistics: (shortUrl: string) => Promise<void> = async (
+    shortUrl,
+  ) => {
     Promise.all([
       this.linkStatisticsRepository.incrementClick(shortUrl),
-      this.linkStatisticsRepository.updateDailyStatistics(shortUrl),
-      this.linkStatisticsRepository.updateWeekdayStatistics(shortUrl),
-      this.linkStatisticsRepository.updateDeviceStatistics(shortUrl, userAgent),
     ]).catch((error) =>
       logger.error(`Unable to update link statistics: ${error}`),
     )

--- a/src/server/services/LinkStatisticsService.ts
+++ b/src/server/services/LinkStatisticsService.ts
@@ -7,7 +7,6 @@ import { LinkStatisticsInterface } from '../../shared/interfaces/link-statistics
 import { UserRepositoryInterface } from '../repositories/interfaces/UserRepositoryInterface'
 import { NotFoundError } from '../util/error'
 import { logger } from '../config'
-import { sequelize } from '../util/sequelize'
 
 @injectable()
 export class LinkStatisticsService implements LinkStatisticsServiceInterface {
@@ -29,22 +28,14 @@ export class LinkStatisticsService implements LinkStatisticsServiceInterface {
     shortUrl: string,
     userAgent: string,
   ) => Promise<void> = async (shortUrl, userAgent) => {
-    sequelize
-      .transaction((t) => {
-        return Promise.all([
-          this.linkStatisticsRepository.incrementClick(shortUrl, t),
-          this.linkStatisticsRepository.updateDailyStatistics(shortUrl, t),
-          this.linkStatisticsRepository.updateWeekdayStatistics(shortUrl, t),
-          this.linkStatisticsRepository.updateDeviceStatistics(
-            shortUrl,
-            userAgent,
-            t,
-          ),
-        ])
-      })
-      .catch((error) =>
-        logger.error(`Unable to update link statistics: ${error}`),
-      )
+    Promise.all([
+      this.linkStatisticsRepository.incrementClick(shortUrl),
+      this.linkStatisticsRepository.updateDailyStatistics(shortUrl),
+      this.linkStatisticsRepository.updateWeekdayStatistics(shortUrl),
+      this.linkStatisticsRepository.updateDeviceStatistics(shortUrl, userAgent),
+    ]).catch((error) =>
+      logger.error(`Unable to update link statistics: ${error}`),
+    )
   }
 
   getLinkStatistics: (

--- a/src/server/services/RedirectService.ts
+++ b/src/server/services/RedirectService.ts
@@ -49,7 +49,7 @@ export class RedirectService implements RedirectServiceInterface {
     const longUrl = await this.urlRepository.getLongUrl(shortUrl)
 
     // Update clicks and click statistics in database.
-    this.linkStatisticsService.updateLinkStatistics(shortUrl, userAgent)
+    this.linkStatisticsService.updateLinkStatistics(shortUrl)
 
     if (this.crawlerCheckService.isCrawler(userAgent)) {
       return {

--- a/src/server/services/analyticsLogger.ts
+++ b/src/server/services/analyticsLogger.ts
@@ -1,10 +1,6 @@
 import Express from 'express'
 import { injectable } from 'inversify'
-import {
-  generateCookie,
-  sendPageViewHit,
-  sendTpServedEvent,
-} from './googleAnalytics'
+import { generateCookie, sendPageViewHit } from './googleAnalytics'
 import { gaTrackingId } from '../config'
 
 export interface AnalyticsLogger {
@@ -21,41 +17,21 @@ export interface AnalyticsLogger {
     shortUrl: string,
     longUrl: string,
   ) => void
-
-  logTransitionPageServed: (
-    req: Express.Request,
-    res: Express.Response,
-    shortUrl: string,
-  ) => void
 }
 
-/* eslint class-methods-use-this: ["error", { "exceptMethods": ["logRedirectAnalytics", "logTransitionPageServed"] }] */
 @injectable()
 export class GaLogger implements AnalyticsLogger {
-  logRedirectAnalytics(
+  logRedirectAnalytics: (
     req: Express.Request,
     res: Express.Response,
     shortUrl: string,
     longUrl: string,
-  ): void {
+  ) => void = (req, res, shortUrl, longUrl) => {
     if (!gaTrackingId) return
     const cookie = generateCookie(req)
     if (cookie) {
       res.cookie(...cookie)
     }
     sendPageViewHit(req, shortUrl, longUrl)
-  }
-
-  logTransitionPageServed(
-    req: Express.Request,
-    res: Express.Response,
-    shortUrl: string,
-  ) {
-    if (!gaTrackingId) return
-    const cookie = generateCookie(req)
-    if (cookie) {
-      res.cookie(...cookie)
-    }
-    sendTpServedEvent(req, shortUrl)
   }
 }

--- a/src/server/services/googleAnalytics/index.ts
+++ b/src/server/services/googleAnalytics/index.ts
@@ -4,9 +4,8 @@ import fetch from 'cross-fetch'
 import { gaTrackingId, logger, ogUrl } from '../../config'
 import getIp from '../../util/request'
 import IGaPageViewForm from './types/IGaPageViewForm'
-import IGaEventForm from './types/IGaEventForm'
 import IGaCoreForm from './types/IGaCoreForm'
-import { EventAction, EventCategory, GaHitVariant } from './types/enum'
+import { GaHitVariant } from './types/enum'
 
 const gaEndpoint = 'https://www.google-analytics.com/collect'
 
@@ -70,32 +69,6 @@ export function getCoreFields(req: express.Request, type: GaHitVariant) {
     t: type, // Hit type.
   }
   return coreForm
-}
-
-export function sendTpServedEvent(req: express.Request, shortUrl: string) {
-  const coreFields = getCoreFields(req, GaHitVariant.EVENT)
-  if (!coreFields) return
-
-  const form: IGaEventForm = {
-    ...coreFields,
-    ec: EventCategory.TRANSITION_PAGE, // Event Category.
-    ea: EventAction.SERVED, // Event Action.
-    el: shortUrl, // Event label.
-  }
-
-  const body = new URLSearchParams((form as unknown) as Record<string, string>)
-
-  fetch(gaEndpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  }).then((response) => {
-    if (!response.ok) {
-      logger.error(
-        `GA tracking failure:\tError: ${response.statusText}\thttpResponse: ${response}\t body:${response.body}`,
-      )
-    }
-  })
 }
 
 /**

--- a/src/server/services/googleAnalytics/types/enum.ts
+++ b/src/server/services/googleAnalytics/types/enum.ts
@@ -8,7 +8,6 @@ export enum EventCategory {
 }
 
 export enum EventAction {
-  SERVED = 'served',
   LOADED = 'loaded',
   PROCEEDED = 'proceeded',
 }

--- a/src/server/services/interfaces/LinkStatisticsServiceInterface.ts
+++ b/src/server/services/interfaces/LinkStatisticsServiceInterface.ts
@@ -8,7 +8,7 @@ export interface LinkStatisticsServiceInterface {
    * @param userAgent The user agent string from the http request.
    * @returns Promise that resolves to be empty.
    */
-  updateLinkStatistics(shortUrl: string, userAgent: string): Promise<void>
+  updateLinkStatistics(shortUrl: string): Promise<void>
 
   /**
    * Retrieves the link statistics for a specified link.

--- a/src/server/util/sequelize.ts
+++ b/src/server/util/sequelize.ts
@@ -1,10 +1,13 @@
 import Sequelize, { Transaction } from 'sequelize'
-import { databaseUri, logger } from '../config'
+import { databaseUri, dbPoolSize, logger } from '../config'
 
 export const sequelize = new Sequelize.Sequelize(databaseUri, {
   dialect: 'postgres',
   timezone: '+08:00',
   logging: logger.info.bind(logger),
+  pool: {
+    max: dbPoolSize,
+  },
 })
 
 export function transaction<T>(

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -145,7 +145,7 @@ describe('redirect API tests', () => {
       .get<RedirectController>(DependencyIds.redirectController)
       .redirect(req, res)
 
-    expect(updateStatisticsSpy).toBeCalledWith('aaa', userAgent)
+    expect(updateStatisticsSpy).toBeCalledWith('aaa')
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(res.statusCode).toBe(200)
     expect(res._getRedirectUrl()).toBe('')
@@ -175,7 +175,7 @@ describe('redirect API tests', () => {
       .get<RedirectController>(DependencyIds.redirectController)
       .redirect(req, res)
 
-    expect(updateStatisticsSpy).toBeCalledWith('aaa', userAgent)
+    expect(updateStatisticsSpy).toBeCalledWith('aaa')
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
@@ -197,7 +197,7 @@ describe('redirect API tests', () => {
       .get<RedirectController>(DependencyIds.redirectController)
       .redirect(req, res)
 
-    expect(updateStatisticsSpy).toBeCalledWith('aaa', '')
+    expect(updateStatisticsSpy).toBeCalledWith('aaa')
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
@@ -216,7 +216,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
     expect(updateStatisticsSpy).toBeCalledTimes(1)
-    expect(updateStatisticsSpy).toBeCalledWith('aaa', '')
+    expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
     expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
   })
@@ -249,7 +249,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
     expect(updateStatisticsSpy).toBeCalledTimes(1)
-    expect(updateStatisticsSpy).toBeCalledWith('aaa', '')
+    expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
     expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
   })

--- a/test/server/mocks/repositories/LinkStatisticsRepository.ts
+++ b/test/server/mocks/repositories/LinkStatisticsRepository.ts
@@ -25,23 +25,23 @@ export class MockLinkStatisticsRepository
   incrementClick: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateDailyStatistics: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateWeekdayStatistics: (
     shortUrl: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 
   updateDeviceStatistics: (
     shortUrl: string,
     userAgent: string,
     transaction?: import('sequelize/types').Transaction,
-  ) => Promise<void> = () => Promise.resolve()
+  ) => Promise<boolean> = () => Promise.resolve(true)
 }
 
 export default MockLinkStatisticsRepository

--- a/test/server/mocks/services/LinkStatisticsService.ts
+++ b/test/server/mocks/services/LinkStatisticsService.ts
@@ -6,10 +6,7 @@ import { LinkStatisticsInterface } from '../../../../src/shared/interfaces/link-
 @injectable()
 export class LinkStatisticsServiceMock
   implements LinkStatisticsServiceInterface {
-  updateLinkStatistics: (
-    shortUrl: string,
-    userAgent: string,
-  ) => Promise<void> = () => {
+  updateLinkStatistics: (shortUrl: string) => Promise<void> = () => {
     return Promise.resolve()
   }
 

--- a/test/server/services/LinkStatisticsService.test.ts
+++ b/test/server/services/LinkStatisticsService.test.ts
@@ -1,13 +1,11 @@
-import { MockSequelizeTransaction } from '../api/util'
+import Sequelize from 'sequelize-mock'
 
 import { MockLinkStatisticsRepository } from '../mocks/repositories/LinkStatisticsRepository'
 import { MockUserRepository } from '../mocks/repositories/UserRepository'
 import { LinkStatisticsService } from '../../../src/server/services/LinkStatisticsService'
 
-const sequelize = new MockSequelizeTransaction()
-
 jest.mock('../../../src/server/util/sequelize', () => ({
-  sequelize,
+  sequelize: new Sequelize(),
 }))
 
 const linkStatisticRepository = new MockLinkStatisticsRepository()
@@ -16,9 +14,6 @@ const service = new LinkStatisticsService(
   new MockUserRepository(),
   linkStatisticRepository,
 )
-
-const userAgent =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15'
 
 /**
  * Unit tests for StatisticService.
@@ -46,28 +41,10 @@ describe('LinkStatisticService tests', () => {
       linkStatisticRepository,
       'incrementClick',
     )
-    const updateDailyStatisticsSpy = jest.spyOn(
-      linkStatisticRepository,
-      'updateDailyStatistics',
-    )
-    const updateWeekdayStatisticsSpy = jest.spyOn(
-      linkStatisticRepository,
-      'updateWeekdayStatistics',
-    )
-    const updateDeviceStatisticsSpy = jest.spyOn(
-      linkStatisticRepository,
-      'updateDeviceStatistics',
-    )
 
     test('should update relevant tables with same transaction', async () => {
-      await service.updateLinkStatistics('a', userAgent)
-      const transactionItem = 'hello'
-      if (sequelize.fn) sequelize.fn(transactionItem)
-
+      await service.updateLinkStatistics('a')
       expect(incrementClickSpy).toBeCalledWith('a')
-      expect(updateDailyStatisticsSpy).toBeCalledWith('a')
-      expect(updateWeekdayStatisticsSpy).toBeCalledWith('a')
-      expect(updateDeviceStatisticsSpy).toBeCalledWith('a', userAgent)
     })
   })
 })

--- a/test/server/services/LinkStatisticsService.test.ts
+++ b/test/server/services/LinkStatisticsService.test.ts
@@ -1,10 +1,10 @@
 import { MockSequelizeTransaction } from '../api/util'
 
-const sequelize = new MockSequelizeTransaction()
-
 import { MockLinkStatisticsRepository } from '../mocks/repositories/LinkStatisticsRepository'
 import { MockUserRepository } from '../mocks/repositories/UserRepository'
 import { LinkStatisticsService } from '../../../src/server/services/LinkStatisticsService'
+
+const sequelize = new MockSequelizeTransaction()
 
 jest.mock('../../../src/server/util/sequelize', () => ({
   sequelize,
@@ -64,14 +64,10 @@ describe('LinkStatisticService tests', () => {
       const transactionItem = 'hello'
       if (sequelize.fn) sequelize.fn(transactionItem)
 
-      expect(incrementClickSpy).toBeCalledWith('a', transactionItem)
-      expect(updateDailyStatisticsSpy).toBeCalledWith('a', transactionItem)
-      expect(updateWeekdayStatisticsSpy).toBeCalledWith('a', transactionItem)
-      expect(updateDeviceStatisticsSpy).toBeCalledWith(
-        'a',
-        userAgent,
-        transactionItem,
-      )
+      expect(incrementClickSpy).toBeCalledWith('a')
+      expect(updateDailyStatisticsSpy).toBeCalledWith('a')
+      expect(updateWeekdayStatisticsSpy).toBeCalledWith('a')
+      expect(updateDeviceStatisticsSpy).toBeCalledWith('a', userAgent)
     })
   })
 })


### PR DESCRIPTION
## Problem

- Remove link statistics logging code.
- Improvements from @LoneRifle earlier PR [here](https://github.com/opengovsg/GoGovSG/pull/238)

## Solution

- Move GA page view logging to after page redirect
- Remove link statistics logging, which as of right now is problematic
- Remove GA served events, which can lighten the network load on our servers
