### PR TITLE
fix(nodemailer): use default value for maxMessages

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -109,7 +109,7 @@ if (DEV_ENV) {
     },
     port: process.env.SES_PORT as string,
     pool: true,
-    maxMessages: Infinity,
+    maxMessages: 100,
     maxConnections: 20,
   }
 }


### PR DESCRIPTION
## Problem

`maxMessages` is set at `Infinity`, which encourages long-living SMTP 
connections. This may not work well with services like AWS SES' SMTP
relays, whose machines are ephemeral and may be culled without notice.

## Solution

Rely on nodemailer's default of 100 messages per [1]. This allows us
to discard and replace connections to better ensure we are talking to
a live connection. Problems with connection leaks were fixed in 
nodemailer 6

References:
[1] - https://nodemailer.com/smtp/pooled/
