### PR TITLE
Fix bug/code smell where GA cookie is set after a server redirect

### DIFF
--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -56,10 +56,16 @@ export class RedirectController implements RedirectControllerInterface {
       const logRedirect = () => {
         this.analyticsLogger.logRedirectAnalytics(
           req,
-          res,
           shortUrl.toLowerCase(),
           longUrl,
         )
+      }
+
+      const generatedCookie = this.analyticsLogger.generateCookie(
+        req.headers.cookie,
+      )
+      if (generatedCookie) {
+        res.cookie(...generatedCookie)
       }
 
       req.session!.visits = visitedUrls

--- a/src/server/services/analyticsLogger.ts
+++ b/src/server/services/analyticsLogger.ts
@@ -13,25 +13,30 @@ export interface AnalyticsLogger {
    */
   logRedirectAnalytics: (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
   ) => void
+
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null
 }
 
 @injectable()
 export class GaLogger implements AnalyticsLogger {
   logRedirectAnalytics: (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
-  ) => void = (req, res, shortUrl, longUrl) => {
+  ) => void = (req, shortUrl, longUrl) => {
     if (!gaTrackingId) return
-    const cookie = generateCookie(req)
-    if (cookie) {
-      res.cookie(...cookie)
-    }
     sendPageViewHit(req, shortUrl, longUrl)
+  }
+
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null = (cookie) => {
+    if (!gaTrackingId) return null
+    return generateCookie(cookie)
   }
 }

--- a/src/server/services/googleAnalytics/index.ts
+++ b/src/server/services/googleAnalytics/index.ts
@@ -30,10 +30,10 @@ function parseCookies(cookie: string | undefined): CookieData {
  * Else return null.
  */
 export function generateCookie(
-  req: express.Request,
+  cookie?: string,
 ): [string, string, { maxAge: number }] | null {
   // Get ga cookie from request headers cookie
-  const { gaClientId } = parseCookies(req.headers.cookie)
+  const { gaClientId } = parseCookies(cookie)
 
   // if cookie is not found, set the cookie
   if (!gaClientId) {

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import { Request, Response } from 'express'
+import { Request } from 'express'
 import httpMocks from 'node-mocks-http'
 import redisMock from 'redis-mock'
 import SequelizeMock from 'sequelize-mock'
@@ -30,7 +30,6 @@ export function getOtpCache(): OtpRepositoryInterface {
  */
 export function isAnalyticsLogged(
   req: Request,
-  res: Response,
   shortUrl: string,
   longUrl: string,
 ): boolean {
@@ -39,7 +38,6 @@ export function isAnalyticsLogged(
   ) as AnalyticsLoggerMock
   return (
     logger.lastReq === req &&
-    logger.lastRes === res &&
     logger.lastShortUrl === shortUrl &&
     logger.lastLongUrl === longUrl
   )

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -154,7 +154,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -184,7 +184,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -202,7 +202,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url does not exist in cache but does in db', async () => {
@@ -330,7 +330,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url in cache and db is down', async () => {

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -154,7 +154,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -184,7 +184,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -202,7 +202,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
   })
 
   test('url does not exist in cache but does in db', async () => {
@@ -218,7 +218,7 @@ describe('redirect API tests', () => {
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url does not exist in neither cache nor db', async () => {
@@ -251,7 +251,7 @@ describe('redirect API tests', () => {
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('both db and cache down', async () => {
@@ -330,7 +330,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req,'aaa', 'aa')).toBeTruthy()
   })
 
   test('url in cache and db is down', async () => {
@@ -346,6 +346,6 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 })

--- a/test/server/mocks/services/analytics.ts
+++ b/test/server/mocks/services/analytics.ts
@@ -6,31 +6,24 @@ import { AnalyticsLogger } from '../../../../src/server/services/analyticsLogger
 export default class AnalyticsLoggerMock implements AnalyticsLogger {
   lastReq?: Express.Request
 
-  lastRes?: Express.Response
-
   lastShortUrl?: string
 
   lastLongUrl?: string
 
   logRedirectAnalytics = (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
   ) => {
     this.lastReq = req
-    this.lastRes = res
     this.lastShortUrl = shortUrl
     this.lastLongUrl = longUrl
   }
 
-  logTransitionPageServed = (
-    req: Express.Request,
-    res: Express.Response,
-    shortUrl: string,
-  ) => {
-    this.lastReq = req
-    this.lastRes = res
-    this.lastShortUrl = shortUrl
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null = (cookie) => {
+    if (cookie) return null
+    return null
   }
 }


### PR DESCRIPTION
## Problem

When a new visitor without a GA cookie visits a short link, the server attempts to set a cookie after a response has already taken place. This results in a HTTP 500 Internal Server Error being logged when in fact a HTTP 302 Redirect has already been returned to the client.

Closes #250

## Solution

- [x] Move cookie generation and setting to another place before setting res
- [ ] Don't create a new `logRedirect` function in every redirect
- [ ] Don't pass res and req into other functions
- [x] Fix broken tests

