### PR TITLE
Release 1.22.1 - GA bugfix, nodemailer config changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Link shortener for Singapore government.",
   "main": "src/server/index.js",
   "scripts": {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -109,7 +109,7 @@ if (DEV_ENV) {
     },
     port: process.env.SES_PORT as string,
     pool: true,
-    maxMessages: Infinity,
+    maxMessages: 100,
     maxConnections: 20,
   }
 }

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -56,10 +56,16 @@ export class RedirectController implements RedirectControllerInterface {
       const logRedirect = () => {
         this.analyticsLogger.logRedirectAnalytics(
           req,
-          res,
           shortUrl.toLowerCase(),
           longUrl,
         )
+      }
+
+      const generatedCookie = this.analyticsLogger.generateCookie(
+        req.headers.cookie,
+      )
+      if (generatedCookie) {
+        res.cookie(...generatedCookie)
       }
 
       req.session!.visits = visitedUrls

--- a/src/server/services/analyticsLogger.ts
+++ b/src/server/services/analyticsLogger.ts
@@ -13,25 +13,30 @@ export interface AnalyticsLogger {
    */
   logRedirectAnalytics: (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
   ) => void
+
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null
 }
 
 @injectable()
 export class GaLogger implements AnalyticsLogger {
   logRedirectAnalytics: (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
-  ) => void = (req, res, shortUrl, longUrl) => {
+  ) => void = (req, shortUrl, longUrl) => {
     if (!gaTrackingId) return
-    const cookie = generateCookie(req)
-    if (cookie) {
-      res.cookie(...cookie)
-    }
     sendPageViewHit(req, shortUrl, longUrl)
+  }
+
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null = (cookie) => {
+    if (!gaTrackingId) return null
+    return generateCookie(cookie)
   }
 }

--- a/src/server/services/googleAnalytics/index.ts
+++ b/src/server/services/googleAnalytics/index.ts
@@ -30,10 +30,10 @@ function parseCookies(cookie: string | undefined): CookieData {
  * Else return null.
  */
 export function generateCookie(
-  req: express.Request,
+  cookie?: string,
 ): [string, string, { maxAge: number }] | null {
   // Get ga cookie from request headers cookie
-  const { gaClientId } = parseCookies(req.headers.cookie)
+  const { gaClientId } = parseCookies(cookie)
 
   // if cookie is not found, set the cookie
   if (!gaClientId) {

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import { Request, Response } from 'express'
+import { Request } from 'express'
 import httpMocks from 'node-mocks-http'
 import redisMock from 'redis-mock'
 import SequelizeMock from 'sequelize-mock'
@@ -30,7 +30,6 @@ export function getOtpCache(): OtpRepositoryInterface {
  */
 export function isAnalyticsLogged(
   req: Request,
-  res: Response,
   shortUrl: string,
   longUrl: string,
 ): boolean {
@@ -39,7 +38,6 @@ export function isAnalyticsLogged(
   ) as AnalyticsLoggerMock
   return (
     logger.lastReq === req &&
-    logger.lastRes === res &&
     logger.lastShortUrl === shortUrl &&
     logger.lastLongUrl === longUrl
   )

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -154,7 +154,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -184,7 +184,7 @@ describe('redirect API tests', () => {
       'aaa',
     )
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
     cookieSpy.mockClear()
   })
 
@@ -202,7 +202,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url does not exist in cache but does in db', async () => {
@@ -218,7 +218,7 @@ describe('redirect API tests', () => {
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url does not exist in neither cache nor db', async () => {
@@ -251,7 +251,7 @@ describe('redirect API tests', () => {
     expect(updateStatisticsSpy).toBeCalledTimes(1)
     expect(updateStatisticsSpy).toBeCalledWith('aaa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('both db and cache down', async () => {
@@ -330,7 +330,7 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 
   test('url in cache and db is down', async () => {
@@ -346,6 +346,6 @@ describe('redirect API tests', () => {
     expect(res.statusCode).toBe(302)
     expect(res._getRedirectUrl()).toBe('aa')
 
-    expect(isAnalyticsLogged(req, res, 'aaa', 'aa')).toBeTruthy()
+    expect(isAnalyticsLogged(req, 'aaa', 'aa')).toBeTruthy()
   })
 })

--- a/test/server/mocks/services/analytics.ts
+++ b/test/server/mocks/services/analytics.ts
@@ -6,31 +6,24 @@ import { AnalyticsLogger } from '../../../../src/server/services/analyticsLogger
 export default class AnalyticsLoggerMock implements AnalyticsLogger {
   lastReq?: Express.Request
 
-  lastRes?: Express.Response
-
   lastShortUrl?: string
 
   lastLongUrl?: string
 
   logRedirectAnalytics = (
     req: Express.Request,
-    res: Express.Response,
     shortUrl: string,
     longUrl: string,
   ) => {
     this.lastReq = req
-    this.lastRes = res
     this.lastShortUrl = shortUrl
     this.lastLongUrl = longUrl
   }
 
-  logTransitionPageServed = (
-    req: Express.Request,
-    res: Express.Response,
-    shortUrl: string,
-  ) => {
-    this.lastReq = req
-    this.lastRes = res
-    this.lastShortUrl = shortUrl
+  generateCookie: (
+    cookie?: string,
+  ) => [string, string, { maxAge: number }] | null = (cookie) => {
+    if (cookie) return null
+    return null
   }
 }


### PR DESCRIPTION
## Bugfixes
- [x] 500 Errors no longer appear when accessing transition page with ga cookies not set

## Home page
- [x] The landing page graphic should animate example short urls correctly
- [x] The landing page should have file upload under features

## Login page
- [x] It should respond with invalid email when email does not end with .gov.sg
- [x] It should not allow submission when email is invalid
- [x] Invalid OTP should not log the user in
- [x] Valid OTP should log the user in
- [x] Resend OTP should send a new OTP to user, and invalidate previous OTP
- [x] After trying to enter wrong OTP 3 times, it should respond with OTP not found/expired (a new OTP must be requested)
- [x] Visiting /user should redirect to login page when not logged in

## User page
- [x] IE11 banner appears on top when accessed via IE11 browser
- [x] User message banner appears on top when USER_MESSAGE env var is set

## Sessions
- [x] Shows the homepage if user does not have an existing session
- [x] Redirects to /user if user has an existing session (ie logged in previously on the same browser)

## URL creation
- [x] The create url modal opens when the "Create link" button is clicked.
- [x] It should populate the short url input box on the create url modal with a random string when the refresh icon on the short url input box is pressed
- [x] It should show the new short url on the users’ links table when a new link is created
- [x] The new short url should be highlighted on the users' links table when a new link is created
- [x] It should close the create url modal on user page when a new link is created
- [x] It should prevent creation of short urls pointing to long urls hosted on blacklisted domains
- [x] It should show an success snackbar when a new url has been added
- [x] It should show a error below the file input when a file larger than 10MB is chosen
- [x] It should disable the submit button when a file larger than 10MB is chosen
- [x] It should show the short url on users' link table when a new file link is created
- [x] The new short url should be highlighted on the users' links table when a new file link is created
- [x] It should close the create url modal on user page when a new file link is created
- [x] It should show an success snackbar when a new file link has been added

## URL Searching and Download
- [x] Searching on the user page search bar shows links that are relevant to the search term.
- [x] Clicking on the download button downloads all link currently shown in the links table as a `.csv` file.

## Transition page
*You may need to clear your cookies before testing this segment.*
- [x] Accessing a short link for the first time shows the transition page.
- [x] Clicking on the "Proceed to your page" button redirects user from the transition page to the correct destination long url.
- [x] Visiting the same short link again does not show the transition page.

## Redirection
- [x] It should redirect to the long url when short url is active
- [x] It should redirect to a 404 page when short url is inactive
- [x] On google analytics, a page view should be recorded for a successful redirection - Page Path: short url , Page Title: long url (Reports > Realtime > Content > Pageviews)

## Drawer, Editing and Toaster logic
- [x] Drawer should open with the correct long url and state when a short url row is clicked
- [x] Drawer can be closed on clickaway or when the close button is clicked.
- [x] It should set short url active or inactive immediately when the toggle is switched (any caching for that short url is cleared)
- [x] It should redirect to the amended url immediately when the long url is changed (any caching for that short url is cleared)
- [x] It should redirect to the amended file immediately when the file is replaced (any caching for that short url is cleared)
- [x] It should show an error and not amend the file when a file of size >10mb is selected on replace file
- [x] It should show a success snackbar when long url is changed
- [x] It should show a success snackbar when link is transferred to another user.
- [x] Url is updated/saved when user enters a new url, then clicks "save"
- [x] Url is reverts to original when user enters a new url, then re-opens the drawer without clicking "save"
- [x] Error validation (red underline + helperText) appears when value in edit long url textfield is invalid
- [x] "Save" button is disabled (grey and unclickable) when value in edit long url textfield is invalid
- [x] Unsuccessful link transfers do not close the drawer.
- [x] Successful link transfers closes the drawer.
- [x] Toasters to disappear when user clicks on the X only
- [x] Toasters to disappear after 5sec
- [x] Toasters to not disappear on clickaway (i.e. to prevent premature closure when user clickaway to save url)
- [x] It should not allow foreign characters in the description field
- [x] It should allow saving of description/contact as long as one of them is changed
- [x] It should allow saving of a blank description or contact
- [x] It should not allow contact emails which are not valid *.gov.sg emails

## QR
- [x] Downloaded PNG QR code should be of width 1000px and height >= 1000px
- [x] Downloaded SVG QR code should work
- [x] PNG and SVG QR codes can be downloaded on IE11
- [x] Scan the downloaded QR code in SVG to check that it points to the correct long url
- [x] Scan the downloaded QR code in PNG to check that it points to the correct long url

## Sort & Filter
- [x] Clicking on the button at the end of the search input should open the sort and filter panel
- [x] Links should be sorted by their created time in descending order when enabling sort by `Date of creation` and clicking apply 
- [x] Links should be sorted by their number of clicks in descending order when enabling sort by `Most number of clicks` and clicking apply 
- [x] Inactive links should be filtered out by checking only `Active` and clicking apply
- [x] Active links should be filtered out by checking only `Inactive` and clicking apply
- [x] File links should be filtered out by checking only `Link` and clicking apply
- [x] Non-file links should be filtered out by checking only `File` and clicking apply
- [x] Panel should be closed when clicking outside of it
- [x] Panel should be closed and links sorted by created time with no filtering after clicking on reset. All links and files should be visible.
- [x] Panel should be closed when apply is clicked
- [x] It should reset the table to page 1 when apply is clicked

## Logging
- [x] UrlHistory table is populated in database
- [x] GA is updated with transition-page loaded event when transition-page is rendered.
- [x] GA is updated with transition-page proceeded event when proceed button on transition-page is clicked.
- [x] Url statistics are **NOT** updated when a link is clicked (`daily_stats`, `devices_stats`, `weekday_stats`).