### PR TITLE
Patch frontend login email validation

### DIFF
--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -34,7 +34,7 @@ import { loginFormVariants } from '../../util/types'
 import { get, postJson } from '../../util/requests'
 import userActions from '../user'
 import rootActions from '../root'
-import { defaultEmailValidationGlobExpression } from '../../reducers/login'
+import { defaultEmailValidator } from '../../reducers/login'
 import { WipeUserStateAction } from '../user/types'
 import { GetReduxState } from '../types'
 import { GoGovReduxState } from '../../reducers/types'
@@ -116,7 +116,7 @@ const getEmailValidationGlobExpression = () => (
 ) => {
   const { login } = getState()
   const { emailValidator } = login
-  if (emailValidator !== defaultEmailValidationGlobExpression) return
+  if (emailValidator !== defaultEmailValidator) return
   get('/api/login/emaildomains').then((response) => {
     if (response.ok) {
       response.text().then((expression) => {

--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -1,6 +1,8 @@
 import { Minimatch } from 'minimatch'
 import { Dispatch } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
+import validator from 'validator'
+
 import {
   EmailValidatorType,
   GET_OTP_EMAIL_ERROR,
@@ -126,7 +128,10 @@ const getEmailValidationGlobExpression = () => (
         })
         dispatch<SetEmailValidatorAction>(
           setEmailValidator((email: string) => {
-            return globValidator.match(email)
+            return (
+              globValidator.match(email) &&
+              validator.isEmail(email, { allow_utf8_local_part: false })
+            )
           }),
         )
       })

--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -1,7 +1,8 @@
-import { IMinimatch, Minimatch } from 'minimatch'
+import { Minimatch } from 'minimatch'
 import { Dispatch } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 import {
+  EmailValidatorType,
   GET_OTP_EMAIL_ERROR,
   GET_OTP_EMAIL_PENDING,
   GET_OTP_EMAIL_SUCCESS,
@@ -64,9 +65,12 @@ const setEmail: (payload: string) => SetEmailAction = (payload) => ({
   payload,
 })
 
-const setEmailValidator: (payload: IMinimatch) => SetEmailValidatorAction = (
+const setEmailValidator: (
+  payload: EmailValidatorType,
+) => SetEmailValidatorAction = (payload) => ({
+  type: SET_EMAIL_VALIDATOR,
   payload,
-) => ({ type: SET_EMAIL_VALIDATOR, payload })
+})
 
 const setOTP: (payload: string) => SetOtpAction = (payload) => ({
   type: SET_OTP,
@@ -114,13 +118,17 @@ const getEmailValidationGlobExpression = () => (
   get('/api/login/emaildomains').then((response) => {
     if (response.ok) {
       response.text().then((expression) => {
-        const validator = new Minimatch(expression, {
+        const globValidator = new Minimatch(expression, {
           noext: true,
           noglobstar: true,
           nobrace: true,
           nonegate: true,
         })
-        dispatch<SetEmailValidatorAction>(setEmailValidator(validator))
+        dispatch<SetEmailValidatorAction>(
+          setEmailValidator((email: string) => {
+            return globValidator.match(email)
+          }),
+        )
       })
     }
   })

--- a/src/client/actions/login/types.ts
+++ b/src/client/actions/login/types.ts
@@ -1,5 +1,3 @@
-import { IMinimatch } from 'minimatch'
-
 export const GET_OTP_EMAIL_SUCCESS = 'GET_OTP_EMAIL_SUCCESS'
 export const GET_OTP_EMAIL_PENDING = 'GET_OTP_EMAIL_PENDING'
 export const GET_OTP_EMAIL_ERROR = 'GET_OTP_EMAIL_ERROR'
@@ -51,9 +49,11 @@ export type SetEmailAction = {
   payload: string
 }
 
+export type EmailValidatorType = (email: string) => Boolean
+
 export type SetEmailValidatorAction = {
   type: typeof SET_EMAIL_VALIDATOR
-  payload: IMinimatch
+  payload: EmailValidatorType
 }
 
 export type IsLoggedInSuccessAction = {

--- a/src/client/components/LoginPage/index.jsx
+++ b/src/client/components/LoginPage/index.jsx
@@ -245,7 +245,7 @@ LoginPage.propTypes = {
   setEmail: PropTypes.func.isRequired,
   setOTP: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
-  emailValidator: PropTypes.func.isRequired, // TODO - Warning: Failed prop type: Invalid prop `emailValidator` of type `object` supplied to `LoginPage`, expected `function`
+  emailValidator: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(Object.values(loginFormVariants.types)).isRequired,
 }
 

--- a/src/client/components/LoginPage/index.jsx
+++ b/src/client/components/LoginPage/index.jsx
@@ -10,7 +10,6 @@ import {
   createStyles,
   makeStyles,
 } from '@material-ui/core'
-import { Minimatch } from 'minimatch'
 import { Redirect } from 'react-router-dom'
 
 import loginActions from '~/actions/login'
@@ -140,7 +139,7 @@ const LoginPage = ({
   if (!isLoggedIn) {
     const variantMap = loginFormVariants.map[variant]
     const isEmailView = loginFormVariants.isEmailView(variant)
-    const emailError = () => !!email && !emailValidator.match(email)
+    const emailError = () => !!email && !emailValidator(email)
 
     const emailFormAttr = {
       id: 'email',
@@ -246,7 +245,7 @@ LoginPage.propTypes = {
   setEmail: PropTypes.func.isRequired,
   setOTP: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
-  emailValidator: PropTypes.instanceOf(Minimatch).isRequired,
+  emailValidator: PropTypes.func.isRequired, // TODO - Warning: Failed prop type: Invalid prop `emailValidator` of type `object` supplied to `LoginPage`, expected `function`
   variant: PropTypes.oneOf(Object.values(loginFormVariants.types)).isRequired,
 }
 

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -191,7 +191,7 @@ export default function ControlPanel() {
   const originalDescription = shortLinkState?.description || ''
   const originalContactEmail = shortLinkState?.contactEmail || ''
   const isContactEmailValid =
-    !editedContactEmail || emailValidator.match(editedContactEmail)
+    !editedContactEmail || emailValidator(editedContactEmail)
   const isDescriptionValid =
     editedDescription.length <= LINK_DESCRIPTION_MAX_LENGTH &&
     isPrintableAscii(editedDescription)

--- a/src/client/components/UserPage/Drawer/ControlPanel/util/shortlink.ts
+++ b/src/client/components/UserPage/Drawer/ControlPanel/util/shortlink.ts
@@ -1,10 +1,10 @@
 import { useDispatch, useSelector } from 'react-redux'
 
-import { IMinimatch } from 'minimatch'
 import userActions from '../../../../../actions/user'
 import { isValidLongUrl } from '../../../../../../shared/util/validation'
 import { UrlType } from '../../../../../reducers/user/types'
 import { GoGovReduxState } from '../../../../../reducers/types'
+import { EmailValidatorType } from '../../../../../actions/login/types'
 
 export type ShortLinkState = [
   UrlType | undefined,
@@ -27,7 +27,7 @@ export default function useShortLink(shortLink: string) {
   const isUploading = useSelector<GoGovReduxState, boolean>(
     (state) => state.user.isUploading,
   )
-  const emailValidator = useSelector<GoGovReduxState, IMinimatch>(
+  const emailValidator = useSelector<GoGovReduxState, EmailValidatorType>(
     (state) => state.login.emailValidator,
   )
   const dispatch = useDispatch()

--- a/src/client/reducers/login/index.ts
+++ b/src/client/reducers/login/index.ts
@@ -1,5 +1,4 @@
-import { Minimatch } from 'minimatch'
-
+import validator from 'validator'
 import {
   GET_OTP_EMAIL_ERROR,
   GET_OTP_EMAIL_PENDING,
@@ -18,11 +17,12 @@ import {
 import { loginFormVariants } from '../../util/types'
 import { LoginState } from './types'
 
-export const defaultEmailValidationGlobExpression = new Minimatch('*')
+export const defaultEmailValidator = (email: string) =>
+  validator.isEmail(email, { allow_utf8_local_part: false })
 
 const initialState: LoginState = {
   email: '',
-  emailValidator: defaultEmailValidationGlobExpression,
+  emailValidator: defaultEmailValidator,
   otp: '',
   user: {},
   isLoggedIn: false,

--- a/src/client/reducers/login/types.ts
+++ b/src/client/reducers/login/types.ts
@@ -1,11 +1,11 @@
-import { IMinimatch } from 'minimatch'
 import { loginFormVariants } from '../../util/types'
+import { EmailValidatorType } from '../../actions/login/types'
 
 type LoginFormVariantKeys = keyof typeof loginFormVariants.types
 
 export type LoginState = {
   email: string
-  emailValidator: IMinimatch
+  emailValidator: EmailValidatorType
   otp: string
   user: {
     id?: string


### PR DESCRIPTION
## Problem

Closes #204

## Solution

Frontend email validation with `validator.isEmail`.

**Improvements**:

- Refactored the login flow from using `IMinimatch` directly, to accepting a function of type signature `(email: string) => boolean`.

**Bug Fixes**:

- UI now checks that user input is an email on the login page.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/5690550/86538244-783b3f80-bf27-11ea-9d57-c1b797a41ce3.png)


**AFTER**:
![image](https://user-images.githubusercontent.com/5690550/86538273-aa4ca180-bf27-11ea-8694-79e808afc926.png)


## Tests

Tested against the following strings:

- "travis .gov.sg"
- "yuanruo@gmail.com;yuanruo@data.gov.sg"

