### PR TITLE
feat: display the link user is editing on edit link drawer

### DIFF
--- a/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
@@ -13,9 +13,6 @@ import CopyButton from '../../Widgets/CopyButton'
 const useStyles = makeStyles((theme) =>
   createStyles({
     drawerTitleDiv: {
-      display: 'flex',
-      alignItems: 'flex-end',
-      justifyContent: 'space-between',
       marginBottom: theme.spacing(6.5),
       marginTop: theme.spacing(1.5),
       [theme.breakpoints.up('md')]: {
@@ -23,11 +20,8 @@ const useStyles = makeStyles((theme) =>
         marginTop: 0,
       },
     },
-    copyLinkDiv: {
-      display: 'flex',
-    },
-    copyIcon: {
-      marginRight: 5,
+    copyButtonWrapper: {
+      marginLeft: -8,
     },
     headerText: {
       marginBottom: '6px',
@@ -53,11 +47,12 @@ export default function DrawerHeader() {
       >
         Edit link
       </Typography>
-      <CopyButton
-        shortUrl={shortUrl}
-        buttonText={'Copy short link'}
-        iconSize={20}
-      />
+      <div className={classes.copyButtonWrapper}>
+        <CopyButton
+          shortUrl={shortUrl}
+          iconSize={20}
+        />
+      </div>
     </div>
   )
 }

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -112,7 +112,7 @@ const useStyles = makeStyles((theme) =>
     },
     topBar: {
       width: '100%',
-      height: '110px',
+      height: 110 + 33 /* 33px for copy button's height */,
       boxShadow: '0 0 8px 0 rgba(0, 0, 0, 0.1)',
       backgroundColor: '#f9f9f9',
       position: 'absolute',

--- a/src/client/components/UserPage/Widgets/CopyButton.tsx
+++ b/src/client/components/UserPage/Widgets/CopyButton.tsx
@@ -29,21 +29,28 @@ const useStyles = makeStyles(() =>
 
 export type CopyButtonProps = {
   shortUrl: string
-  buttonText: string
+  buttonText?: string // if omitted, defaults to the url to copy
   iconSize: number
   variant?: TypographyVariant
   stopPropagation?: boolean
 }
 
-export default function CopyButton(props: CopyButtonProps) {
-  const classes = useStyles({ iconSize: props.iconSize })
+export default function CopyButton({
+  iconSize,
+  buttonText,
+  shortUrl,
+  stopPropagation,
+  variant,
+}: CopyButtonProps) {
+  const classes = useStyles({ iconSize })
+  const urlToCopy = `${document.location.protocol}//${document.location.host}/${shortUrl}`
+
   return (
     <OnClickTooltip tooltipText="Short link copied">
       <Button
         onClick={(e) => {
-          const urlToCopy = `${document.location.protocol}//${document.location.host}/${props.shortUrl}`
           copy(urlToCopy)
-          if (props.stopPropagation) {
+          if (stopPropagation) {
             e.stopPropagation()
           }
         }}
@@ -54,8 +61,8 @@ export default function CopyButton(props: CopyButtonProps) {
             src={copyIcon}
             alt="Copy short link"
           />
-          <Typography variant={props.variant || 'subtitle2'}>
-            {props.buttonText}
+          <Typography variant={variant || 'subtitle2'}>
+            {buttonText || urlToCopy}
           </Typography>
         </div>
       </Button>


### PR DESCRIPTION
## Problem

Closes #180 

## Solution

Update according to the proposed design in https://github.com/opengovsg/GoGovSG/issues/180#issuecomment-645731155

**Improvements**:

- Change `buttonText` prop in `CopyButton` to be optional, defaults to the url to copy if omitted.
- Removed unused styles
- Destructure props for `CopyButton`

## Before & After Screenshots

**BEFORE (Desktop)**:
![image](https://user-images.githubusercontent.com/6182649/87222879-5cfa8500-c3aa-11ea-8513-6d401432d4f5.png)

**AFTER (Desktop)**:
![image](https://user-images.githubusercontent.com/6182649/87222846-2d4b7d00-c3aa-11ea-99b6-37767c221143.png)

**BEFORE (Mobile)**:
![image](https://user-images.githubusercontent.com/6182649/87222863-46542e00-c3aa-11ea-99d7-f269ba95ed21.png)

**AFTER (Mobile)**:
![image](https://user-images.githubusercontent.com/6182649/87222849-363c4e80-c3aa-11ea-8b06-876868aa96f2.png)




