### PR TITLE
fix: correct ts-node-dev transpile-only option

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postbuild": "copyfiles -u 1 src/server/views/**/* build && copyfiles -u 4 src/server/services/QrCodeService/assets/**/* build/server/services/QrCodeService",
     "start": "node build/server/index.js",
     "client-dev": "webpack-dev-server --mode development --host 0.0.0.0 --devtool inline-source-map --hot",
-    "server-dev": "ts-node-dev --poll --respawn --transpileOnly --inspect=0.0.0.0 -- src/server/index.ts",
+    "server-dev": "ts-node-dev --poll --respawn --transpile-only --inspect=0.0.0.0 -- src/server/index.ts",
     "docker-dev": "concurrently \"npm run server-dev\" \"npm run client-dev\"",
     "dev": "docker-compose -f docker-compose.yml up --build",
     "test": "jest --collectCoverage",


### PR DESCRIPTION
## Problem

In development, the current `transpileOnly` ts-node option we are using with ts-node-dev is flagged as a bad option.

Specifically, running the server-dev script throws the following error:

```
app_1         | [0] Using ts-node version 8.10.2, typescript version 3.9.6
app_1         | [0] /usr/local/bin/node: bad option: --transpileOnly
```

## Solution

The solution which worked for me requires changing the `transpileOnly` option to  `transpile-only`, which is the supported syntax to enable TypeScript transpile only option in ts-node.