### PR TITLE
chore: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Problem

Dependency updates can be tedious and should be automated

## Solution
Specify the default config for dependabot to ensure automatic 
dependency updates

## Notes

Dependabot, unlike renovatebot, does not group dependencies from
monorepo-driven releases. This is a feature that is currently worked on
via dependabot/dependabot-core#1190