### PR TITLE
feat: index tweaks and exclude blank description from search

### DIFF
--- a/src/client/components/BaseLayout/BaseLayoutHeader.jsx
+++ b/src/client/components/BaseLayout/BaseLayoutHeader.jsx
@@ -97,7 +97,12 @@ const mapDispatchToProps = (dispatch) => ({
   logout: () => dispatch(loginActions.logout()),
 })
 
-const BaseLayoutHeader = ({ backgroundType, isLoggedIn, logout, hideAuth }) => {
+const BaseLayoutHeader = ({
+  backgroundType,
+  isLoggedIn,
+  logout,
+  hideNavButtons,
+}) => {
   const isLightItems = backgroundType === 'darkest'
   const theme = useTheme()
   const isMobileVariant = useMediaQuery(theme.breakpoints.down('sm'))
@@ -190,33 +195,36 @@ const BaseLayoutHeader = ({ backgroundType, isLoggedIn, logout, hideAuth }) => {
             />
           </a>
           <span className={classes.rowSpace} />
-          {headers.map(
-            (header) =>
-              (header.public ? !isLoggedIn : isLoggedIn) &&
-              !header.hidden && (
-                <Button
-                  href={header.internalLink ? `/#${header.link}` : header.link}
-                  target={header.internalLink ? '' : '_blank'}
-                  color="primary"
-                  size="large"
-                  variant="text"
-                  key={header.text}
-                  className={classes.headerButton}
-                  style={
-                    isMobileVariant && header.mobileOrder
-                      ? { order: header.mobileOrder }
-                      : {}
-                  }
-                >
-                  {isMobileVariant && header.icon && (
-                    <img src={header.icon} alt={header.text} />
-                  )}
-                  {isMobileVariant && header.component}
-                  {!isMobileVariant && header.text}
-                </Button>
-              ),
-          )}
-          {!hideAuth && appBarBtn}
+          {!hideNavButtons &&
+            headers.map(
+              (header) =>
+                (header.public ? !isLoggedIn : isLoggedIn) &&
+                !header.hidden && (
+                  <Button
+                    href={
+                      header.internalLink ? `/#${header.link}` : header.link
+                    }
+                    target={header.internalLink ? '' : '_blank'}
+                    color="primary"
+                    size="large"
+                    variant="text"
+                    key={header.text}
+                    className={classes.headerButton}
+                    style={
+                      isMobileVariant && header.mobileOrder
+                        ? { order: header.mobileOrder }
+                        : {}
+                    }
+                  >
+                    {isMobileVariant && header.icon && (
+                      <img src={header.icon} alt={header.text} />
+                    )}
+                    {isMobileVariant && header.component}
+                    {!isMobileVariant && header.text}
+                  </Button>
+                ),
+            )}
+          {!hideNavButtons && appBarBtn}
         </Toolbar>
       </AppBar>
     </Section>
@@ -227,11 +235,11 @@ BaseLayoutHeader.propTypes = {
   backgroundType: PropTypes.string.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   logout: PropTypes.func.isRequired,
-  hideAuth: PropTypes.bool,
+  hideNavButtons: PropTypes.bool,
 }
 
 BaseLayoutHeader.defaultProps = {
-  hideAuth: false,
+  hideNavButtons: false,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(BaseLayoutHeader)

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -45,7 +45,7 @@ const BaseLayout = ({
   headerBackgroundType,
   withFooter,
   children,
-  hideAuth,
+  hideNavButtons,
 }) => {
   const classes = useStyles()
   const path = useLocation().pathname
@@ -60,7 +60,7 @@ const BaseLayout = ({
       {withHeader && (
         <BaseLayoutHeader
           backgroundType={headerBackgroundType}
-          hideAuth={hideAuth}
+          hideNavButtons={hideNavButtons}
         />
       )}
       <div className={classes.layout}>{children}</div>
@@ -73,14 +73,14 @@ BaseLayout.propTypes = {
   withHeader: PropTypes.bool,
   headerBackgroundType: PropTypes.string,
   withFooter: PropTypes.bool,
-  hideAuth: PropTypes.bool,
+  hideNavButtons: PropTypes.bool,
 }
 
 BaseLayout.defaultProps = {
   withHeader: true,
   headerBackgroundType: 'dark',
   withFooter: true,
-  hideAuth: false,
+  hideNavButtons: false,
 }
 
 export default BaseLayout

--- a/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
+++ b/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme) =>
       marginBottom: '76px',
       position: 'relative',
       right: theme.spacing(5),
+      zIndex: -1,
     },
     emptyStateBodyText: {
       marginTop: '8px',

--- a/src/client/components/SearchPage/index.tsx
+++ b/src/client/components/SearchPage/index.tsx
@@ -180,7 +180,7 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
 
   return (
     <div className={classes.root}>
-      <BaseLayout headerBackgroundType="darkest" hideAuth>
+      <BaseLayout headerBackgroundType="darkest" hideNavButtons>
         <SearchHeader
           onQueryChange={onQueryChange}
           query={pendingQuery}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -175,6 +175,6 @@ export const sentryDns: string | undefined = process.env.SENTRY_DNS
 
 // Search variables
 export const searchShortUrlWeight =
-  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 1
+  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 1.0
 export const searchDescriptionWeight =
   Number(process.env.SEARCH_DESCRIPTION_WEIGHT) || 0.4

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -177,4 +177,4 @@ export const sentryDns: string | undefined = process.env.SENTRY_DNS
 export const searchShortUrlWeight =
   Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 1
 export const searchDescriptionWeight =
-  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 0.4
+  Number(process.env.SEARCH_DESCRIPTION_WEIGHT) || 0.4

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -172,3 +172,9 @@ export const accessEndpoint =
 export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 40
 
 export const sentryDns: string | undefined = process.env.SENTRY_DNS
+
+// Search variables
+export const searchShortUrlWeight =
+  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 1
+export const searchDescriptionWeight =
+  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 0.4

--- a/src/server/db_migrations/20200720_delete_search_index.sql
+++ b/src/server/db_migrations/20200720_delete_search_index.sql
@@ -1,0 +1,4 @@
+-- This migration script adds the old index for GoSearch
+-- The new index will be managed by sequelize
+-- This must be run before the deployment of the sequelize managed index.
+DROP INDEX IF EXISTS urls_weighted_search_idx;

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -5,7 +5,6 @@ import { Clicks } from './statistics/daily'
 import { WeekdayClicks } from './statistics/weekday'
 import { Devices } from './statistics/devices'
 import { syncFunctions } from './functions'
-import { syncSearchIndex } from './search'
 
 // One user can create many urls but each url can only be mapped to one user.
 User.hasMany(Url, { as: 'Urls', foreignKey: { allowNull: false } })
@@ -29,5 +28,4 @@ Devices.belongsTo(Url, { foreignKey: 'shortUrl' })
 export default async () => {
   await sequelize.sync()
   await syncFunctions()
-  await syncSearchIndex()
 }

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -5,6 +5,7 @@ import { Clicks } from './statistics/daily'
 import { WeekdayClicks } from './statistics/weekday'
 import { Devices } from './statistics/devices'
 import { syncFunctions } from './functions'
+import { syncSearchIndex } from './search'
 
 // One user can create many urls but each url can only be mapped to one user.
 User.hasMany(Url, { as: 'Urls', foreignKey: { allowNull: false } })
@@ -28,4 +29,5 @@ Devices.belongsTo(Url, { foreignKey: 'shortUrl' })
 export default async () => {
   await sequelize.sync()
   await syncFunctions()
+  await syncSearchIndex()
 }

--- a/src/server/models/search.ts
+++ b/src/server/models/search.ts
@@ -1,33 +1,10 @@
-import { QueryTypes } from 'sequelize'
-import { Url } from './url'
-import { sequelize } from '../util/sequelize'
 import { StorableUrlState } from '../repositories/enums'
 
-const { tableName } = Url
-const INDEX_NAME = 'urls_weighted_search_idx'
-
-// Warning: This expression has to be EXACTLY the same as the one used in the index
+// Warning: This expression and conditions has to be EXACTLY the same as the one used in the index
 // or else the index will not be used leading to unnecessarily long query times.
 export const urlSearchVector = `
-  setweight(to_tsvector('english', ${tableName}."shortUrl"), 'A') ||
-  setweight(to_tsvector('english', ${tableName}."description"), 'B')
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
 `
 
 export const urlSearchConditions = `urls.state = '${StorableUrlState.Active}' AND urls.description != ''`
-
-const dropIndex = `DROP INDEX IF EXISTS ${INDEX_NAME};`
-const createIndex = `CREATE INDEX IF NOT EXISTS urls_weighted_search_idx ON urls USING gin ((${urlSearchVector}))
-    WHERE ${urlSearchConditions};`
-
-export async function syncSearchIndex() {
-  await sequelize.query(
-    `
-  BEGIN;
-  ${dropIndex}
-  ${createIndex}
-  COMMIT;`,
-    {
-      type: QueryTypes.RAW,
-    },
-  )
-}

--- a/src/server/models/search.ts
+++ b/src/server/models/search.ts
@@ -16,11 +16,18 @@ export const urlSearchVector = `
 export const urlSearchConditions = `urls.state = '${StorableUrlState.Active}' AND urls.description != ''`
 
 const dropIndex = `DROP INDEX IF EXISTS ${INDEX_NAME};`
-const createIndex = `CREATE INDEX urls_weighted_search_idx ON urls USING gin ((${urlSearchVector}))
+const createIndex = `CREATE INDEX IF NOT EXISTS urls_weighted_search_idx ON urls USING gin ((${urlSearchVector}))
     WHERE ${urlSearchConditions};`
 
 export async function syncSearchIndex() {
-  await sequelize.query(`${dropIndex} ${createIndex}`, {
-    type: QueryTypes.RAW,
-  })
+  await sequelize.query(
+    `
+  BEGIN;
+  ${dropIndex}
+  ${createIndex}
+  COMMIT;`,
+    {
+      type: QueryTypes.RAW,
+    },
+  )
 }

--- a/src/server/models/search.ts
+++ b/src/server/models/search.ts
@@ -1,0 +1,26 @@
+import { QueryTypes } from 'sequelize'
+import { Url } from './url'
+import { sequelize } from '../util/sequelize'
+import { StorableUrlState } from '../repositories/enums'
+
+const { tableName } = Url
+const INDEX_NAME = 'urls_weighted_search_idx'
+
+// Warning: This expression has to be EXACTLY the same as the one used in the index
+// or else the index will not be used leading to unnecessarily long query times.
+export const urlSearchVector = `
+  setweight(to_tsvector('english', ${tableName}."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', ${tableName}."description"), 'B')
+`
+
+export const urlSearchConditions = `urls.state = '${StorableUrlState.Active}' AND urls.description != ''`
+
+const dropIndex = `DROP INDEX IF EXISTS ${INDEX_NAME};`
+const createIndex = `CREATE INDEX urls_weighted_search_idx ON urls USING gin ((${urlSearchVector}))
+    WHERE ${urlSearchConditions};`
+
+export async function syncSearchIndex() {
+  await sequelize.query(`${dropIndex} ${createIndex}`, {
+    type: QueryTypes.RAW,
+  })
+}

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -11,6 +11,7 @@ import { sequelize } from '../util/sequelize'
 import { IdType } from '../../types/server/models'
 import { DEV_ENV, emailValidator, ogHostname } from '../config'
 import { StorableUrlState } from '../repositories/enums'
+import { urlSearchVector } from './search'
 
 interface UrlBaseType extends IdType {
   readonly shortUrl: string
@@ -149,6 +150,22 @@ export const Url = <UrlTypeStatic>sequelize.define(
       {
         unique: false,
         fields: ['userId'],
+      },
+      {
+        name: 'urls_weighted_search_idx',
+        unique: false,
+        using: 'GIN',
+        fields: [
+          // Type definition on sequelize seems to be inaccurate.
+          // @ts-ignore
+          Sequelize.literal(`(${urlSearchVector})`),
+        ],
+        where: {
+          state: ACTIVE,
+          description: {
+            [Sequelize.Op.ne]: '',
+          },
+        },
       },
     ],
   },

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -278,7 +278,7 @@ export class UrlRepository implements UrlRepositoryInterface {
           // the normalization option that specifies whether and how
           // a document's length should impact its rank. It works as a bit mask.
           // 1 divides the rank by 1 + the logarithm of the document length
-          const textRanking = `ts_rank_cd('{${searchShortUrlWeight}, ${searchDescriptionWeight}, 0, 0}',${urlSearchVector}, query, 1)`
+          const textRanking = `ts_rank_cd('{0, 0, ${searchDescriptionWeight}, ${searchShortUrlWeight}}',${urlSearchVector}, query, 1)`
           rankingAlgorithm = `${textRanking} * log(${tableName}.clicks + 1)`
         }
         break

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -278,7 +278,7 @@ export class UrlRepository implements UrlRepositoryInterface {
           // the normalization option that specifies whether and how
           // a document's length should impact its rank. It works as a bit mask.
           // 1 divides the rank by 1 + the logarithm of the document length
-          const textRanking = `ts_rank_cd('{${searchShortUrlWeight}, ${searchDescriptionWeight}, 0, 0}', ${urlSearchVector}, query, 1)`
+          const textRanking = `ts_rank_cd('{${searchShortUrlWeight}, ${searchDescriptionWeight}, 0, 0}',${urlSearchVector}, query, 1)`
           rankingAlgorithm = `${textRanking} * log(${tableName}.clicks + 1)`
         }
         break

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -14,8 +14,10 @@ import { StorableFile, StorableUrl, UrlsPaginated } from './types'
 import { StorableUrlState } from './enums'
 import { Mapper } from '../mappers/Mapper'
 import { SearchResultsSortOrder } from '../../shared/search'
+import { urlSearchConditions, urlSearchVector } from '../models/search'
 
 const { Public, Private } = FileVisibility
+
 /**
  * A url repository that handles access to the data store of Urls.
  * The following implementation uses Sequelize, AWS S3 and Redis.
@@ -148,23 +150,11 @@ export class UrlRepository implements UrlRepositoryInterface {
   ) => Promise<UrlsPaginated> = async (query, order, limit, offset) => {
     const { tableName } = Url
 
-    // Warning: This expression has to be EXACTLY the same as the one used in the index
-    // or else the index will not be used leading to unnecessarily long query times.
-    const urlVector = `
-      setweight(to_tsvector('english', ${tableName}."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', ${tableName}."description"), 'B')
-    `
-    const count = await this.getPlainTextSearchResultsCount(
-      tableName,
-      urlVector,
-      query,
-    )
+    const urlVector = urlSearchVector
 
-    const rankingAlgorithm = this.getRankingAlgorithm(
-      order,
-      urlVector,
-      tableName,
-    )
+    const count = await this.getPlainTextSearchResultsCount(tableName, query)
+
+    const rankingAlgorithm = this.getRankingAlgorithm(order, tableName)
 
     const urlsModel = await this.getRelevantUrls(
       tableName,
@@ -254,7 +244,7 @@ export class UrlRepository implements UrlRepositoryInterface {
     const rawQuery = `
       SELECT ${tableName}.*
       FROM ${tableName}, plainto_tsquery($query) query
-      WHERE query @@ (${urlVector}) AND state = '${StorableUrlState.Active}'
+      WHERE query @@ (${urlVector}) AND ${urlSearchConditions}
       ORDER BY (${rankingAlgorithm}) DESC
       LIMIT $limit
       OFFSET $offset`
@@ -273,7 +263,6 @@ export class UrlRepository implements UrlRepositoryInterface {
 
   private getRankingAlgorithm(
     order: SearchResultsSortOrder,
-    urlVector: string,
     tableName: string,
   ) {
     let rankingAlgorithm
@@ -284,7 +273,7 @@ export class UrlRepository implements UrlRepositoryInterface {
           // the normalization option that specifies whether and how
           // a document's length should impact its rank. It works as a bit mask.
           // 1 divides the rank by 1 + the logarithm of the document length
-          const textRanking = `ts_rank_cd(${urlVector}, query, 1)`
+          const textRanking = `ts_rank_cd(${urlSearchVector}, query, 1)`
           rankingAlgorithm = `${textRanking} * log(${tableName}.clicks + 1)`
         }
         break
@@ -302,13 +291,12 @@ export class UrlRepository implements UrlRepositoryInterface {
 
   private async getPlainTextSearchResultsCount(
     tableName: string,
-    urlVector: string,
     query: string,
   ) {
     const rawCountQuery = `
       SELECT count(*)
       FROM ${tableName}, plainto_tsquery($query) query
-      WHERE query @@ (${urlVector}) AND state = '${StorableUrlState.Active}'
+      WHERE query @@ (${urlSearchVector}) AND ${urlSearchConditions}
     `
     const [{ count: countString }] = await sequelize.query(rawCountQuery, {
       bind: {

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -5,7 +5,12 @@ import { QueryTypes } from 'sequelize'
 import { Url, UrlType } from '../models/url'
 import { NotFoundError } from '../util/error'
 import { redirectClient } from '../redis'
-import { logger, redirectExpiry } from '../config'
+import {
+  logger,
+  redirectExpiry,
+  searchDescriptionWeight,
+  searchShortUrlWeight,
+} from '../config'
 import { sequelize } from '../util/sequelize'
 import { DependencyIds } from '../constants'
 import { FileVisibility, S3Interface } from '../services/aws'
@@ -273,7 +278,7 @@ export class UrlRepository implements UrlRepositoryInterface {
           // the normalization option that specifies whether and how
           // a document's length should impact its rank. It works as a bit mask.
           // 1 divides the rank by 1 + the logarithm of the document length
-          const textRanking = `ts_rank_cd(${urlSearchVector}, query, 1)`
+          const textRanking = `ts_rank_cd('{${searchShortUrlWeight}, ${searchDescriptionWeight}, 0, 0}', ${urlSearchVector}, query, 1)`
           rankingAlgorithm = `${textRanking} * log(${tableName}.clicks + 1)`
         }
         break

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -44,4 +44,6 @@ jest.mock('../../src/server/config', () => ({
   s3Bucket: 'file-staging.go.gov.sg',
   linksToRotate: 'testlink1,testlink2,testlink3',
   sentryDns: 'mocksentry.com',
+  searchShortUrlWeight: 1,
+  searchDescriptionWeight: 0.4,
 }))

--- a/test/server/respositories/UrlRepository.test.ts
+++ b/test/server/respositories/UrlRepository.test.ts
@@ -145,7 +145,7 @@ describe('UrlRepository tests', () => {
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
 ) AND urls.state = 'ACTIVE' AND urls.description != ''
-      ORDER BY (ts_rank_cd('{1, 0.4, 0, 0}',
+      ORDER BY (ts_rank_cd('{0, 0, 0.4, 1.0}',
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
 , query, 1) * log(urls.clicks + 1)) DESC

--- a/test/server/respositories/UrlRepository.test.ts
+++ b/test/server/respositories/UrlRepository.test.ts
@@ -102,9 +102,9 @@ describe('UrlRepository tests', () => {
       SELECT count(*)
       FROM urls, plainto_tsquery($query) query
       WHERE query @@ (
-      setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', urls."description"), 'B')
-    ) AND state = 'ACTIVE'
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
+) AND urls.state = 'ACTIVE' AND urls.description != ''
     `,
         { bind: { query: 'query' }, raw: true, type: QueryTypes.SELECT },
       )
@@ -114,9 +114,9 @@ describe('UrlRepository tests', () => {
       SELECT urls.*
       FROM urls, plainto_tsquery($query) query
       WHERE query @@ (
-      setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', urls."description"), 'B')
-    ) AND state = 'ACTIVE'
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
+) AND urls.state = 'ACTIVE' AND urls.description != ''
       ORDER BY (urls.clicks) DESC
       LIMIT $limit
       OFFSET $offset`,
@@ -142,13 +142,13 @@ describe('UrlRepository tests', () => {
       SELECT urls.*
       FROM urls, plainto_tsquery($query) query
       WHERE query @@ (
-      setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', urls."description"), 'B')
-    ) AND state = 'ACTIVE'
-      ORDER BY (ts_rank_cd(
-      setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', urls."description"), 'B')
-    , query, 1) * log(urls.clicks + 1)) DESC
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
+) AND urls.state = 'ACTIVE' AND urls.description != ''
+      ORDER BY (ts_rank_cd('{1, 0.4, 0, 0}',
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
+, query, 1) * log(urls.clicks + 1)) DESC
       LIMIT $limit
       OFFSET $offset`,
         {
@@ -173,9 +173,9 @@ describe('UrlRepository tests', () => {
       SELECT urls.*
       FROM urls, plainto_tsquery($query) query
       WHERE query @@ (
-      setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
-      setweight(to_tsvector('english', urls."description"), 'B')
-    ) AND state = 'ACTIVE'
+  setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
+  setweight(to_tsvector('english', urls."description"), 'B')
+) AND urls.state = 'ACTIVE' AND urls.description != ''
       ORDER BY (urls."createdAt") DESC
       LIMIT $limit
       OFFSET $offset`,

--- a/test/server/respositories/UrlRepository.test.ts
+++ b/test/server/respositories/UrlRepository.test.ts
@@ -145,7 +145,7 @@ describe('UrlRepository tests', () => {
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
 ) AND urls.state = 'ACTIVE' AND urls.description != ''
-      ORDER BY (ts_rank_cd('{0, 0, 0.4, 1.0}',
+      ORDER BY (ts_rank_cd('{0, 0, 0.4, 1}',
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
 , query, 1) * log(urls.clicks + 1)) DESC


### PR DESCRIPTION
## Problem

Links with no description should be excluded from search as some links should not be discoverable.

## Solution

Add a condition to search to exclude urls with blank descriptions

**Improvements**:

- Index will be managed by sequelize instead
- Explicit configuration of search weights allow easy reconfiguration either through `config.ts` or env vars
- Empty state graphic should no longer overlap the sort panel
- Nav buttons hidden on search page

**Deploy notes**:
- Run migration script before deploying on production. This will allow sequelize to create the new updated search index in place of the old one.