### PR TITLE
feat: gosearch ui tweaks

### DIFF
--- a/src/client/components/HomePage/index.jsx
+++ b/src/client/components/HomePage/index.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { /* Redirect, */ withRouter } from 'react-router-dom'
+import { Redirect, withRouter } from 'react-router-dom'
 
 import { useMediaQuery, useTheme } from '@material-ui/core'
 import homeActions from '~/actions/home'
 import loginActions from '~/actions/login'
-// import { USER_PAGE } from '~/util/types'
+import { USER_PAGE } from '~/util/types'
 import TrustedBySliver from './TrustedBySliver'
 import StatisticsSliver from './StatisticsSliver'
 import DescriptionSliver from './FeatureListSliver'
@@ -29,7 +29,7 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const HomePage = (props) => {
-  // const { isLoggedIn } = props
+  const { isLoggedIn } = props
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
 
@@ -39,15 +39,15 @@ const HomePage = (props) => {
     getIsLoggedIn()
   })
 
-  // if (isLoggedIn) {
-  //   return (
-  //     <Redirect
-  //       to={{
-  //         pathname: USER_PAGE,
-  //       }}
-  //     />
-  //   )
-  // }
+  if (isLoggedIn) {
+    return (
+      <Redirect
+        to={{
+          pathname: USER_PAGE,
+        }}
+      />
+    )
+  }
 
   return (
     <BaseLayout headerBackgroundType={isMobileView ? '#f9f9f9' : 'light'}>

--- a/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
+++ b/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
@@ -8,11 +8,6 @@ import {
   Hidden,
 } from '@material-ui/core'
 import emptyStateGraphic from '../assets/empty-state-graphic.svg'
-import useAppMargins from '../../AppMargins/appMargins'
-
-type EmptySearchGraphicStyleProps = {
-  appMargins: number
-}
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -21,8 +16,6 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       marginTop: theme.spacing(8),
       alignItems: 'center',
-      maxWidth: (props: EmptySearchGraphicStyleProps) =>
-        `calc(${theme.spacing(180)}px - ${props.appMargins}px)`,
       [theme.breakpoints.up('md')]: {
         marginTop: theme.spacing(16),
       },
@@ -42,8 +35,7 @@ const useStyles = makeStyles((theme) =>
 )
 
 const EmptyStateGraphic: FunctionComponent = () => {
-  const appMargins = useAppMargins()
-  const classes = useStyles({ appMargins })
+  const classes = useStyles()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (

--- a/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
+++ b/src/client/components/SearchPage/EmptySearchGraphic/index.tsx
@@ -8,6 +8,11 @@ import {
   Hidden,
 } from '@material-ui/core'
 import emptyStateGraphic from '../assets/empty-state-graphic.svg'
+import useAppMargins from '../../AppMargins/appMargins'
+
+type EmptySearchGraphicStyleProps = {
+  appMargins: number
+}
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -16,6 +21,8 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       marginTop: theme.spacing(8),
       alignItems: 'center',
+      maxWidth: (props: EmptySearchGraphicStyleProps) =>
+        `calc(${theme.spacing(180)}px - ${props.appMargins}px)`,
       [theme.breakpoints.up('md')]: {
         marginTop: theme.spacing(16),
       },
@@ -35,7 +42,8 @@ const useStyles = makeStyles((theme) =>
 )
 
 const EmptyStateGraphic: FunctionComponent = () => {
-  const classes = useStyles()
+  const appMargins = useAppMargins()
+  const classes = useStyles({ appMargins })
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (

--- a/src/client/components/SearchPage/SearchHeader/index.tsx
+++ b/src/client/components/SearchPage/SearchHeader/index.tsx
@@ -19,6 +19,10 @@ type SearchHeaderProps = {
   query: string
 }
 
+type SearchHeaderStyleProps = {
+  appMargins: number
+}
+
 const useStyles = makeStyles((theme) =>
   createStyles({
     headerWrapper: {
@@ -52,7 +56,7 @@ const SearchHeader: FunctionComponent<SearchHeaderProps> = ({
   query,
 }: SearchHeaderProps) => {
   const appMargins = useAppMargins()
-  const classes = useStyles(appMargins)
+  const classes = useStyles({ appMargins })
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (

--- a/src/client/components/SearchPage/SearchHeader/index.tsx
+++ b/src/client/components/SearchPage/SearchHeader/index.tsx
@@ -9,7 +9,6 @@ import {
 import { ApplyAppMargins } from '../../AppMargins'
 import GoSearchInput from '../../widgets/GoSearchInput'
 import { SearchResultsSortOrder } from '../../../../shared/search'
-import useAppMargins from '../../AppMargins/appMargins'
 
 type SearchHeaderProps = {
   onQueryChange: (query: string) => void

--- a/src/client/components/SearchPage/SearchHeader/index.tsx
+++ b/src/client/components/SearchPage/SearchHeader/index.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent } from 'react'
-import { Typography, createStyles, makeStyles } from '@material-ui/core'
+import {
+  Typography,
+  createStyles,
+  makeStyles,
+  useTheme,
+  useMediaQuery,
+} from '@material-ui/core'
 import { ApplyAppMargins } from '../../AppMargins'
 import GoSearchInput from '../../widgets/GoSearchInput'
 import { SearchResultsSortOrder } from '../../../../shared/search'
@@ -11,10 +17,6 @@ type SearchHeaderProps = {
   onClearQuery: () => void
   sortOrder: SearchResultsSortOrder
   query: string
-}
-
-type SearchHeaderStyleProps = {
-  appMargins: number
 }
 
 const useStyles = makeStyles((theme) =>
@@ -29,8 +31,7 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       position: 'relative',
       top: '22px',
-      maxWidth: (props: SearchHeaderStyleProps) =>
-        `calc(${theme.spacing(180)}px - ${props.appMargins}px)`,
+      maxWidth: theme.spacing(180),
       [theme.breakpoints.up('md')]: {
         top: '35px',
       },
@@ -49,14 +50,18 @@ const SearchHeader: FunctionComponent<SearchHeaderProps> = ({
   sortOrder,
   query,
 }: SearchHeaderProps) => {
-  const appMargins = useAppMargins()
-  const classes = useStyles({ appMargins })
+  const classes = useStyles()
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (
     <div className={classes.headerWrapper}>
       <ApplyAppMargins>
         <div className={classes.headerContent}>
-          <Typography variant="h2" className={classes.headerText}>
-            GoSearch
+          <Typography
+            variant={isMobileView ? 'h4' : 'h2'}
+            className={classes.headerText}
+          >
+            Search go.gov.sg links
           </Typography>
           <GoSearchInput
             showAdornments

--- a/src/client/components/SearchPage/SearchHeader/index.tsx
+++ b/src/client/components/SearchPage/SearchHeader/index.tsx
@@ -9,6 +9,7 @@ import {
 import { ApplyAppMargins } from '../../AppMargins'
 import GoSearchInput from '../../widgets/GoSearchInput'
 import { SearchResultsSortOrder } from '../../../../shared/search'
+import useAppMargins from '../../AppMargins/appMargins'
 
 type SearchHeaderProps = {
   onQueryChange: (query: string) => void
@@ -30,7 +31,8 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       position: 'relative',
       top: '22px',
-      maxWidth: theme.spacing(180),
+      maxWidth: (props: SearchHeaderStyleProps) =>
+        `calc(${theme.spacing(180)}px - ${props.appMargins}px)`,
       [theme.breakpoints.up('md')]: {
         top: '35px',
       },
@@ -49,7 +51,8 @@ const SearchHeader: FunctionComponent<SearchHeaderProps> = ({
   sortOrder,
   query,
 }: SearchHeaderProps) => {
-  const classes = useStyles()
+  const appMargins = useAppMargins()
+  const classes = useStyles(appMargins)
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (

--- a/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
+++ b/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
@@ -109,6 +109,11 @@ const useStyles = makeStyles((theme) =>
       whiteSpace: 'nowrap',
       overflow: 'hidden',
     },
+    contactEmailClickable: {
+      '&:hover': {
+        textDecoration: 'underline',
+      },
+    },
   }),
 )
 
@@ -147,7 +152,15 @@ const SearchTableRow: FunctionComponent<SearchTableRowProps> = ({
       <TableCell className={classes.contactEmailCell} key="emailCell">
         <Typography
           variant={isMobileView ? 'caption' : 'body2'}
-          className={classes.contactEmailText}
+          className={`${classes.contactEmailText} ${
+            url.contactEmail ? classes.contactEmailClickable : ''
+          }`}
+          onClick={(e) => {
+            if (url.contactEmail) {
+              window.location.href = `mailto:${url.contactEmail}`
+              e.stopPropagation()
+            }
+          }}
         >
           {url.contactEmail || 'No contact specified'}
         </Typography>

--- a/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
+++ b/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
@@ -162,9 +162,7 @@ const SearchTableRow: FunctionComponent<SearchTableRowProps> = ({
             }
           }}
         >
-          {!!url.contactEmail
-            ? `For enquiries: ${url.contactEmail}`
-            : 'No contact specified'}
+          {url.contactEmail || 'No contact specified'}
         </Typography>
       </TableCell>
     </TableRow>

--- a/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
+++ b/src/client/components/SearchPage/SearchResults/SearchTable/SearchTableRow/index.tsx
@@ -162,7 +162,9 @@ const SearchTableRow: FunctionComponent<SearchTableRowProps> = ({
             }
           }}
         >
-          {url.contactEmail || 'No contact specified'}
+          {!!url.contactEmail
+            ? `For enquiries: ${url.contactEmail}`
+            : 'No contact specified'}
         </Typography>
       </TableCell>
     </TableRow>

--- a/src/client/components/SearchPage/SearchResults/index.tsx
+++ b/src/client/components/SearchPage/SearchResults/index.tsx
@@ -62,9 +62,11 @@ const SearchResults: FunctionComponent<SearchResultsProps> = ({
           variant={isMobileView ? 'h5' : 'h3'}
           className={classes.resultsHeaderText}
         >
-          {`Showing ${resultsCount} link${
-            resultsCount > 1 ? 's' : ''
-          } for “${query}”`}
+          {!!resultsCount &&
+            `Showing ${resultsCount} link${
+              resultsCount > 1 ? 's' : ''
+            } for “${query}”`}
+          {!resultsCount && `No links found for “${query}”`}
         </Typography>
       </ApplyAppMargins>
       {!!resultsCount && (

--- a/src/client/components/SearchPage/SearchResults/index.tsx
+++ b/src/client/components/SearchPage/SearchResults/index.tsx
@@ -62,7 +62,9 @@ const SearchResults: FunctionComponent<SearchResultsProps> = ({
           variant={isMobileView ? 'h5' : 'h3'}
           className={classes.resultsHeaderText}
         >
-          {`Showing ${resultsCount} links for “${query}”`}
+          {`Showing ${resultsCount} link${
+            resultsCount > 1 ? 's' : ''
+          } for “${query}”`}
         </Typography>
       </ApplyAppMargins>
       {!!resultsCount && (

--- a/src/client/components/SearchPage/index.tsx
+++ b/src/client/components/SearchPage/index.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles(() =>
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
+      flexShrink: 0,
       '-ms-flex': '1 1 auto',
     },
   }),

--- a/src/client/components/widgets/GoSearchInput/index.tsx
+++ b/src/client/components/widgets/GoSearchInput/index.tsx
@@ -134,7 +134,6 @@ const GoSearchInput: FunctionComponent<GoSearchInputProps> = ({
           variant="outlined"
           InputProps={{
             className: classes.searchInput,
-            // disableUnderline: true,
             startAdornment: (
               <div className={classes.searchInputIcon}>
                 <SearchIcon size={isMobileView ? 16 : 30} />

--- a/src/client/components/widgets/GoSearchInput/index.tsx
+++ b/src/client/components/widgets/GoSearchInput/index.tsx
@@ -125,12 +125,13 @@ const GoSearchInput: FunctionComponent<GoSearchInputProps> = ({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyPress={onKeyPress}
+          variant="outlined"
           InputProps={{
             className: classes.searchInput,
-            disableUnderline: true,
+            // disableUnderline: true,
             startAdornment: (
               <div className={classes.searchInputIcon}>
-                <SearchIcon size={isMobileView ? 16 : 24} />
+                <SearchIcon size={isMobileView ? 16 : 30} />
               </div>
             ),
             endAdornment: (

--- a/src/client/components/widgets/GoSearchInput/index.tsx
+++ b/src/client/components/widgets/GoSearchInput/index.tsx
@@ -50,6 +50,12 @@ const useStyles = makeStyles((theme) =>
       boxShadow: '0px 0px 30px rgba(0, 0, 0, 0.25)',
       borderRadius: '5px',
       border: 0,
+      paddingRight: 0,
+      paddingLeft: 0,
+      [theme.breakpoints.up('md')]: {
+        paddingRight: theme.spacing(2),
+        paddingLeft: theme.spacing(2),
+      },
     },
     searchInputNested: {
       [theme.breakpoints.up('md')]: {

--- a/src/server/api/search.ts
+++ b/src/server/api/search.ts
@@ -28,7 +28,7 @@ const apiLimiter = rateLimit({
 })
 
 const router = Express.Router()
-const validator = createValidator()
+const validator = createValidator({ passError: true })
 const searchController = container.get<SearchControllerInterface>(
   DependencyIds.searchController,
 )


### PR DESCRIPTION
## Problem

Certain icon sizes are not in line with the Figma design. Furthermore it is not easy to reach the contact emails on search.

## Solution

- Allow contact emails to be clickable
- Adjust icon sizes
- Add border to search input on hover