### PR TITLE
fix: explicit parsing config on query

### DIFF
--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -248,7 +248,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   ) {
     const rawQuery = `
       SELECT ${tableName}.*
-      FROM ${tableName}, plainto_tsquery($query) query
+      FROM ${tableName}, plainto_tsquery('english', $query) query
       WHERE query @@ (${urlVector}) AND ${urlSearchConditions}
       ORDER BY (${rankingAlgorithm}) DESC
       LIMIT $limit
@@ -300,7 +300,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   ) {
     const rawCountQuery = `
       SELECT count(*)
-      FROM ${tableName}, plainto_tsquery($query) query
+      FROM ${tableName}, plainto_tsquery('english', $query) query
       WHERE query @@ (${urlSearchVector}) AND ${urlSearchConditions}
     `
     const [{ count: countString }] = await sequelize.query(rawCountQuery, {

--- a/test/server/respositories/UrlRepository.test.ts
+++ b/test/server/respositories/UrlRepository.test.ts
@@ -100,7 +100,7 @@ describe('UrlRepository tests', () => {
       expect(mockQuery).toBeCalledWith(
         `
       SELECT count(*)
-      FROM urls, plainto_tsquery($query) query
+      FROM urls, plainto_tsquery('english', $query) query
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
@@ -112,7 +112,7 @@ describe('UrlRepository tests', () => {
       expect(mockQuery).toBeCalledWith(
         `
       SELECT urls.*
-      FROM urls, plainto_tsquery($query) query
+      FROM urls, plainto_tsquery('english', $query) query
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
@@ -140,7 +140,7 @@ describe('UrlRepository tests', () => {
       expect(mockQuery).toBeCalledWith(
         `
       SELECT urls.*
-      FROM urls, plainto_tsquery($query) query
+      FROM urls, plainto_tsquery('english', $query) query
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
@@ -171,7 +171,7 @@ describe('UrlRepository tests', () => {
       expect(mockQuery).toBeCalledWith(
         `
       SELECT urls.*
-      FROM urls, plainto_tsquery($query) query
+      FROM urls, plainto_tsquery('english', $query) query
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')


### PR DESCRIPTION
## Problem

While the default configuration for parsing queries is set to english on most database configurations and on the local docker image, it might be different in production environments.

For example, in AWS RDS, the default is set to `simple` which does not stem query words.

## Solution

Explicitly state that the configuration to use in the query is `english`
