### PR TITLE
Documentation for using SQL functions to transfer link ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ The official Singapore government link shortener.
     - [Setting up the infrastructure](#setting-up-the-infrastructure)
     - [Deploying](#deploying)
   - [Pre-release](#pre-release)
-  - [Documentation](#documentation)
+  - [Operations](#operations)
+    - [Transferring links to a new owner or email address](#transferring-links-to-a-new-owner-or-email-address)
+  - [Developer Documentation](#developer-documentation)
     - [Folder Structure](#folder-structure)
     - [Babel](#babel)
     - [ESLint](#eslint)
     - [Webpack](#webpack)
     - [Webpack dev server](#webpack-dev-server)
-    - [Nodemon](#nodemon)
+    - [ts-node-dev](#ts-node-dev)
     - [Express](#express)
     - [Concurrently](#concurrently)
     - [VSCode + ESLint](#vscode--eslint)
@@ -135,7 +137,23 @@ We have yet to setup travis to automate these steps:
 - Update credits [opengovsg/credits-generator](https://github.com/opengovsg/credits-generator)
 - Upload pdf to S3 bucket
 
-## Documentation
+## Operations
+
+### Transferring links to a new owner or email address
+
+Use the following SQL functions defined in [scripts folder](scripts/) to safely transfer link ownership.
+
+To transfer a single link to a new email address (must be lowercase):
+```sql
+SELECT migrate_url_to_user('the-short-link', 'new_email@domain.com');
+```
+
+To transfer all links belonging to an account to another account, specify the email accounts of both (must be in lowercase):
+```sql
+SELECT migrate_user_links('from@domain.com','to@domain.com');
+```
+
+## Developer Documentation
 
 ### Folder Structure
 

--- a/README.md
+++ b/README.md
@@ -144,11 +144,13 @@ We have yet to setup travis to automate these steps:
 Use the following SQL functions defined in [scripts folder](scripts/) to safely transfer link ownership.
 
 To transfer a single link to a new email address (must be lowercase):
+
 ```sql
 SELECT migrate_url_to_user('the-short-link', 'new_email@domain.com');
 ```
 
 To transfer all links belonging to an account to another account, specify the email accounts of both (must be in lowercase):
+
 ```sql
 SELECT migrate_user_links('from@domain.com','to@domain.com');
 ```


### PR DESCRIPTION
## Problem

Hand-rolling SQL queries when transferring link ownership is inherently unsafe, and runs the risk of data corruption.

## Solution

Document the use of tried-and-tested SQL functions, which have been tested safely and are easy-to-use. The functions also take care to track the changes in the `url_histories` audit table.

