### PR TITLE
feat(helmet): implement CSP policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - ROTATED_LINKS=whatsapp,passport,spsc,sppr
       - AWS_ACCESS_KEY_ID=foobar
       - AWS_SECRET_ACCESS_KEY=foobar
+      - CSP_ONLY_REPORT_VIOLATIONS=true
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -163,6 +163,10 @@ export const sessionSettings: SessionSettings = {
   name: 'gogovsg',
 }
 
+export const cspOnlyReportViolations =
+  process.env.CSP_ONLY_REPORT_VIOLATIONS === 'true'
+export const cspReportUri = process.env.CSP_REPORT_URI
+
 // LocalStack variables.
 export const bucketEndpoint =
   process.env.BUCKET_ENDPOINT || 'http://localstack:4566'

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -13,6 +13,7 @@ import { createPageViewHit } from '../services/analytics'
 import IGaPageViewForm from '../services/analytics/types/IGaPageViewForm'
 
 const TRANSITION_PATH = 'transition-page.ejs'
+const GTAG_PATH = 'gtag.ejs'
 
 @injectable()
 export class RedirectController implements RedirectControllerInterface {
@@ -38,6 +39,21 @@ export class RedirectController implements RedirectControllerInterface {
     if (pageViewHit) {
       this.analyticsLogger.logRedirectAnalytics(pageViewHit)
     }
+  }
+
+  public gtagForTransitionPage: (
+    req: Express.Request,
+    res: Express.Response,
+  ) => Promise<void> = async (_, res) => {
+    res
+      .status(200)
+      .header('content-type', 'text/javascript')
+      .render(GTAG_PATH, {
+        gaTrackingId,
+        gaEventType: EventCategory.TRANSITION_PAGE,
+        gaOnLoad: EventAction.LOADED,
+        gaOnProceed: EventAction.PROCEEDED,
+      })
   }
 
   public redirect: (
@@ -82,9 +98,6 @@ export class RedirectController implements RedirectControllerInterface {
           escapedLongUrl: RedirectController.encodeLongUrl(longUrl),
           rootDomain,
           gaTrackingId,
-          gaEventType: EventCategory.TRANSITION_PAGE,
-          gaOnLoad: EventAction.LOADED,
-          gaOnProceed: EventAction.PROCEEDED,
         })
         this.logRedirect(req, shortUrl, longUrl)
         return

--- a/src/server/controllers/interfaces/RedirectControllerInterface.ts
+++ b/src/server/controllers/interfaces/RedirectControllerInterface.ts
@@ -2,6 +2,16 @@ import Express from 'express'
 
 export interface RedirectControllerInterface {
   /**
+   * Renders Google Tag Manager script for transition page.
+   * @param {Object} req Express request object.
+   * @param {Object} res Express response object.
+   */
+  gtagForTransitionPage(
+    req: Express.Request,
+    res: Express.Response,
+  ): Promise<void>
+
+  /**
    * The redirect function.
    * @param {Object} req Express request object.
    * @param {Object} res Express response object.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,7 +18,15 @@ bindInversifyDependencies()
 import api from './api'
 
 // Logger configuration
-import { cookieSettings, logger, sessionSettings, trustProxy } from './config'
+import {
+  cookieSettings,
+  cspOnlyReportViolations,
+  cspReportUri,
+  logger,
+  sentryDns,
+  sessionSettings,
+  trustProxy,
+} from './config'
 
 // Services
 const SessionStore = connectRedis(session)
@@ -35,6 +43,7 @@ import { container } from './util/inversify'
 import { DependencyIds } from './constants'
 import { Mailer } from './services/email'
 import { RedirectControllerInterface } from './controllers/interfaces/RedirectControllerInterface'
+import parseDomain from './util/domain'
 // Define our own token for client ip
 // req.headers['cf-connecting-ip'] : Cloudflare
 
@@ -60,8 +69,37 @@ const MORGAN_LOG_FORMAT =
   ':client-ip - [:date[clf]] ":method :url HTTP/:http-version" :status ' +
   '":redirectUrl" ":userId" :res[content-length] ":referrer" ":user-agent" :response-time ms'
 
+const connectSrc = ["'self'", 'www.google-analytics.com']
+if (cspReportUri) {
+  connectSrc.push(parseDomain(cspReportUri))
+}
+if (sentryDns) {
+  connectSrc.push(sentryDns)
+}
+
 const app = express()
 app.use(helmet())
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", 'fonts.googleapis.com'],
+      fontSrc: ["'self'", 'fonts.gstatic.com'],
+      imgSrc: ["'self'", 'www.google-analytics.com'],
+      scriptSrc: [
+        "'self'",
+        'www.google-analytics.com',
+        'www.googletagmanager.com',
+      ],
+      connectSrc,
+      frameAncestors: ["'self'"],
+      ...(cspReportUri ? { reportUri: cspReportUri } : {}),
+      upgradeInsecureRequests: true,
+    },
+    reportOnly: cspOnlyReportViolations,
+  }),
+)
+
 initDb()
   .then(() => {
     logger.info('Database initialised.')
@@ -103,7 +141,9 @@ initDb()
         ...sessionSettings,
       } as session.SessionOptions),
       // application/json
-      bodyParser.json(),
+      cspOnlyReportViolations
+        ? bodyParser.json({ type: ['json', 'application/csp-report'] })
+        : bodyParser.json(),
     ]
 
     const redirectSpecificMiddleware = [
@@ -117,14 +157,19 @@ initDb()
     // Log http requests
     app.use(morgan(MORGAN_LOG_FORMAT))
 
+    const redirectController = container.get<RedirectControllerInterface>(
+      DependencyIds.redirectController,
+    )
     // API configuration
     app.use('/api', ...apiSpecificMiddleware, api) // Attach all API endpoints
+    app.get(
+      '/assets/transition-page/js/gtag.js',
+      redirectController.gtagForTransitionPage,
+    )
     app.use(
       '/:shortUrl([a-zA-Z0-9-]+)',
       ...redirectSpecificMiddleware,
-      container.get<RedirectControllerInterface>(
-        DependencyIds.redirectController,
-      ).redirect,
+      redirectController.redirect,
     ) // The Redirect Endpoint
     app.use((req, res) => {
       const shortUrl = req.path.slice(1)

--- a/src/server/views/gtag.ejs
+++ b/src/server/views/gtag.ejs
@@ -1,0 +1,23 @@
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+
+// Skip page hit and send transition-page loaded event to GA.
+gtag('config', '<%= gaTrackingId %>', { 'send_page_view': false });
+gtag('event', '<%= gaOnLoad %>', {
+    'event_category': '<%= gaEventType %>'
+});
+
+// Ensures that proceeded event sends at most once.
+var proceedIsLogged = false
+
+function proceedToDestination(url) {
+    // Logs transition-page proceeded event to GA.
+    if (!proceedIsLogged) {
+        proceedIsLogged = true
+        gtag('event', '<%= gaOnProceed %>', {
+            'event_category': '<%= gaEventType %>'
+        });
+    }
+    window.location = url
+}

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -24,7 +24,8 @@
                 link.
             </h3>
             <p>You are visiting a page at <span class="semi-bold-text"><%= rootDomain _%></span>.</p>
-            <button onclick="proceedToDestination()">
+            <!-- Use double-quotes to avoid templating issue as per RFC3986 (https://tools.ietf.org/html/rfc3986#appendix-C) -->
+            <button onclick='proceedToDestination("<%- escapedLongUrl %>")'>
                 <div id="main-button-content">
                     <p>Proceed to your page</p>
                     <!-- button right arrow icon -->
@@ -42,33 +43,7 @@
     </div>
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= gaTrackingId %>"></script>
-    <script>
-
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        // Skip page hit and send transition-page loaded event to GA.
-        gtag('config', '<%= gaTrackingId %>', { 'send_page_view': false });
-        gtag('event', '<%= gaOnLoad %>', {
-            'event_category': '<%= gaEventType %>'
-        });
-
-        // Ensures that proceeded event sends at most once.
-        var proceedIsLogged = false
-
-        function proceedToDestination() {
-            // Logs transition-page proceeded event to GA.
-            if (!proceedIsLogged) {
-                proceedIsLogged = true
-                gtag('event', '<%= gaOnProceed %>', {
-                    'event_category': '<%= gaEventType %>'
-                });
-            }
-            // Use double-quotes to avoid templating issue as per RFC3986 (https://tools.ietf.org/html/rfc3986#appendix-C)
-            window.location = "<%- escapedLongUrl %>"
-        }
-    </script>
+    <script src="./assets/transition-page/js/gtag.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Problem

Closes #291 

## Solution
Tighten how the browser interacts with the rest of the world when
accessing go.gov.sg. Avoid having to inject a nonce into the transition
page by moving the sole inline script into its own templated file.

- specify a content security policy using helmet
- allow requests from Google, Sentry (if present)
- move inline script in transition-page.ejs to its own template, and
  map this to `/assets/transition-page/js/gtag.js`

## Screenshots
![image](https://user-images.githubusercontent.com/10572368/88516786-66c5ee80-d020-11ea-9f20-4cef6b2d36d4.png)

## Deploy Notes

**New environment variables**:

- `CSP_ONLY_REPORT_VIOLATIONS` - when true, only reports CSP violations
- `CSP_REPORT_URI` - the URI that a browser can POST CSP violations to
