### PR TITLE
feat(links): scan for threats with Cloudmersive

### DIFF
--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -12,6 +12,7 @@ import {
 } from './validators'
 import { UserControllerInterface } from '../../controllers/interfaces/UserControllerInterface'
 import { FileCheckControllerInterface } from '../../controllers/interfaces/FileCheckControllerInterface'
+import { UrlCheckControllerInterface } from '../../controllers/interfaces/UrlCheckControllerInterface'
 
 const router = Express.Router()
 
@@ -21,6 +22,10 @@ const userController = container.get<UserControllerInterface>(
 
 const fileCheckController = container.get<FileCheckControllerInterface>(
   DependencyIds.fileCheckController,
+)
+
+const urlCheckController = container.get<UrlCheckControllerInterface>(
+  DependencyIds.urlCheckController,
 )
 
 const fileUploadMiddleware = fileUpload({
@@ -62,6 +67,7 @@ router.post(
   fileUploadMiddleware,
   preprocessPotentialIncomingFile,
   fileCheckController.checkFile,
+  urlCheckController.checkUrl,
   validator.body(urlSchema),
   userController.createUrl,
 )
@@ -84,6 +90,7 @@ router.patch(
   fileUploadMiddleware,
   preprocessPotentialIncomingFile,
   fileCheckController.checkFile,
+  urlCheckController.checkUrl,
   validator.body(urlEditSchema),
   userController.updateUrl,
 )

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -37,6 +37,8 @@ export const DependencyIds = {
   fileTypeFilterService: Symbol.for('fileTypeFilterService'),
   virusScanService: Symbol.for('virusScanService'),
   fileCheckController: Symbol.for('fileCheckController'),
+  urlThreatScanService: Symbol.for('urlThreatScanService'),
+  urlCheckController: Symbol.for('urlCheckController'),
 }
 
 export const ERROR_404_PATH = '404.error.ejs'

--- a/src/server/controllers/UrlCheckController.ts
+++ b/src/server/controllers/UrlCheckController.ts
@@ -1,0 +1,44 @@
+import { NextFunction, Request, Response } from 'express'
+import { inject, injectable } from 'inversify'
+
+import jsonMessage from '../util/json'
+import { UrlCheckControllerInterface } from './interfaces/UrlCheckControllerInterface'
+import { UrlCreationRequest } from '../../types/server/controllers/UserController'
+import { UrlThreatScanServiceInterface } from '../services/interfaces/UrlThreatScanServiceInterface'
+import { DependencyIds } from '../constants'
+
+@injectable()
+export class UrlCheckController implements UrlCheckControllerInterface {
+  private urlThreatScanService: UrlThreatScanServiceInterface
+
+  public constructor(
+    @inject(DependencyIds.urlThreatScanService)
+    urlThreatScanService: UrlThreatScanServiceInterface,
+  ) {
+    this.urlThreatScanService = urlThreatScanService
+  }
+
+  checkUrl: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<void> = async (req, res, next) => {
+    const { longUrl }: UrlCreationRequest = req.body
+
+    if (longUrl) {
+      try {
+        const isThreat = await this.urlThreatScanService.isThreat(longUrl)
+        if (isThreat) {
+          res.badRequest(jsonMessage('Link is likely to be malicious.'))
+          return
+        }
+      } catch (error) {
+        res.serverError(jsonMessage(error.message))
+        return
+      }
+    }
+    next()
+  }
+}
+
+export default UrlCheckController

--- a/src/server/controllers/interfaces/UrlCheckControllerInterface.ts
+++ b/src/server/controllers/interfaces/UrlCheckControllerInterface.ts
@@ -1,0 +1,9 @@
+import Express from 'express'
+
+export interface UrlCheckControllerInterface {
+  checkUrl(
+    req: Express.Request,
+    res: Express.Response,
+    next: Express.NextFunction,
+  ): Promise<void>
+}

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -40,8 +40,10 @@ import {
   DEFAULT_ALLOWED_FILE_EXTENSIONS,
   FileTypeFilterService,
 } from './services/FileTypeFilterService'
-import { CloudmersiveVirusScanService } from './services/CloudmersiveVirusScanService'
+import { CloudmersiveScanService } from './services/CloudmersiveScanService'
 import { FileCheckController } from './controllers/FileCheckController'
+
+import { UrlCheckController } from './controllers/UrlCheckController'
 
 function bindIfUnbound<T>(
   dependencyId: symbol,
@@ -80,12 +82,21 @@ export default () => {
   bindIfUnbound(DependencyIds.urlSearchService, UrlSearchService)
   bindIfUnbound(DependencyIds.deviceCheckService, DeviceCheckService)
 
+  const cloudmersiveScanService = new CloudmersiveScanService()
+
   container
     .bind(DependencyIds.allowedFileExtensions)
     .toConstantValue(DEFAULT_ALLOWED_FILE_EXTENSIONS)
   bindIfUnbound(DependencyIds.fileTypeFilterService, FileTypeFilterService)
-  bindIfUnbound(DependencyIds.virusScanService, CloudmersiveVirusScanService)
+  container
+    .bind(DependencyIds.virusScanService)
+    .toConstantValue(cloudmersiveScanService)
   bindIfUnbound(DependencyIds.fileCheckController, FileCheckController)
+
+  container
+    .bind(DependencyIds.urlThreatScanService)
+    .toConstantValue(cloudmersiveScanService)
+  bindIfUnbound(DependencyIds.urlCheckController, UrlCheckController)
 
   bindIfUnbound(
     DependencyIds.linkStatisticsController,

--- a/src/server/services/interfaces/UrlThreatScanServiceInterface.ts
+++ b/src/server/services/interfaces/UrlThreatScanServiceInterface.ts
@@ -1,0 +1,3 @@
+export interface UrlThreatScanServiceInterface {
+  isThreat(url: string): Promise<boolean>
+}

--- a/test/server/controllers/UrlCheckController.test.ts
+++ b/test/server/controllers/UrlCheckController.test.ts
@@ -1,0 +1,77 @@
+import httpMocks from 'node-mocks-http'
+
+import { UrlCheckController } from '../../../src/server/controllers/UrlCheckController'
+import { createRequestWithUser } from '../api/util'
+
+describe('UrlCheckController test', () => {
+  const url = 'https://example.com'
+  const isThreat = jest.fn()
+
+  const controller = new UrlCheckController({ isThreat })
+  const badRequest = jest.fn()
+
+  beforeEach(() => {
+    isThreat.mockClear()
+    badRequest.mockClear()
+  })
+
+  it('does not invoke checks if no urls', async () => {
+    const req = createRequestWithUser(undefined)
+    const res = httpMocks.createResponse()
+    const next = jest.fn()
+
+    await controller.checkUrl(req, res, next)
+
+    expect(isThreat).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('reports on server error', async () => {
+    const req = createRequestWithUser(undefined)
+    req.body.longUrl = url
+    const res = httpMocks.createResponse() as any
+    const next = jest.fn()
+
+    isThreat.mockRejectedValue(false)
+    res.serverError = badRequest
+
+    await controller.checkUrl(req, res, next)
+
+    expect(isThreat).toHaveBeenCalled()
+    expect(badRequest).toHaveBeenCalled()
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('rejects on bad URL', async () => {
+    const req = createRequestWithUser(undefined)
+    req.body.longUrl = url
+    const res = httpMocks.createResponse() as any
+    const next = jest.fn()
+
+    isThreat.mockResolvedValue(true)
+    res.badRequest = badRequest
+
+    await controller.checkUrl(req, res, next)
+
+    expect(isThreat).toHaveBeenCalled()
+    expect(badRequest).toHaveBeenCalled()
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('passes through on good URL', async () => {
+    const req = createRequestWithUser(undefined)
+    req.body.longUrl = url
+    const res = httpMocks.createResponse() as any
+    const next = jest.fn()
+
+    isThreat.mockResolvedValue(false)
+    res.badRequest = badRequest
+    res.serverError = badRequest
+
+    await controller.checkUrl(req, res, next)
+
+    expect(isThreat).toHaveBeenCalled()
+    expect(badRequest).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem
Links submitted by users are not checked for threats, and may be malicious

## Solution
Use Cloudmersive's Virus Scan API to check URLs submitted by users through 
a new controller

- Rename CloudmersiveVirusScanService to CloudmersiveScanService
- Declare UrlThreatScanServiceInterface and provide
  CloudmersiveScanService as an implementation, delegating to the
  Virus Scan API client
- Declare and implement UrlCheckController and interface, along with
  scaffolding to drop into Express
- Rework inversify config so that a single CloudmersiveScanService is
  injected both as a virus scan service and a url threat scan service
