### PR TITLE
fix(links): correct website scan API call

### DIFF
--- a/src/server/services/CloudmersiveScanService.ts
+++ b/src/server/services/CloudmersiveScanService.ts
@@ -28,9 +28,11 @@ export class CloudmersiveScanService
 
   private static scanUrlPromise: (url: string) => Promise<boolean> = (url) =>
     new Promise((res, rej) => {
-      api.scanWebsite(url, (err, data) => {
+      // @ts-ignore
+      api.scanWebsite({ Url: url }, (err, data) => {
         if (err) {
-          logger.error(`Error when scanning file via Cloudmersive: ${err}`)
+          logger.error(`Error when scanning ${url} via Cloudmersive: ${err}`)
+          logger.error(data)
           return rej(err)
         }
         return res(!data.CleanResult)


### PR DESCRIPTION
## Problem and Solution

The Cloudmersive SDK incorrectly specifies the first argument of
`scanWebsite()` as a string, the URL itself; its docs clarify that
it should be an explicit request object. Supply the correct value,
and use `@ts-ignore` to stop TypeScript from complaining
