### PR TITLE
fix(csp): add GTM to img-src

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -85,7 +85,12 @@ app.use(
       defaultSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'", 'fonts.googleapis.com'],
       fontSrc: ["'self'", 'fonts.gstatic.com'],
-      imgSrc: ["'self'", 'data:', 'www.google-analytics.com'],
+      imgSrc: [
+        "'self'",
+        'data:',
+        'www.google-analytics.com',
+        'www.googletagmanager.com',
+      ],
       scriptSrc: [
         "'self'",
         'www.google-analytics.com',


### PR DESCRIPTION
Add Google Tag Manager as a possible image source to pacify our Content Security Policy