### PR TITLE
fix(cloudmersive): just log URL threats

### DIFF
--- a/src/server/services/CloudmersiveScanService.ts
+++ b/src/server/services/CloudmersiveScanService.ts
@@ -56,7 +56,11 @@ export class CloudmersiveScanService
       logger.warn(`No Cloudmersive API key provided. Not scanning url: ${url}`)
       return false
     }
-    return CloudmersiveScanService.scanUrlPromise(url)
+    const isThreat = await CloudmersiveScanService.scanUrlPromise(url)
+    if (isThreat) {
+      logger.info(`Considered threat by Cloudmersive but ignoring: ${url}`)
+    }
+    return false
   }
 }
 


### PR DESCRIPTION
## Problem and Solution

Cloudmersive Virus Scan APIs for URLs are highly aggressive, marking
bonafide links as malicious. Neuter CloudmersiveScanService.isThreat
for now, just logging if Cloudmersive deems something as so.

TODO: Replace with Google Safe Browsing
