### PR TITLE
feat(404-page): add sg crest banner

### DIFF
--- a/public/assets/not-found-page/styles/not-found-page.css
+++ b/public/assets/not-found-page/styles/not-found-page.css
@@ -36,6 +36,10 @@ img {
   margin-bottom: 54px;
 }
 
+.masthead-root {
+  padding: 6px 30px;
+}
+
 #main-container {
   margin-top: 10vh;
   margin-bottom: 10vh;

--- a/src/server/views/404.error.ejs
+++ b/src/server/views/404.error.ejs
@@ -9,11 +9,18 @@
     <title>Go.gov.sg: Page not found</title>
     <base href="~/" />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.13/css/sgds.css">
     <link href="/assets/not-found-page/styles/not-found-page.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 </head>
 
 <body>
+    <div class="sgds-masthead masthead-root">
+        <a href="https://www.gov.sg" target="_blank" rel=”noreferrer noopener”>
+            <span class="sgds-icon sgds-icon-sg-crest"></span>
+            <span class="is-text">A Singapore Government Agency Website</span>
+        </a>
+    </div>
     <main id="main-container">
         <div id="main-message-container">
             <div id="main-message">


### PR DESCRIPTION
## Problem

The not-found page does not have the SG govt banner at the top, which is an inconsistency in design as all other pages have it.

## Solution
Follow SGDS's [masthead guidelines](https://www.designsystem.gov.sg/docs/masthead/)

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/16982839/89577218-ee063400-d862-11ea-8b93-5e9b56af7f76.png)


