### PR TITLE
feat(links): scan threats with Google Safe Browsing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - REDIS_SESSION_URI=redis://redis:6379/1
       - REDIS_REDIRECT_URI=redis://redis:6379/2
       - REDIS_STAT_URI=redis://redis:6379/3
+      - REDIS_SAFE_BROWSING_URI=redis://redis:6379/4
       - SESSION_SECRET=thiscouldbeanything
       - GA_TRACKING_ID=UA-139330318-1
       - OG_URL=https://go.gov.sg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - AWS_ACCESS_KEY_ID=foobar
       - AWS_SECRET_ACCESS_KEY=foobar
       - CSP_ONLY_REPORT_VIOLATIONS=true
+      - SAFE_BROWSING_KEY=
       - CLOUDMERSIVE_KEY=
     volumes:
       - ./public:/usr/src/gogovsg/public

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -167,6 +167,8 @@ export const cspOnlyReportViolations =
   process.env.CSP_ONLY_REPORT_VIOLATIONS === 'true'
 export const cspReportUri = process.env.CSP_REPORT_URI
 
+export const safeBrowsingLogOnly = process.env.SAFE_BROWSING_LOG_ONLY === 'true'
+
 export const cloudmersiveKey: string | undefined = process.env.CLOUDMERSIVE_KEY
 export const safeBrowsingKey: string | undefined = process.env.SAFE_BROWSING_KEY
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -26,6 +26,7 @@ const requiredVars: string[] = [
   'REDIS_SESSION_URI', // Cache for storing session info
   'REDIS_REDIRECT_URI', // Cache for short links
   'REDIS_STAT_URI', // Cache for statistics (user, link, and click counts)
+  'REDIS_SAFE_BROWSING_URI', // Cache for Safe Browsing threat matches
   'SESSION_SECRET',
   'VALID_EMAIL_GLOB_EXPRESSION', // Glob pattern for valid emails
   'AWS_S3_BUCKET', // For file.go.gov.sg uploads
@@ -145,6 +146,8 @@ export const redisOtpUri = process.env.REDIS_OTP_URI as string
 export const redisSessionUri = process.env.REDIS_SESSION_URI as string
 export const redisRedirectUri = process.env.REDIS_REDIRECT_URI as string
 export const redisStatUri = process.env.REDIS_STAT_URI as string
+export const redisSafeBrowsingUri = process.env
+  .REDIS_SAFE_BROWSING_URI as string
 export const getOTP: OtpFunction = otpFunction
 export const transporterOptions: nodemailer.TransporterOptions | null = transporterOpts
 export const trustProxy: boolean = proxy

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -168,6 +168,7 @@ export const cspOnlyReportViolations =
 export const cspReportUri = process.env.CSP_REPORT_URI
 
 export const cloudmersiveKey: string | undefined = process.env.CLOUDMERSIVE_KEY
+export const safeBrowsingKey: string | undefined = process.env.SAFE_BROWSING_KEY
 
 // LocalStack variables.
 export const bucketEndpoint =

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -3,6 +3,7 @@ export const DependencyIds = {
   urlMapper: Symbol.for('urlMapper'),
   userMapper: Symbol.for('userMapper'),
   otpMapper: Symbol.for('otpMapper'),
+  safeBrowsingMapper: Symbol.for('safeBrowsingMapper'),
   analyticsLoggerService: Symbol.for('analyticsLoggerService'),
   cookieReducer: Symbol.for('cookieReducer'),
   userRepository: Symbol.for('userRepository'),
@@ -37,6 +38,7 @@ export const DependencyIds = {
   fileTypeFilterService: Symbol.for('fileTypeFilterService'),
   virusScanService: Symbol.for('virusScanService'),
   fileCheckController: Symbol.for('fileCheckController'),
+  safeBrowsingRepository: Symbol.for('safeBrowsingRepository'),
   urlThreatScanService: Symbol.for('urlThreatScanService'),
   urlCheckController: Symbol.for('urlCheckController'),
 }

--- a/src/server/controllers/UrlCheckController.ts
+++ b/src/server/controllers/UrlCheckController.ts
@@ -35,7 +35,11 @@ export class UrlCheckController implements UrlCheckControllerInterface {
           logger.warn(
             `Malicious link attempt: User ${user?.id} tried to link ${shortUrl} to ${longUrl}`,
           )
-          res.badRequest(jsonMessage('Link is likely to be malicious.'))
+          res.badRequest(
+            jsonMessage(
+              'Link is likely to be malicious, please contact us for further assistance',
+            ),
+          )
           return
         }
       } catch (error) {

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -43,6 +43,8 @@ import {
 import { CloudmersiveScanService } from './services/CloudmersiveScanService'
 import { FileCheckController } from './controllers/FileCheckController'
 
+import { SafeBrowsingMapper } from './mappers/SafeBrowsingMapper'
+import { SafeBrowsingRepository } from './repositories/SafeBrowsingRepository'
 import { SafeBrowsingService } from './services/SafeBrowsingService'
 import { UrlCheckController } from './controllers/UrlCheckController'
 
@@ -90,6 +92,8 @@ export default () => {
   bindIfUnbound(DependencyIds.virusScanService, CloudmersiveScanService)
   bindIfUnbound(DependencyIds.fileCheckController, FileCheckController)
 
+  bindIfUnbound(DependencyIds.safeBrowsingMapper, SafeBrowsingMapper)
+  bindIfUnbound(DependencyIds.safeBrowsingRepository, SafeBrowsingRepository)
   bindIfUnbound(DependencyIds.urlThreatScanService, SafeBrowsingService)
   bindIfUnbound(DependencyIds.urlCheckController, UrlCheckController)
 

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -43,6 +43,7 @@ import {
 import { CloudmersiveScanService } from './services/CloudmersiveScanService'
 import { FileCheckController } from './controllers/FileCheckController'
 
+import { SafeBrowsingService } from './services/SafeBrowsingService'
 import { UrlCheckController } from './controllers/UrlCheckController'
 
 function bindIfUnbound<T>(
@@ -82,20 +83,14 @@ export default () => {
   bindIfUnbound(DependencyIds.urlSearchService, UrlSearchService)
   bindIfUnbound(DependencyIds.deviceCheckService, DeviceCheckService)
 
-  const cloudmersiveScanService = new CloudmersiveScanService()
-
   container
     .bind(DependencyIds.allowedFileExtensions)
     .toConstantValue(DEFAULT_ALLOWED_FILE_EXTENSIONS)
   bindIfUnbound(DependencyIds.fileTypeFilterService, FileTypeFilterService)
-  container
-    .bind(DependencyIds.virusScanService)
-    .toConstantValue(cloudmersiveScanService)
+  bindIfUnbound(DependencyIds.virusScanService, CloudmersiveScanService)
   bindIfUnbound(DependencyIds.fileCheckController, FileCheckController)
 
-  container
-    .bind(DependencyIds.urlThreatScanService)
-    .toConstantValue(cloudmersiveScanService)
+  bindIfUnbound(DependencyIds.urlThreatScanService, SafeBrowsingService)
   bindIfUnbound(DependencyIds.urlCheckController, UrlCheckController)
 
   bindIfUnbound(

--- a/src/server/mappers/SafeBrowsingMapper.ts
+++ b/src/server/mappers/SafeBrowsingMapper.ts
@@ -1,0 +1,27 @@
+/* eslint-disable class-methods-use-this, lines-between-class-members, no-dupe-class-members */
+import { injectable } from 'inversify'
+import { TwoWayMapper } from './TwoWayMapper'
+import { HasCacheDuration } from '../repositories/types'
+
+@injectable()
+export class SafeBrowsingMapper
+  implements TwoWayMapper<HasCacheDuration[], string> {
+  persistenceToDto(matches: string): HasCacheDuration[]
+  persistenceToDto(matches: string | null): HasCacheDuration[] | null {
+    if (!matches) {
+      return null
+    }
+    return JSON.parse(matches)
+  }
+
+  dtoToPersistence(matches: HasCacheDuration[]): string
+  dtoToPersistence(matches: HasCacheDuration[] | null): string | null {
+    if (!matches) {
+      return null
+    }
+
+    return JSON.stringify(matches)
+  }
+}
+
+export default SafeBrowsingMapper

--- a/src/server/redis.ts
+++ b/src/server/redis.ts
@@ -3,6 +3,7 @@ import {
   logger,
   redisOtpUri,
   redisRedirectUri,
+  redisSafeBrowsingUri,
   redisSessionUri,
   redisStatUri,
 } from './config'
@@ -61,4 +62,16 @@ export const statClient = redis
   })
   .on('error', (error) => {
     logger.error(`statClient error:${error}`)
+  })
+
+// For storing computed statistics
+export const safeBrowsingClient = redis
+  .createClient({
+    url: redisSafeBrowsingUri,
+  })
+  .on('connect', () => {
+    logger.info('safeBrowsingClient client connected')
+  })
+  .on('error', (error) => {
+    logger.error(`safeBrowsingClient error:${error}`)
   })

--- a/src/server/repositories/SafeBrowsingRepository.ts
+++ b/src/server/repositories/SafeBrowsingRepository.ts
@@ -1,0 +1,73 @@
+/* eslint-disable class-methods-use-this */
+
+import { inject, injectable } from 'inversify'
+import { safeBrowsingClient } from '../redis'
+import { HasCacheDuration } from './types'
+import { SafeBrowsingRepositoryInterface } from './interfaces/SafeBrowsingRepositoryInterface'
+import { TwoWayMapper } from '../mappers/TwoWayMapper'
+import { DependencyIds } from '../constants'
+import { NotFoundError } from '../util/error'
+
+@injectable()
+export class SafeBrowsingRepository implements SafeBrowsingRepositoryInterface {
+  private safeBrowsingMapper: TwoWayMapper<HasCacheDuration[], string>
+
+  public constructor(
+    @inject(DependencyIds.safeBrowsingMapper)
+    safeBrowsingMapper: TwoWayMapper<HasCacheDuration[], string>,
+  ) {
+    this.safeBrowsingMapper = safeBrowsingMapper
+  }
+
+  public set: (url: string, matches: HasCacheDuration[]) => Promise<void> = (
+    url,
+    matches,
+  ) => {
+    return new Promise((resolve, reject) => {
+      if (!matches.length || !matches[0]) {
+        reject(
+          new NotFoundError(`No matches found for ${url}, should not persist`),
+        )
+      }
+      // Threat matches from Safe Browsing API specify a
+      // cache duration in seconds, with an 's' suffix
+      const [{ cacheDuration }] = matches
+      const expiryInSeconds = Number(
+        cacheDuration.substring(0, cacheDuration.length - 1),
+      )
+      safeBrowsingClient.set(
+        url,
+        this.safeBrowsingMapper.dtoToPersistence(matches),
+        'EX',
+        expiryInSeconds,
+        (redisSetError) => {
+          if (redisSetError) {
+            reject(redisSetError)
+            return
+          }
+
+          resolve()
+        },
+      )
+    })
+  }
+
+  public get: (url: string) => Promise<HasCacheDuration[] | null> = (url) => {
+    return new Promise((resolve, reject) => {
+      safeBrowsingClient.get(url, (redisError, string) => {
+        if (redisError) {
+          reject(redisError)
+          return
+        }
+
+        if (!string) {
+          resolve(null)
+        }
+
+        resolve(this.safeBrowsingMapper.persistenceToDto(string))
+      })
+    })
+  }
+}
+
+export default SafeBrowsingRepository

--- a/src/server/repositories/interfaces/SafeBrowsingRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/SafeBrowsingRepositoryInterface.ts
@@ -1,0 +1,17 @@
+import { HasCacheDuration } from '../types'
+
+export interface SafeBrowsingRepositoryInterface {
+  /**
+   * Sets or replaces the Safe Browsing threat matches associated with a URL.
+   * @param  {string} url The URL.
+   * @param  {Array<HasCacheDuration>} matches The threat matches returned by Safe Browsing for the URL.
+   */
+  set(url: string, matches: HasCacheDuration[]): Promise<void>
+
+  /**
+   * Retrieves Safe Browsing threat matches for a URL, if any.
+   * @param  {string} url The URL.
+   * @returns {Promise<Array<HasCacheDuration> | null>} An array of threat matches, or null if none.
+   */
+  get(url: string): Promise<HasCacheDuration[] | null>
+}

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -67,3 +67,13 @@ export type GlobalStatistics = {
   clickCount: number
   linkCount: number
 }
+
+/**
+ * Has a cache duration expressed as a human-readable
+ * time interval. An example of this is the threat matches
+ * returned by Google Safe Browsing, which have a cacheDuration
+ * specified as the number of seconds followed by 's'.
+ */
+export type HasCacheDuration = {
+  cacheDuration: string
+}

--- a/src/server/services/SafeBrowsingService.ts
+++ b/src/server/services/SafeBrowsingService.ts
@@ -1,12 +1,23 @@
 import fetch from 'cross-fetch'
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
 import { UrlThreatScanServiceInterface } from './interfaces/UrlThreatScanServiceInterface'
 import { logger, safeBrowsingKey, safeBrowsingLogOnly } from '../config'
+import { SafeBrowsingRepositoryInterface } from '../repositories/interfaces/SafeBrowsingRepositoryInterface'
+import { DependencyIds } from '../constants'
 
 const ENDPOINT = `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${safeBrowsingKey}`
 
 @injectable()
 export class SafeBrowsingService implements UrlThreatScanServiceInterface {
+  private safeBrowsingRepository: SafeBrowsingRepositoryInterface
+
+  public constructor(
+    @inject(DependencyIds.safeBrowsingRepository)
+    safeBrowsingRepository: SafeBrowsingRepositoryInterface,
+  ) {
+    this.safeBrowsingRepository = safeBrowsingRepository
+  }
+
   /**
    * Request template for Safe Browsing. Threat lists found
    * at /v4/threatLists and are keyed by type, platform and entry.
@@ -36,6 +47,15 @@ export class SafeBrowsingService implements UrlThreatScanServiceInterface {
       logger.warn(`No Safe Browsing API key provided. Not scanning url: ${url}`)
       return false
     }
+    let matches = await this.safeBrowsingRepository.get(url)
+    if (!matches) {
+      matches = await this.lookup(url)
+    }
+    return safeBrowsingLogOnly && Boolean(matches)
+  }
+
+  private async lookup(url: string) {
+    let matches = null
     const request = { ...this.requestTemplate } as any
     request.threatInfo.threatEntries = [{ url }]
     const response = await fetch(ENDPOINT, {
@@ -52,17 +72,20 @@ export class SafeBrowsingService implements UrlThreatScanServiceInterface {
       } else {
         throw error
       }
+    } else {
+      const result = await response.json()
+      if (result?.matches) {
+        await this.safeBrowsingRepository.set(url, result.matches)
+        const prefix = safeBrowsingLogOnly
+          ? 'Considered threat by Safe Browsing but ignoring'
+          : 'Malicious link content'
+        logger.warn(
+          `${prefix}: ${url} yields ${JSON.stringify(result.matches, null, 2)}`,
+        )
+        matches = result.matches
+      }
     }
-    const result = await response.json()
-    if (result?.matches) {
-      const prefix = safeBrowsingLogOnly
-        ? 'Considered threat by Safe Browsing but ignoring'
-        : 'Malicious link content'
-      logger.warn(
-        `${prefix}: ${url} yields ${JSON.stringify(result.matches, null, 2)}`,
-      )
-    }
-    return safeBrowsingLogOnly && Boolean(result?.matches)
+    return matches
   }
 }
 

--- a/src/server/services/SafeBrowsingService.ts
+++ b/src/server/services/SafeBrowsingService.ts
@@ -1,0 +1,65 @@
+import fetch from 'cross-fetch'
+import { injectable } from 'inversify'
+import { UrlThreatScanServiceInterface } from './interfaces/UrlThreatScanServiceInterface'
+import { logger, safeBrowsingKey } from '../config'
+
+const ENDPOINT = `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${safeBrowsingKey}`
+
+@injectable()
+export class SafeBrowsingService implements UrlThreatScanServiceInterface {
+  /**
+   * Request template for Safe Browsing. Threat lists found
+   * at /v4/threatLists and are keyed by type, platform and entry.
+   * Both ANY_PLATFORM and all the platforms are specified, the latter
+   * so that we can look up the IP_RANGE lists, which are not keyed by
+   * ANY_PLATFORM.
+   */
+  private requestTemplate = Object.freeze({
+    client: {
+      clientId: 'GoGovSG',
+      clientVersion: '1.0.0',
+    },
+    threatInfo: {
+      threatTypes: [
+        'POTENTIALLY_HARMFUL_APPLICATION',
+        'UNWANTED_SOFTWARE',
+        'MALWARE',
+        'SOCIAL_ENGINEERING',
+      ],
+      platformTypes: ['ANY_PLATFORM', 'WINDOWS', 'LINUX', 'OSX'],
+      threatEntryTypes: ['URL', 'EXECUTABLE', 'IP_RANGE'],
+    },
+  })
+
+  public isThreat: (url: string) => Promise<boolean> = async (url) => {
+    if (!safeBrowsingKey) {
+      logger.warn(`No Safe Browsing API key provided. Not scanning url: ${url}`)
+      return false
+    }
+    const request = { ...this.requestTemplate } as any
+    request.threatInfo.threatEntries = [{ url }]
+    const response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    })
+    if (!response.ok) {
+      throw new Error(
+        `Safe Browsing failure:\tError: ${response.statusText}\thttpResponse: ${response}\t body:${response.body}`,
+      )
+    }
+    const result = await response.json()
+    if (result?.matches) {
+      logger.warn(
+        `Malicious link content: ${url} yields ${JSON.stringify(
+          result.matches,
+          null,
+          2,
+        )}`,
+      )
+    }
+    return Boolean(result?.matches)
+  }
+}
+
+export default SafeBrowsingService

--- a/test/server/respositories/SafeBrowsingRepository.test.ts
+++ b/test/server/respositories/SafeBrowsingRepository.test.ts
@@ -1,0 +1,60 @@
+import { redisMockClient } from '../api/util'
+import { SafeBrowsingRepository } from '../../../src/server/repositories/SafeBrowsingRepository'
+import { SafeBrowsingMapper } from '../../../src/server/mappers/SafeBrowsingMapper'
+
+jest.mock('../../../src/server/redis', () => ({
+  safeBrowsingClient: redisMockClient,
+}))
+
+const setSpy = jest.spyOn(redisMockClient, 'set')
+const getSpy = jest.spyOn(redisMockClient, 'get')
+const repository = new SafeBrowsingRepository(new SafeBrowsingMapper())
+
+const durationInSeconds = 1
+const url = 'https://example.com'
+const matches = [
+  {
+    cacheDuration: `${durationInSeconds}s`,
+  },
+]
+
+describe('otp repository redis test', () => {
+  beforeEach(async () => {
+    await new Promise((resolve) => {
+      redisMockClient.flushall(() => resolve())
+    })
+    setSpy.mockClear()
+    getSpy.mockClear()
+  })
+
+  it('returns a value if present', async () => {
+    redisMockClient.set(url, JSON.stringify(matches))
+    await expect(repository.get(url)).resolves.toStrictEqual(matches)
+    expect(redisMockClient.get).toBeCalledWith(url, expect.any(Function))
+  })
+
+  it('returns null if absent', async () => {
+    await expect(repository.get(url)).resolves.toBeNull()
+    expect(redisMockClient.get).toBeCalledWith(url, expect.any(Function))
+  })
+
+  it('sets a value if specified', async () => {
+    await repository.set(url, matches)
+    expect(redisMockClient.set).toBeCalledWith(
+      url,
+      JSON.stringify(matches),
+      'EX',
+      durationInSeconds,
+      expect.any(Function),
+    )
+  })
+
+  it('throws if no matches', async () => {
+    const originalSet = redisMockClient.set
+    redisMockClient.set = () => {
+      throw Error()
+    }
+    await expect(repository.set(url, [])).rejects.toThrowError()
+    redisMockClient.set = originalSet
+  })
+})


### PR DESCRIPTION
## Problem

The Virus Scan API for websites provided by Cloudmersive was far 
too aggressive, declaring Google Drive links and even a well-known
international organisation as threats. We need a more effective service
that accurately classifies websites that our users link to.

Fixes #377 

## Solution

Replace Cloudmersive's URL scanning with Google Safe Browsing,
which is more nuanced and more consistent with the browsing experience
for most users, who are probable Chrome users.

- Implement SafeBrowsingService, which vets a given URL against threat
  lists maintained by Google. If we have a match, log the match and
  declare the URL threat

- Drop SafeBrowsingService into inversify, and wire that into
  UrlCheckController

## Deploy Notes

**New environment variables**:

- `SAFE_BROWSING_KEY` - the Google Cloud API key for Safe Browsing APIs
- `REDIS_SAFE_BROWSING_URI` - Redis URI for caching Safe Browsing threat matches