### PR TITLE
fix(file-upload): race condition caused by not awaiting a DB promise

### DIFF
--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -101,7 +101,7 @@ export class UserController implements UserControllerInterface {
     }
 
     try {
-      const url = this.urlManagementService.updateUrl(userId, shortUrl, {
+      const url = await this.urlManagementService.updateUrl(userId, shortUrl, {
         longUrl,
         state: urlState,
         file,


### PR DESCRIPTION
## Problem

Replace file does not update the file extension in the UI.

Closes #261

## Solution

There was a race condition between the server-side update of the longUrl and the subsequent retrieval of all urls made by the client.

Because we did not await the promise, it returns a success to the client very early (before the update operation completes in the database). This prompts the client to initiate its next step: retrieve all urls and update its redux state. Because the database update operation isnt completed yet, the server returns the old state of urls, causing this bug.

The fix was to await the promise.

