### PR TITLE
fix(upload): log a message with the Error, not the Error itself

### DIFF
--- a/src/server/controllers/FileCheckController.ts
+++ b/src/server/controllers/FileCheckController.ts
@@ -56,7 +56,7 @@ export class FileCheckController implements FileCheckControllerInterface {
           return
         }
       } catch (error) {
-        logger.error(error)
+        logger.error('Unable to check file: ', error)
         res.serverError(jsonMessage(error.message))
         return
       }


### PR DESCRIPTION
## Problem and Solution

Winston does not natively handle Error objects when supplied as the sole argument to `error(message: any)`, and as a result, Error does not get properly stringified. Replace with a call to `error(message: string, ...meta: any[])`

## Screenshot

![image](https://user-images.githubusercontent.com/10572368/90095228-9ab04c00-dd62-11ea-8656-d48836eea2fc.png)
