### PR TITLE
feat(redirect): remove trailing slash in redirect

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -150,12 +150,25 @@ initDb()
       bodyParser.json(),
     ]
 
+    const removeTrailingSlashes = (
+      req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (req.originalUrl.substr(-1) === '/') {
+        res.redirect(req.baseUrl)
+        return
+      }
+      next()
+    }
+
     const redirectSpecificMiddleware = [
       cookieSession({
         name: 'visits',
         maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
         secret: sessionSettings.secret,
       }),
+      removeTrailingSlashes,
     ]
 
     // Log http requests


### PR DESCRIPTION
## Problem

CSP errors occur when accessing shortlinks with a trailing slash. These slashes are supported by express but semantically incorrect. 

Closes #427 

## Solution

Opt to redirect clients to the short link equivalent without trailing slash whenever it is detected.

