### PR TITLE
fix(transition): correct relative paths, redirect middleware

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -83,8 +83,13 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'", 'fonts.googleapis.com'],
-        fontSrc: ["'self'", 'fonts.gstatic.com'],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'fonts.googleapis.com',
+          'cdn.jsdelivr.net',
+        ],
+        fontSrc: ["'self'", 'fonts.gstatic.com', 'cdn.jsdelivr.net'],
         imgSrc: [
           "'self'",
           'data:',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -175,7 +175,7 @@ initDb()
       '/assets/transition-page/js/redirect.js',
       redirectController.gtagForTransitionPage,
     )
-    app.use(
+    app.get(
       '/:shortUrl([a-zA-Z0-9-]+)',
       ...redirectSpecificMiddleware,
       redirectController.redirect,

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -9,7 +9,7 @@
     <title>Go.gov.sg</title>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.13/css/sgds.css">
-    <link href="./assets/transition-page/styles/transition-page.css" rel="stylesheet">
+    <link href="/assets/transition-page/styles/transition-page.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 </head>
 
@@ -31,15 +31,15 @@
     </div>
     <div class="bottom-half">
         <p id="url" data-href="<%- escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
-        <img class="loading-image" src="./assets/transition-page/images/loading.gif" alt="loading" />
+        <img class="loading-image" src="/assets/transition-page/images/loading.gif" alt="loading" />
         <div class="footer">
-            <img src="./assets/transition-page/icons/go-logo.svg" alt="go logo" />
+            <img src="/assets/transition-page/icons/go-logo.svg" alt="go logo" />
             <p>You will only be shown this page the first time you access this short link.</p>
         </div>
     </div>
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= gaTrackingId %>"></script>
-    <script src="./assets/transition-page/js/redirect.js"></script>
+    <script src="/assets/transition-page/js/redirect.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Problem

Closes #427 

## Solution
- Ensure all requested assets are relative to the site root
- Add cdn.jsdelivr.net to the CSP allow list for SGDS resources
- Ensure that only GETs to `/short-url` and nothing else are redirected, everything else is 404

## Screenshots

![image](https://user-images.githubusercontent.com/10572368/90581024-d03eb480-e1fc-11ea-834a-d321948d5ef7.png)


```
# Before
::ffff:127.0.0.1 - [19/Aug/2020:01:24:05 +0000] "GET /haha/assets HTTP/1.1" 302 "https://google.com" "-" 80 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36" 2.625 ms
# After
::ffff:127.0.0.1 - [19/Aug/2020:01:41:12 +0000] "GET /haha/assets HTTP/1.1" 404 "-" "-" 1780 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36" 9.094 ms
::ffff:127.0.0.1 - [19/Aug/2020:01:56:24 +0000] "GET /haha/ HTTP/1.1" 302 "https://google.com" "-" 80 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36" 61.161 ms
```