### PR TITLE
fix(search): omit most params in querystring if default

### DIFF
--- a/src/client/components/SearchPage/index.tsx
+++ b/src/client/components/SearchPage/index.tsx
@@ -54,9 +54,16 @@ const defaultParams: GoSearchParams = {
 }
 
 const redirectWithParams = (newParams: GoSearchParams, history: History) => {
+  // Always ensure that the query is populated
+  const queryObject: any = { query: newParams.query }
+  for (const [ key, value ] of Object.entries(newParams)) {
+    if (value && value !== (defaultParams as any)[key]) {
+        queryObject[key] = value
+    }
+  }
   const newPath = {
     pathname: SEARCH_PAGE,
-    search: `${querystring.stringify(newParams)}`,
+    search: `${querystring.stringify(queryObject)}`,
   }
   history.push(newPath)
 }


### PR DESCRIPTION
## Problem

Closes #323 

## Solution

- copy `newParams` in `redirectWithParams()`, ensuring that query
  is always populated
- for each param in `newParams`, if its value differs from default,
  populate in the copy. This results in an object omitting defaults
  from the querystring

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/10572368/90708195-ce8ff200-e2cb-11ea-9fc9-d37691fa9185.png)
