### PR TITLE
fix(csp): allow doubleclick for img and connect

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -69,7 +69,11 @@ const MORGAN_LOG_FORMAT =
   ':client-ip - [:date[clf]] ":method :url HTTP/:http-version" :status ' +
   '":redirectUrl" ":userId" :res[content-length] ":referrer" ":user-agent" :response-time ms'
 
-const connectSrc = ["'self'", 'www.google-analytics.com']
+const connectSrc = [
+  "'self'",
+  'www.google-analytics.com',
+  'stats.g.doubleclick.net',
+]
 if (cspReportUri) {
   connectSrc.push(parseDomain(cspReportUri))
 }
@@ -95,6 +99,7 @@ app.use(
           'data:',
           'www.google-analytics.com',
           'www.googletagmanager.com',
+          'stats.g.doubleclick.net',
         ],
         scriptSrc: [
           "'self'",


### PR DESCRIPTION
## Problem and Solution

Add doubleclick.net to the list of allowed domains for CSP
so that Google Tag Manager and GA can function