### PR TITLE
feat(redirect): allow trailing period in shortlink

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -176,7 +176,7 @@ initDb()
       redirectController.gtagForTransitionPage,
     )
     app.get(
-      '/:shortUrl([a-zA-Z0-9-]+)',
+      '/:shortUrl([a-zA-Z0-9-]+).?',
       ...redirectSpecificMiddleware,
       redirectController.redirect,
     ) // The Redirect Endpoint


### PR DESCRIPTION
## Problem

When shortlinks are distributed, they are occasionally included in sentences and therefore have a period appended to them. Some devices aren't smart enough at parsing these shortlinks and include them in the request, causing 404 errors to occur.

## Solution

A simple solution would be to tweak the regex of the redirect `.get(...)` middleware to account for a possible trailing period in the shorturl and ignore it in the handler.
