### PR TITLE
refactor(file-upload): cloudmersive failures now return HTTP 400 Bad Request to client

### DIFF
--- a/src/server/controllers/FileCheckController.ts
+++ b/src/server/controllers/FileCheckController.ts
@@ -50,14 +50,16 @@ export class FileCheckController implements FileCheckControllerInterface {
         if (hasVirus) {
           const user = req.session?.user as UserType
           logger.warn(
-            `Malicious link attempt: User ${user?.id} tried to upload ${file.name}`,
+            `Malicious file attempt: User ${user?.id} tried to upload ${file.name}`,
           )
           res.badRequest(jsonMessage('File is likely to be malicious.'))
           return
         }
       } catch (error) {
-        logger.error('Unable to check file: ', error)
-        res.serverError(jsonMessage(error.message))
+        logger.error('Unable to scan file: ', error)
+        res.badRequest(
+          jsonMessage('Your file could not be scanned by antivirus software.'),
+        )
         return
       }
     }

--- a/test/server/controllers/FileCheckController.test.ts
+++ b/test/server/controllers/FileCheckController.test.ts
@@ -60,20 +60,20 @@ describe('FileCheckController test', () => {
     expect(next).not.toHaveBeenCalled()
   })
 
-  it('returns server error on virus scan failure', async () => {
+  it('returns bad request on virus scan failure', async () => {
     const req = createRequestWithFile(file)
     const res = httpMocks.createResponse() as any
     const next = jest.fn()
 
     hasAllowedType.mockResolvedValue(true)
     hasVirus.mockRejectedValue(false)
-    res.serverError = badRequest
+    res.badRequest = badRequest
 
     await controller.checkFile(req, res, next)
 
     expect(hasAllowedType).toHaveBeenCalled()
     expect(hasVirus).toHaveBeenCalled()
-    expect(res.serverError).toHaveBeenCalled()
+    expect(res.badRequest).toHaveBeenCalled()
     expect(next).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Problem

Using HTTP 500 Internal Server Error presumes that the problem lies with the server; however
Cloudmersive is clearly rejecting the file as a client error.

## Solution

Change the HTTP Status Code returned and updated the response message.
