### PR TITLE
Allow drag-and-drop to upload files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6321,6 +6321,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "attr-accept": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.1.tgz",
+      "integrity": "sha512-GpefLMsbH5ojNgfTW+OBin2xKzuHfyeNA+qCktzZojBhbA/lPZdCFMWdwk5ajb989Ok7ZT+EADqvW3TAFNMjhA=="
+    },
     "aws-sdk": {
       "version": "2.738.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.738.0.tgz",
@@ -11146,6 +11151,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
       "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
+    "file-selector": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.12.tgz",
+      "integrity": "sha512-Kx7RTzxyQipHuiqyZGf+Nz4vY9R1XGxuQl/hLoJwq+J4avk/9wxxgZyHKtbyIPJmbD4A66DWGYfyykWNpcYutQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "file-type": {
       "version": "15.0.0",
@@ -19043,6 +19056,16 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-dropzone": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.0.3.tgz",
+      "integrity": "sha512-+MoMOoKZfkZ9i1+qEFl2ZU29AB/c9K2bFxyACqGynguJunmqO+k2PJ2AcuiH51xVNl9R7q/x5QdBaIWb6RtoSw==",
+      "requires": {
+        "attr-accept": "^2.0.0",
+        "file-selector": "^0.1.12",
+        "prop-types": "^15.7.2"
       }
     },
     "react-i18next": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react": "^16.13.1",
     "react-chartjs-2": "^2.10.0",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.0.3",
     "react-i18next": "^11.7.2",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -189,7 +189,7 @@ function CreateLinkForm({
                 text={
                   file
                     ? file.name
-                    : 'Drag and drop some files here, or click to select files'
+                    : 'Drag and drop your file here, or click to select file'
                 }
                 uploadFileError={uploadFileError}
                 inputId="file"

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -184,7 +184,11 @@ function CreateLinkForm({
               </div>
               <FileInputField
                 textFieldHeight={TEXT_FIELD_HEIGHT}
-                text={file ? file.name : 'No file selected'}
+                text={
+                  file
+                    ? file.name
+                    : 'Drag and drop some files here, or click to select files'
+                }
                 uploadFileError={uploadFileError}
                 inputId="file"
                 setFile={setFile}

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -30,6 +30,8 @@ import userActions from '~/actions/user'
 
 // Height of the text field in the create link dialog.
 const TEXT_FIELD_HEIGHT = 44
+// Height of the droppable area for file upload.
+const FILE_DROP_ZONE_HEIGHT = 160
 
 const FormStartAdorment = ({ children }) => {
   const classes = useCreateLinkFormStyles({
@@ -183,7 +185,7 @@ function CreateLinkForm({
                 </div>
               </div>
               <FileInputField
-                textFieldHeight={TEXT_FIELD_HEIGHT}
+                fileDropZoneHeight={FILE_DROP_ZONE_HEIGHT}
                 text={
                   file
                     ? file.name
@@ -199,19 +201,8 @@ function CreateLinkForm({
                       variant="body2"
                       className={classes.fileSizeText}
                     >
-                      {file ? formatBytes(file.size) : ''}
+                      {file ? `(${formatBytes(file.size)})` : ''}
                     </Typography>
-                    <label htmlFor="file">
-                      <Button
-                        variant="contained"
-                        className={classes.uploadFileButton}
-                        component="span"
-                        color="primary"
-                        disabled={isUploading}
-                      >
-                        Browse
-                      </Button>
-                    </label>
                   </div>
                 }
               />

--- a/src/client/components/UserPage/CreateUrlModal/styles/createLinkForm.ts
+++ b/src/client/components/UserPage/CreateUrlModal/styles/createLinkForm.ts
@@ -154,7 +154,6 @@ const useCreateLinkFormStyles = makeStyles((theme) =>
       fontWeight: 400,
       display: 'flex',
       alignItems: 'center',
-      paddingRight: theme.spacing(1.5),
     },
     uploadFileInputEndWrapper: {
       display: 'flex',

--- a/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/index.tsx
@@ -351,7 +351,7 @@ export default function ControlPanel() {
                   <FileInputField
                     className={classes.fileInputField}
                     uploadFileError={uploadFileError}
-                    textFieldHeight="44px"
+                    fileDropZoneHeight="160px"
                     inputId="replace-file-input"
                     text={originalLongUrl}
                     setFile={(newFile) => {

--- a/src/client/components/UserPage/widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/widgets/FileInputField.tsx
@@ -1,7 +1,8 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useCallback } from 'react'
 import { Hidden, Typography, makeStyles, createStyles } from '@material-ui/core'
 import FileIconLarge from './FileIconLarge'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
+import { useDropzone } from 'react-dropzone'
 
 type FileInputFieldStyleProps = {
   uploadFileError: string | null
@@ -35,9 +36,6 @@ const useStyles = makeStyles((theme) =>
       paddingLeft: '16px',
       display: 'flex',
       alignItems: 'center',
-    },
-    fileInputInvis: {
-      display: 'none',
     },
     leftFileIcon: {
       width: '44px',
@@ -76,8 +74,31 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   className,
 }) => {
   const classes = useStyles({ textFieldHeight, uploadFileError })
+  const onDrop = useCallback((acceptedFiles) => {
+    if (!acceptedFiles) {
+      return
+    }
+
+    const chosenFile = acceptedFiles[0];
+    if (!chosenFile) {
+      return
+    }
+
+    if (chosenFile.size > MAX_FILE_UPLOAD_SIZE) {
+      setFile(null)
+      setUploadFileError(
+        'File too large, please upload a file smaller than 10mb',
+      )
+      return
+    }
+
+    setUploadFileError(null)
+    setFile(chosenFile)
+  }, [])
+  const { getRootProps, getInputProps } = useDropzone({ onDrop });
+
   return (
-    <div className={`${classes.fileInputWrapper} ${className}`}>
+    <div {...getRootProps({ className: `${classes.fileInputWrapper} ${className || ''}` })}>
       <Hidden smDown>
         <div className={classes.leftFileIcon}>
           <FileIconLarge color="#f9f9f9" />
@@ -87,28 +108,10 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
         <Typography variant="body2" className={classes.fileNameText}>
           {text}
         </Typography>
+
         <input
-          type="file"
+          {...getInputProps()}
           id={inputId}
-          className={classes.fileInputInvis}
-          onChange={(event) => {
-            if (!event.target.files) {
-              return
-            }
-            const chosenFile = event.target.files[0]
-            if (!chosenFile) {
-              return
-            }
-            if (chosenFile.size > MAX_FILE_UPLOAD_SIZE) {
-              setFile(null)
-              setUploadFileError(
-                'File too large, please upload a file smaller than 10mb',
-              )
-              return
-            }
-            setUploadFileError(null)
-            setFile(chosenFile)
-          }}
         />
         {endAdornment}
       </div>

--- a/src/client/components/UserPage/widgets/FileInputField.tsx
+++ b/src/client/components/UserPage/widgets/FileInputField.tsx
@@ -1,17 +1,16 @@
 import React, { FunctionComponent, useCallback } from 'react'
-import { Hidden, Typography, makeStyles, createStyles } from '@material-ui/core'
-import FileIconLarge from './FileIconLarge'
+import { Typography, makeStyles, createStyles } from '@material-ui/core'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../../shared/constants'
 import { useDropzone } from 'react-dropzone'
 
 type FileInputFieldStyleProps = {
   uploadFileError: string | null
-  textFieldHeight: number | string
+  fileDropZoneHeight: number | string
 }
 
 type FileInputFieldProps = {
   uploadFileError: string | null
-  textFieldHeight: number | string
+  fileDropZoneHeight: number | string
   text: string
   endAdornment?: JSX.Element
   inputId: string
@@ -20,51 +19,35 @@ type FileInputFieldProps = {
   className?: string
 }
 
-const useStyles = makeStyles((theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
-    fileInputWrapper: {
-      width: '100%',
-      display: 'flex',
-      alignItems: 'stretch',
-      borderRadius: '3px',
-      overflow: 'hidden',
-      border: (props: FileInputFieldStyleProps) =>
-        props.uploadFileError ? '2px solid #C85151' : '',
-    },
     fileNameText: {
       fontWeight: 400,
-      paddingLeft: '16px',
       display: 'flex',
+      flexDirection: 'column',
       alignItems: 'center',
     },
-    leftFileIcon: {
-      width: '44px',
-      backgroundColor: '#456682',
+    dropZone: {
+      flex: 1,
       display: 'flex',
-      alignItems: 'center',
+      flexDirection: 'column',
       justifyContent: 'center',
-    },
-    fileInput: {
-      flexGrow: 1,
-      height: '100%',
-      minHeight: (props: FileInputFieldStyleProps) => props.textFieldHeight,
-      padding: theme.spacing(0),
-      lineHeight: 1.5,
-      backgroundColor: '#d8d8d8',
-      display: 'flex',
-      alignItems: 'stretch',
-      overflow: 'hidden',
-      justifyContent: 'space-between',
-      borderRadius: '3px',
-      [theme.breakpoints.up('sm')]: {
-        backgroundColor: '#e8e8e8',
-      },
+      alignItems: 'center',
+      minHeight: (props: FileInputFieldStyleProps) => props.fileDropZoneHeight,
+      padding: 20,
+      borderRadius: 2,
+      border: (props: FileInputFieldStyleProps) =>
+        props.uploadFileError ? '2px dashed #C85151' : '2px dashed rgba(0, 0, 0, 0.23)',
+      backgroundColor: '#4566821A',
+      color: '#384a51',
+      outline: 'none',
+      transition: 'border .24s ease-in-out',
     },
   }),
 )
 
 export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
-  textFieldHeight,
+  fileDropZoneHeight,
   text,
   uploadFileError,
   endAdornment,
@@ -73,7 +56,7 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   setUploadFileError,
   className,
 }) => {
-  const classes = useStyles({ textFieldHeight, uploadFileError })
+  const classes = useStyles({ fileDropZoneHeight, uploadFileError })
   const onDrop = useCallback((acceptedFiles) => {
     if (!acceptedFiles) {
       return
@@ -98,23 +81,17 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   const { getRootProps, getInputProps } = useDropzone({ onDrop });
 
   return (
-    <div {...getRootProps({ className: `${classes.fileInputWrapper} ${className || ''}` })}>
-      <Hidden smDown>
-        <div className={classes.leftFileIcon}>
-          <FileIconLarge color="#f9f9f9" />
-        </div>
-      </Hidden>
-      <div className={classes.fileInput}>
-        <Typography variant="body2" className={classes.fileNameText}>
-          {text}
-        </Typography>
+    <div {...getRootProps({ className: `${classes.dropZone} ${className || ''}` })}>
+      <Typography variant="body2" className={classes.fileNameText}>
+        {text}
+      </Typography>
 
-        <input
-          {...getInputProps()}
-          id={inputId}
-        />
-        {endAdornment}
-      </div>
+      <input
+        {...getInputProps()}
+        id={inputId}
+      />
+
+      {endAdornment}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Closes #190

## Solution

Installed react-dropzone and implement it.

Note:
- when dragging a file over the droppable area, a different cursor will be displayed to indicate that the area is droppable.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/6182649/90916203-3b61d400-e413-11ea-95e2-19326de18742.png)

**AFTER**:
before file upload
![image](https://user-images.githubusercontent.com/6182649/90959343-0e71f780-e4cd-11ea-827d-411ef50cd614.png)

after file upload
![image](https://user-images.githubusercontent.com/6182649/90959353-20539a80-e4cd-11ea-87f8-62356f349036.png)

**BEFORE**:
![image](https://user-images.githubusercontent.com/6182649/90916071-02296400-e413-11ea-905a-6e3cddf22a9f.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/6182649/90959380-52fd9300-e4cd-11ea-96d5-41786a8c39f8.png)

## Tests

No test was written. Manual test is required.

Test cases:
- upload file by drag and drop to the area
- upload file by clicking the area to open file dialog 

Note: file input component is used in two places:
- when adding a new link with file
- when editing a link created with uploaded file

## Deploy Notes

**New dependencies**:

- `react-dropzone` : Simple React hook to create a HTML5-compliant drag'n'drop zone for files.

