### PR TITLE
feat(links): redesign create URL modal

### DIFF
--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -514,7 +514,6 @@ const urlCreated = (
   dispatch<SetSuccessMessageAction>(
     rootActions.setSuccessMessage(successMessage),
   )
-  dispatch<CloseCreateUrlModalAction>(closeCreateUrlModal())
 }
 
 //

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -517,9 +517,14 @@ const urlCreated = (
   dispatch<CloseCreateUrlModalAction>(closeCreateUrlModal())
 }
 
-// API call to create URL
-// If user is not logged in, the createUrl call returns unauthorized,
-// get them to login, else create the url.
+//
+/**
+ * API call to create URL
+ * If user is not logged in, the createUrl call returns unauthorized,
+ * get them to login, else create the url.
+ * @param history
+ * @returns Promise<bool> Whether creation succeeded.
+ */
 const createUrlOrRedirect = (history: History) => async (
   dispatch: ThunkDispatch<
     GoGovReduxState,
@@ -543,7 +548,7 @@ const createUrlOrRedirect = (history: History) => async (
         'Short links should only consist of a-z, 0-9 and hyphens.',
       ),
     )
-    return
+    return false
   }
 
   // Append https:// as the protocol is stripped out
@@ -556,7 +561,7 @@ const createUrlOrRedirect = (history: History) => async (
     dispatch<SetErrorMessageAction>(
       rootActions.setErrorMessage('URL is invalid.'),
     )
-    return
+    return false
   }
 
   const response = await postJson('/api/user/url', { longUrl, shortUrl })
@@ -564,13 +569,14 @@ const createUrlOrRedirect = (history: History) => async (
   if (!response.ok) {
     if (response.status === 401) {
       history.push(LOGIN_PAGE)
-      return
+      return false
     }
     handleError(dispatch, response)
-    return
+    return false
   }
   const json = await response.json()
   urlCreated(dispatch, json.shortUrl)
+  return true
 }
 
 const transferOwnership = (
@@ -604,6 +610,11 @@ const transferOwnership = (
     },
   )
 
+/**
+ * API call to upload a file.
+ * @param file
+ * @returns Promise<bool> Whether file upload succeeded.
+ */
 const uploadFile = (file: File) => async (
   dispatch: ThunkDispatch<
     GoGovReduxState,
@@ -624,7 +635,7 @@ const uploadFile = (file: File) => async (
     dispatch<SetErrorMessageAction>(
       rootActions.setErrorMessage('File is missing.'),
     )
-    return
+    return false
   }
   dispatch<SetIsUploadingAction>(setIsUploading(true))
   const data = new FormData()
@@ -634,10 +645,11 @@ const uploadFile = (file: File) => async (
   dispatch<SetIsUploadingAction>(setIsUploading(false))
   if (!response.ok) {
     await handleError(dispatch, response)
-    return
+    return false
   }
   const json = await response.json()
   urlCreated(dispatch, json.shortUrl)
+  return true
 }
 
 export default {

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -516,7 +516,6 @@ const urlCreated = (
   )
 }
 
-//
 /**
  * API call to create URL
  * If user is not logged in, the createUrl call returns unauthorized,

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+import LinkInfoEditor from '../widgets/LinkInfoEditor'
+import ModalMargins from './ModalMargins'
+
+type AddDescriptionFormProps = {}
+
+export default function AddDescriptionForm(_: AddDescriptionFormProps) {
+  const [contactEmail, setContactEmail] = useState('')
+  const [isContactEmailValid, setIsContactEmailValid] = useState(true)
+  const [description, setDescription] = useState('')
+  const [isDescriptionValid, setIsDescriptionValid] = useState(true)
+  const onContactEmailChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setContactEmail(event.target.value)
+  const onDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setDescription(event.target.value)
+
+  return (
+    <div>
+      {/* Temporarily suppress unusued variable name error. */}
+      {isContactEmailValid && !isContactEmailValid && isDescriptionValid
+        ? 'hi'
+        : null}
+      <ModalMargins>
+        <LinkInfoEditor
+          contactEmail={contactEmail}
+          description={description}
+          onContactEmailChange={onContactEmailChange}
+          onDescriptionChange={onDescriptionChange}
+          onContactEmailValidation={setIsContactEmailValid}
+          onDescriptionValidation={setIsDescriptionValid}
+        />
+      </ModalMargins>
+    </div>
+  )
+}

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -16,8 +16,9 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       [theme.breakpoints.up('md')]: {
         flexDirection: 'row',
+        marginBottom: 50,
       },
-      marginBottom: 50,
+      marginBottom: 80,
     },
     skipButton: {
       width: '100%',

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -45,6 +45,10 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
   const onDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setDescription(event.target.value)
 
+  const isBothFieldsBlank = contactEmail === '' && description === ''
+  const isContainsInvalidField = !(isContactEmailValid && isDescriptionValid)
+  const isSaveButtonDisabled = isBothFieldsBlank || isContainsInvalidField
+
   return (
     <div>
       {/* Temporarily suppress unusued variable name error. */}
@@ -74,6 +78,7 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
             Skip for now
           </Button>
           <Button
+            disabled={isSaveButtonDisabled}
             color="primary"
             size="large"
             variant="outlined"

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -9,6 +9,9 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
   const [isContactEmailValid, setIsContactEmailValid] = useState(true)
   const [description, setDescription] = useState('')
   const [isDescriptionValid, setIsDescriptionValid] = useState(true)
+  const [isSearchable, setIsSearchable] = useState(true)
+  const onIsSearchableChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setIsSearchable(event.target.checked)
   const onContactEmailChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setContactEmail(event.target.value)
   const onDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) =>
@@ -28,6 +31,9 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
           onDescriptionChange={onDescriptionChange}
           onContactEmailValidation={setIsContactEmailValid}
           onDescriptionValidation={setIsDescriptionValid}
+          isSearchable={isSearchable}
+          onIsSearchableChange={onIsSearchableChange}
+          isMountedOnCreateUrlModal
         />
       </ModalMargins>
     </div>

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles((theme) =>
   createStyles({
     shortUrlText: {
       marginBottom: 8,
+      marginTop: 8,
     },
     buttonWrapper: {
       display: 'flex',

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import { Button, createStyles, makeStyles } from '@material-ui/core'
 import LinkInfoEditor from '../widgets/LinkInfoEditor'
 import ModalMargins from './ModalMargins'
+import userActions from '../../../actions/user'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -33,6 +35,10 @@ type AddDescriptionFormProps = {}
 
 export default function AddDescriptionForm(_: AddDescriptionFormProps) {
   const classes = useStyles()
+
+  const dispatch = useDispatch()
+  const closeCreateUrlModal = () => dispatch(userActions.closeCreateUrlModal())
+
   const [contactEmail, setContactEmail] = useState('')
   const [isContactEmailValid, setIsContactEmailValid] = useState(true)
   const [description, setDescription] = useState('')
@@ -69,7 +75,7 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
         />
         <div className={classes.buttonWrapper}>
           <Button
-            onClick={() => {}}
+            onClick={closeCreateUrlModal}
             size="large"
             color="primary"
             variant="text"

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -1,10 +1,38 @@
 import React, { useState } from 'react'
+import { Button, createStyles, makeStyles } from '@material-ui/core'
 import LinkInfoEditor from '../widgets/LinkInfoEditor'
 import ModalMargins from './ModalMargins'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    buttonWrapper: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      flexDirection: 'column',
+      [theme.breakpoints.up('md')]: {
+        flexDirection: 'row',
+      },
+      marginBottom: 50,
+    },
+    skipButton: {
+      width: '100%',
+      [theme.breakpoints.up('md')]: {
+        maxWidth: 135,
+      },
+    },
+    saveButton: {
+      width: '100%',
+      [theme.breakpoints.up('md')]: {
+        maxWidth: 135,
+      },
+    },
+  }),
+)
 
 type AddDescriptionFormProps = {}
 
 export default function AddDescriptionForm(_: AddDescriptionFormProps) {
+  const classes = useStyles()
   const [contactEmail, setContactEmail] = useState('')
   const [isContactEmailValid, setIsContactEmailValid] = useState(true)
   const [description, setDescription] = useState('')
@@ -35,6 +63,25 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
           onIsSearchableChange={onIsSearchableChange}
           isMountedOnCreateUrlModal
         />
+        <div className={classes.buttonWrapper}>
+          <Button
+            onClick={() => {}}
+            size="large"
+            color="primary"
+            variant="text"
+            className={classes.skipButton}
+          >
+            Skip for now
+          </Button>
+          <Button
+            color="primary"
+            size="large"
+            variant="outlined"
+            className={classes.saveButton}
+          >
+            Save
+          </Button>
+        </div>
       </ModalMargins>
     </div>
   )

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Button, createStyles, makeStyles } from '@material-ui/core'
+import { Button, Typography, createStyles, makeStyles } from '@material-ui/core'
 import LinkInfoEditor from '../widgets/LinkInfoEditor'
 import ModalMargins from './ModalMargins'
 import { patch } from '../../../util/requests'
@@ -10,6 +10,9 @@ import { GoGovReduxState } from '../../../reducers/types'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
+    shortUrlText: {
+      marginBottom: 8,
+    },
     buttonWrapper: {
       display: 'flex',
       justifyContent: 'flex-end',
@@ -81,11 +84,13 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
 
   return (
     <div>
-      {/* Temporarily suppress unusued variable name error. */}
-      {isContactEmailValid && !isContactEmailValid && isDescriptionValid
-        ? 'hi'
-        : null}
       <ModalMargins>
+        <Typography variant="body2" className={classes.shortUrlText}>
+          <strong>
+            go.gov.sg/
+            {shortUrl}
+          </strong>
+        </Typography>
         <LinkInfoEditor
           contactEmail={contactEmail}
           description={description}

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) =>
     buttonWrapper: {
       display: 'flex',
       justifyContent: 'flex-end',
-      flexDirection: 'column',
+      flexDirection: 'column-reverse',
       [theme.breakpoints.up('md')]: {
         flexDirection: 'row',
         marginBottom: 50,

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -49,8 +49,6 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
   const [description, setDescription] = useState('')
   const [isDescriptionValid, setIsDescriptionValid] = useState(true)
   const [isSearchable, setIsSearchable] = useState(true)
-  const onIsSearchableChange = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setIsSearchable(event.target.checked)
   const onContactEmailChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setContactEmail(event.target.value)
   const onDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) =>
@@ -72,6 +70,25 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
       dispatch(userActions.getUrlsForUser())
       dispatch(rootActions.setSuccessMessage('URL is updated.'))
       closeCreateUrlModal()
+      return
+    }
+
+    const jsonResponse = await response.json()
+    dispatch(rootActions.setErrorMessage(jsonResponse.message))
+  }
+  const toggleLinkSearchable = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newIsSearchable = event.target.checked
+    const response = await patch('/api/user/url', {
+      isSearchable: newIsSearchable,
+      shortUrl,
+    })
+
+    if (response.ok) {
+      dispatch(userActions.getUrlsForUser())
+      dispatch(rootActions.setSuccessMessage('URL is updated.'))
+      setIsSearchable(newIsSearchable)
       return
     }
 
@@ -100,7 +117,7 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
           onContactEmailValidation={setIsContactEmailValid}
           onDescriptionValidation={setIsDescriptionValid}
           isSearchable={isSearchable}
-          onIsSearchableChange={onIsSearchableChange}
+          onIsSearchableChange={toggleLinkSearchable}
           isMountedOnCreateUrlModal
         />
         <div className={classes.buttonWrapper}>

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -111,7 +111,7 @@ export default function AddDescriptionForm(_: AddDescriptionFormProps) {
             disabled={isSaveButtonDisabled}
             color="primary"
             size="large"
-            variant="outlined"
+            variant="contained"
             className={classes.saveButton}
           >
             Save

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -39,9 +39,7 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-type AddDescriptionFormProps = {}
-
-export default function AddDescriptionForm(_: AddDescriptionFormProps) {
+export default function AddDescriptionForm() {
   const classes = useStyles()
 
   const [contactEmail, setContactEmail] = useState('')

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -309,9 +309,9 @@ CreateLinkForm.propTypes = {
   setLongUrl: PropTypes.func.isRequired,
   setRandomShortUrl: PropTypes.func.isRequired,
   isUploading: PropTypes.bool.isRequired,
-  uploadFileError: PropTypes.string.isRequired,
+  uploadFileError: PropTypes.string,
   setUploadFileError: PropTypes.func.isRequired,
-  createShortLinkError: PropTypes.string.isRequired,
+  createShortLinkError: PropTypes.string,
   setCreateShortLinkError: PropTypes.func.isRequired,
 }
 

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -56,7 +56,6 @@ const mapDispatchToProps = (dispatch) => ({
   setShortUrl: (shortUrl) => dispatch(userActions.setShortUrl(shortUrl)),
   setLongUrl: (longUrl) => dispatch(userActions.setLongUrl(longUrl)),
   setRandomShortUrl: () => dispatch(userActions.setRandomShortUrl()),
-  onSubmitFile: (file) => dispatch(userActions.uploadFile(file)),
   setUploadFileError: (error) =>
     dispatch(userActions.setUploadFileError(error)),
   setCreateShortLinkError: (error) =>

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -98,7 +98,9 @@ const CreateUrlModal = ({
               variant={isFullScreenDialog ? 'h6' : 'h3'}
               color="primary"
             >
-              {step === 0 ? 'Create new link' : 'Add description'}
+              {step === 0
+                ? 'Create new link'
+                : "Done! You can now customise your link's visibility"}
             </Typography>
             <IconButton
               className={classes.closeIconButton}

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -77,6 +77,9 @@ const CreateUrlModal = ({
   const history = useHistory()
   const onSubmitLink = incrementDecorator(() => onCreateUrl(history))
   const onSubmitFile = incrementDecorator(onUploadFile)
+
+  // Reset step when modal closes and reopens
+  useEffect(() => setStep(0), [createUrlModal])
   return (
     <Dialog
       aria-labelledby="createUrlModal"

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -98,7 +98,7 @@ const CreateUrlModal = ({
               variant={isFullScreenDialog ? 'h6' : 'h3'}
               color="primary"
             >
-              Create new link
+              {step === 0 ? 'Create new link' : 'Add description'}
             </Typography>
             <IconButton
               className={classes.closeIconButton}

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -67,8 +67,16 @@ const CreateUrlModal = ({
 }) => {
   const isFullScreenDialog = useFullScreenDialog()
   const classes = useStyles({ isFullScreenDialog })
+  const [step, setStep] = useState(0)
+  const incrementDecorator = (func) => async (...args) => {
+    const proceed = await func(...args)
+    if (proceed) {
+      setStep(step + 1)
+    }
+  }
   const history = useHistory()
-  const onSubmit = () => onCreateUrl(history)
+  const onSubmitLink = incrementDecorator(() => onCreateUrl(history))
+  const onSubmitFile = incrementDecorator(onUploadFile)
   return (
     <Dialog
       aria-labelledby="createUrlModal"
@@ -99,7 +107,7 @@ const CreateUrlModal = ({
           </div>
         </ModalMargins>
       </div>
-      <CreateLinkForm onSubmitLink={onSubmit} onSubmitFile={onUploadFile} />
+      <CreateLinkForm onSubmitLink={onSubmitLink} onSubmitFile={onSubmitFile} />
     </Dialog>
   )
 }

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -80,7 +80,9 @@ const CreateUrlModal = ({
   const onSubmitFile = incrementDecorator(onUploadFile)
 
   // Reset step when modal closes and reopens
-  useEffect(() => setStep(0), [createUrlModal])
+  useEffect(() => {
+    if (createUrlModal) setStep(0)
+  }, [createUrlModal])
   return (
     <Dialog
       aria-labelledby="createUrlModal"

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { useHistory } from 'react-router-dom'
 import {
   Dialog,
   IconButton,
@@ -54,11 +55,18 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   closeCreateUrlModal: () => dispatch(userActions.closeCreateUrlModal()),
+  onCreateUrl: (history) => dispatch(userActions.createUrlOrRedirect(history)),
 })
 
-const CreateUrlModal = ({ createUrlModal, closeCreateUrlModal, onSubmit }) => {
+const CreateUrlModal = ({
+  createUrlModal,
+  closeCreateUrlModal,
+  onCreateUrl,
+}) => {
   const isFullScreenDialog = useFullScreenDialog()
   const classes = useStyles({ isFullScreenDialog })
+  const history = useHistory()
+  const onSubmit = () => onCreateUrl(history)
   return (
     <Dialog
       aria-labelledby="createUrlModal"
@@ -95,7 +103,7 @@ const CreateUrlModal = ({ createUrlModal, closeCreateUrlModal, onSubmit }) => {
 }
 
 CreateUrlModal.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
+  onCreateUrl: PropTypes.func.isRequired,
   createUrlModal: PropTypes.bool.isRequired,
   closeCreateUrlModal: PropTypes.func.isRequired,
 }

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -14,7 +14,8 @@ import CloseIcon from '../../widgets/CloseIcon'
 import CreateLinkForm from './CreateLinkForm'
 import useFullScreenDialog from './helpers/fullScreenDialog'
 import ModalMargins from './ModalMargins'
-import userActions from '~/actions/user'
+import userActions from '../../../actions/user'
+import AddDescriptionForm from './AddDescriptionForm'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -112,7 +113,14 @@ const CreateUrlModal = ({
           </div>
         </ModalMargins>
       </div>
-      <CreateLinkForm onSubmitLink={onSubmitLink} onSubmitFile={onSubmitFile} />
+      {step === 0 ? (
+        <CreateLinkForm
+          onSubmitLink={onSubmitLink}
+          onSubmitFile={onSubmitFile}
+        />
+      ) : (
+        <AddDescriptionForm />
+      )}
     </Dialog>
   )
 }

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -56,12 +56,14 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   closeCreateUrlModal: () => dispatch(userActions.closeCreateUrlModal()),
   onCreateUrl: (history) => dispatch(userActions.createUrlOrRedirect(history)),
+  onUploadFile: (file) => dispatch(userActions.uploadFile(file)),
 })
 
 const CreateUrlModal = ({
   createUrlModal,
   closeCreateUrlModal,
   onCreateUrl,
+  onUploadFile,
 }) => {
   const isFullScreenDialog = useFullScreenDialog()
   const classes = useStyles({ isFullScreenDialog })
@@ -97,13 +99,14 @@ const CreateUrlModal = ({
           </div>
         </ModalMargins>
       </div>
-      <CreateLinkForm onSubmitLink={onSubmit} />
+      <CreateLinkForm onSubmitLink={onSubmit} onSubmitFile={onUploadFile} />
     </Dialog>
   )
 }
 
 CreateUrlModal.propTypes = {
   onCreateUrl: PropTypes.func.isRequired,
+  onUploadFile: PropTypes.func.isRequired,
   createUrlModal: PropTypes.bool.isRequired,
   closeCreateUrlModal: PropTypes.func.isRequired,
 }

--- a/src/client/components/UserPage/index.jsx
+++ b/src/client/components/UserPage/index.jsx
@@ -21,7 +21,6 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-  onCreateUrl: (history) => dispatch(userActions.createUrlOrRedirect(history)),
   getUrlsForUser: () => dispatch(userActions.getUrlsForUser()),
   getEmailValidator: () =>
     dispatch(loginActions.getEmailValidationGlobExpression()),
@@ -33,8 +32,6 @@ const mapDispatchToProps = (dispatch) => ({
  */
 const UserPage = ({
   isLoggedIn,
-  onCreateUrl,
-  history,
   getUrlsForUser,
   getEmailValidator,
   emailValidator,
@@ -73,7 +70,7 @@ const UserPage = ({
           ) : (
             <UserLinkTable />
           )}
-          <CreateUrlModal onSubmit={() => onCreateUrl(history)} />
+          <CreateUrlModal />
         </Drawer>
       </BaseLayout>
     )

--- a/src/client/components/UserPage/widgets/LinkInfoEditor.tsx
+++ b/src/client/components/UserPage/widgets/LinkInfoEditor.tsx
@@ -19,8 +19,11 @@ import BetaTag from '../../widgets/BetaTag'
 import CollapsibleMessage from '../../CollapsibleMessage'
 import ConfigOption, { TrailingPosition } from './ConfigOption'
 import PrefixableTextField from './PrefixableTextField'
-import { CollapsibleMessageType, CollapsibleMessagePosition } from '../../CollapsibleMessage/types'
 import GoSwitch from './GoSwitch'
+import {
+  CollapsibleMessagePosition,
+  CollapsibleMessageType,
+} from '../../CollapsibleMessage/types'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -75,17 +78,19 @@ type LinkInfoEditorProps = {
   onDescriptionChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onContactEmailValidation: (isContactEmailValid: boolean) => void
   onDescriptionValidation: (isDescriptionValid: boolean) => void
+  isMountedOnCreateUrlModal?: boolean
 }
 
 export default function LinkInfoEditor({
   isSearchable,
-  contactEmail, 
+  contactEmail,
   description,
-  onIsSearchableChange, 
+  onIsSearchableChange,
   onContactEmailChange,
   onDescriptionChange,
   onContactEmailValidation,
   onDescriptionValidation,
+  isMountedOnCreateUrlModal,
 }: LinkInfoEditorProps) {
   // Styles used in this component.
   const classes = useStyles()
@@ -96,25 +101,18 @@ export default function LinkInfoEditor({
     (state) => state.login.emailValidator,
   )
 
-  const isContactEmailValid =
-    !contactEmail || emailValidator(contactEmail)
+  const isContactEmailValid = !contactEmail || emailValidator(contactEmail)
   const isDescriptionValid =
     description.length <= LINK_DESCRIPTION_MAX_LENGTH &&
     isPrintableAscii(description)
 
-  useEffect(
-    () => {
-      onContactEmailValidation(isContactEmailValid)
-    },
-    [isContactEmailValid]
-  )
+  useEffect(() => {
+    onContactEmailValidation(isContactEmailValid)
+  }, [isContactEmailValid])
 
-  useEffect(
-    () => {
-      onDescriptionValidation(isDescriptionValid)
-    },
-    [isDescriptionValid]
-  )
+  useEffect(() => {
+    onDescriptionValidation(isDescriptionValid)
+  }, [isDescriptionValid])
 
   const contactEmailHelp = (
     <>
@@ -138,16 +136,19 @@ export default function LinkInfoEditor({
 
   return (
     <>
-      <div className={classes.linkInformationHeaderWrapper}>
-        <Typography
-          variant="h3"
-          className={classes.linkInformationHeader}
-          color="primary"
-        >
-          Link information
-        </Typography>
-        <BetaTag />
-      </div>
+      {/* TODO: Move linkInformationHeaderWrapper back to drawer > control panel */}
+      {!isMountedOnCreateUrlModal && (
+        <div className={classes.linkInformationHeaderWrapper}>
+          <Typography
+            variant="h3"
+            className={classes.linkInformationHeader}
+            color="primary"
+          >
+            Link information
+          </Typography>
+          <BetaTag />
+        </div>
+      )}
       <Typography variant="body2" className={classes.linkInformationDesc}>
         The information you enter below will be displayed on our{' '}
         <a href="https://go.gov.sg/go-search" className={classes.hotlink}>


### PR DESCRIPTION
## Problem

The number of links with descriptions and contact details are low. One way we to address this would be to prompt users to add them after creating their links. This PR serves to redesign the create-url-modal to do that.

Closes #399 

## Solution


- [x] Prevent modal from closing after url-create-success
- [x] Introduce the notion of steps within create-url-modal to conditionally show the add-description fields
- [x] Wire up the add-description reusable widget into create-url-modal via a wrapper component
- [x] Add 'submit' and 'skip' buttons in add-description stage
- [x] API call for edit description on submission
- [x] API call for isSearchable toggle
- [x] Swap button order in mobile view
- [x] Display newly-created url in modal
- [x] Fix the problem where the bottom banner blocks buttons in mobile view 
- [x] Save button should have grey background grey when disabled

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/16982839/91756979-3ca7b380-ec00-11ea-9ad1-00d083662160.png)
![image](https://user-images.githubusercontent.com/16982839/91757007-4a5d3900-ec00-11ea-963e-1320dcfa1cd3.png)



