### PR TITLE
test(redirect): cover gtagForTransitionPage, res.cookie

### DIFF
--- a/test/server/mocks/services/analytics.ts
+++ b/test/server/mocks/services/analytics.ts
@@ -14,7 +14,7 @@ export default class AnalyticsLoggerMock
   generateCookie: (
     cookie?: string,
   ) => [string, string, { maxAge: number }] | null = (cookie) => {
-    if (cookie) return null
+    if (cookie) return JSON.parse(cookie)
     return null
   }
 }


### PR DESCRIPTION
## Problem

Finally closes #251 , which was also addressed in #94 and others

## Solution

Provide tests to cover `gtagForTransitionPage()` and cookie
parsing when redirecting a user
