### PR TITLE
chore(transition): copy apple-touch-icon from index.html

### DIFF
--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.13/css/sgds.css">
     <link href="/assets/transition-page/styles/transition-page.css" rel="stylesheet">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 </head>
 


### PR DESCRIPTION
## Problem and Solution

Browsers eagerly guess the path for apple-touch-icon, triggering 404 alarms for popular links. 
Add a proper reference to what we have, copied from index.html.