### PR TITLE
fix(searchable-toggle): update toaster message to reflect changes

### DIFF
--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -474,9 +474,7 @@ const toggleIsSearchable = (shortUrl: string, isSearchable: boolean) => (
     if (response.ok) {
       dispatch<void>(getUrlsForUser())
       dispatch<SetSuccessMessageAction>(
-        rootActions.setSuccessMessage(
-          `URL is now ${isSearchable ? '' : 'not'} searchable.`,
-        ),
+        rootActions.setSuccessMessage('Your link visibility has been updated.'),
       )
       return null
     }

--- a/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/components/UserPage/CreateUrlModal/AddDescriptionForm.tsx
@@ -85,7 +85,9 @@ export default function AddDescriptionForm() {
 
     if (response.ok) {
       dispatch(userActions.getUrlsForUser())
-      dispatch(rootActions.setSuccessMessage('URL is updated.'))
+      dispatch(
+        rootActions.setSuccessMessage('Your link visibility has been updated.'),
+      )
       setIsSearchable(newIsSearchable)
       return
     }


### PR DESCRIPTION
## Problem

The toaster message when visibility is updated is not effective.

Reason is that even though the state of visibility has changed, the toaster visually hasn’t, which may be confusing to users. Since the changed visibility state is clearly stated in the edit link panel (Colour changing text), the toaster should just be a confirmation that a change took place.

