### PR TITLE
test: remove hard-coded sequelize dialect

### DIFF
--- a/src/server/util/sequelize.ts
+++ b/src/server/util/sequelize.ts
@@ -2,7 +2,6 @@ import Sequelize, { Transaction } from 'sequelize'
 import { databaseUri, dbPoolSize, logger } from '../config'
 
 export const sequelize = new Sequelize.Sequelize(databaseUri, {
-  dialect: 'postgres',
   timezone: '+08:00',
   logging: logger.info.bind(logger),
   pool: {


### PR DESCRIPTION
## Problem
While GoGovSG uses a variety of postgres-specific queries and features,
the codebase still mostly talks to the database via Sequelize. To facilitate
integration testing, we will have to use something other than postgres,
eg an in-memory embedded database like SQLite.

## Solution
Remove the hard-coded dialect in Sequelize options and let the dialect
be driven from the database URI. This allows us to easily make use of
other database implementations where needed.

### Considerations
If the hard-coded dialect is kept, integration tests would be limited to
running on CI or an elaborate development environment. Integration tests
_could_ run on a developer environment by mocking the postgres client, but
this is tedious and does not account for potential mistakes in SQL query
syntax or behaviour