### PR TITLE
chore(create-form): provide default error messages

### DIFF
--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -315,4 +315,9 @@ CreateLinkForm.propTypes = {
   setCreateShortLinkError: PropTypes.func.isRequired,
 }
 
+CreateLinkForm.defaultProps = {
+  createShortLinkError: 'An error occurred while creating short link',
+  uploadFileError: 'An error occurred while uploading file',
+}
+
 export default connect(mapStateToProps, mapDispatchToProps)(CreateLinkForm)


### PR DESCRIPTION
## Problem and Solution

Suppress linting warnings by providing default (but helpful) messages
if errors occur when creating links or file uploads

Fixes #563 