### PR TITLE
fix: applied rate limit to otp generation and verification

### DIFF
--- a/src/server/api/login/index.ts
+++ b/src/server/api/login/index.ts
@@ -30,19 +30,6 @@ const apiOtpGeneratorLimiter = rateLimit({
 })
 
 /**
- * Rate limiter for API verifying OTP.
- */
-const apiOtpVerificationLimiter = rateLimit({
-  keyGenerator: (req) => getIp(req) as string,
-  onLimitReached: (req) =>
-    logger.warn(
-      `Rate limit (verifying OTP) reached for IP Address: ${getIp(req)}`,
-    ),
-  windowMs: 60000, // 1 minute
-  max: 5,
-})
-
-/**
  * For the Login message banner.
  */
 router.get('/message', loginController.getLoginMessage)
@@ -64,7 +51,6 @@ router.post(
  */
 router.post(
   '/verify',
-  apiOtpVerificationLimiter,
   authValidator.body(otpVerificationSchema),
   loginController.verifyOtp,
 )


### PR DESCRIPTION
## Problem

Prevent abuse of the endpoint responsible for sending OTPs by introducing rate limiting, using the express-rate-limit package already available in GoGovSG. 


## Solution

Adding rate limits for /otp endpoints. 
For the rate limit, the maximum tries are set to 5 per minute. The numbers are derived from common user's usage. Failing to obtain the OTP up to 3 ~ 4 times in a minute is plausible for normal users. Anything that is 5 and above is likely to be intentional.  



