### PR TITLE
fix: go logo intersects with redirect link

### DIFF
--- a/public/assets/transition-page/styles/transition-page.css
+++ b/public/assets/transition-page/styles/transition-page.css
@@ -101,10 +101,6 @@ body {
   width: 80%;
 }
 
-.footer img {
-  margin-bottom: 24px;
-}
-
 .footer p {
   color: #bbbbbb;
   font-size: 13px;
@@ -159,6 +155,10 @@ body {
 
   .footer {
     bottom: 30px;
+  }
+
+  .footer img {
+    margin-bottom: 24px;
   }
 
   .mobile-break {


### PR DESCRIPTION
## Problem

GO Logo intersects with the redirect link

## Solution

Resolved using CSS. Underneath the image, is there a margin of 24px which causes the logo to intersect with the redirect link when screen height compress. Moving the selector to only trigger in mobile seem to stop that.

##Images
-before
![Screenshot 2020-09-16 at 7 32 41 PM](https://user-images.githubusercontent.com/29625514/93333998-c5f0f400-f856-11ea-9fc6-efc1b754217a.png)

-after
![Screenshot 2020-09-16 at 7 34 19 PM](https://user-images.githubusercontent.com/29625514/93334055-dd2fe180-f856-11ea-9793-3061c6fdaf35.png)


