### PR TITLE
fix: fix misaligned tooltip

### DIFF
--- a/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.tsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.tsx
@@ -110,6 +110,9 @@ const useStyles = makeStyles((theme) => {
     clicksCellContent: {
       width: 118,
     },
+    clicksCellTooltipContent: {
+      display: 'inline-block',
+    },
     rightCell: {
       [theme.breakpoints.up('md')]: {
         textAlign: 'right',
@@ -243,18 +246,20 @@ export default function EnhancedTableBody() {
               </Typography>
             </TableCell>
             <TableCell className={classes.clicksCell}>
-              <Tooltip title={row.clicks} placement="top" arrow>
-                <div className={classes.clicksCellContent}>
-                  <img
-                    className={classes.clicksIcon}
-                    src={clickCountIcon}
-                    alt="Clicks"
-                  />
-                  <Typography variant="caption" className={classes.clicksText}>
-                    {numberUnitFormatter(row.clicks)}
-                  </Typography>
-                </div>
-              </Tooltip>
+              <div className={classes.clicksCellContent}>
+                <Tooltip title={row.clicks} placement="top" arrow>
+                  <div className={classes.clicksCellTooltipContent}>
+                    <img
+                      className={classes.clicksIcon}
+                      src={clickCountIcon}
+                      alt="Clicks"
+                    />
+                    <Typography variant="caption" className={classes.clicksText}>
+                      {numberUnitFormatter(row.clicks)}
+                    </Typography>
+                  </div>
+                </Tooltip>
+              </div>
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/GoGovSG/issues/602

## Solution
 
The misaligned tooltip is due to the tooltip content taking up the table cell's width as illustrated in the image below. Restructure the html and wrap the tooltip content with an inline-block div fixes the issue.
![image](https://user-images.githubusercontent.com/6182649/93657743-9b29ba00-fa67-11ea-98cf-a4db7f3532b0.png)

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/6182649/93657809-2440f100-fa68-11ea-9006-269b42415ac8.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/6182649/93657839-6d914080-fa68-11ea-93ae-ccd00e252a91.png)
