### PR TITLE
Add description meta tag to transition page

### DIFF
--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -133,7 +133,7 @@ export class RedirectController implements RedirectControllerInterface {
     return longUrl.replace(/["]/g, encodeURIComponent)
   }
 
-  private static renderMetaTagDescription(description: string | null) {
+  private static renderMetaTagDescription(description: string) {
     if (!description) {
       return ''
     }

--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -1,5 +1,6 @@
 import Express from 'express'
 import { inject, injectable } from 'inversify'
+import { escape } from 'lodash'
 import { gaTrackingId, logger } from '../config'
 import { NotFoundError } from '../util/error'
 import parseDomain from '../util/domain'
@@ -68,10 +69,11 @@ export class RedirectController implements RedirectControllerInterface {
       return
     }
 
-    // Find longUrl to redirect to.
+    // Find longUrl to redirect to and description.
     try {
       const {
         longUrl,
+        description,
         visitedUrls,
         redirectType,
       } = await this.redirectService.redirectFor(
@@ -95,6 +97,9 @@ export class RedirectController implements RedirectControllerInterface {
         const rootDomain: string = parseDomain(longUrl)
 
         res.status(200).render(TRANSITION_PATH, {
+          metaTagDescription: RedirectController.renderMetaTagDescription(
+            description,
+          ),
           escapedLongUrl: RedirectController.encodeLongUrl(longUrl),
           rootDomain,
           gaTrackingId,
@@ -126,6 +131,14 @@ export class RedirectController implements RedirectControllerInterface {
    */
   private static encodeLongUrl(longUrl: string) {
     return longUrl.replace(/["]/g, encodeURIComponent)
+  }
+
+  private static renderMetaTagDescription(description: string | null) {
+    if (!description) {
+      return ''
+    }
+
+    return `<meta name="description" content="${escape(description)}" />`
   }
 }
 

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -3,7 +3,7 @@
 import { inject, injectable } from 'inversify'
 import { QueryTypes } from 'sequelize'
 import { Url, UrlType } from '../models/url'
-import { NotFoundError } from '../util/error'
+import { InvalidFormatError, NotFoundError } from '../util/error'
 import { redirectClient } from '../redis'
 import {
   logger,
@@ -121,36 +121,26 @@ export class UrlRepository implements UrlRepositoryInterface {
   public getLongUrl: (shortUrl: string) => Promise<string> = async (
     shortUrl,
   ) => {
-    try {
-      // Cache lookup
-      return await this.getLongUrlFromCache(shortUrl)
-    } catch {
-      // Cache failed, look in database
-      const longUrl = await this.getLongUrlFromDatabase(shortUrl)
-      this.cacheShortUrl(shortUrl, longUrl).catch((error) =>
-        logger.error(`Unable to cache short URL: ${error}`),
-      )
-      return longUrl
-    }
+    const { longUrl } = await this.getLongUrlAndDescription(shortUrl)
+    return longUrl
   }
 
-  /**
-   * Retrieves the description of the short url from the database.
-   * @param  {string} shortUrl Short url.
-   * @returns The description of the short url.
-   */
-  public getDescription: (shortUrl: string) => Promise<string> = async (
-    shortUrl,
-  ) => {
-    const url = await Url.findOne({
-      where: { shortUrl, state: StorableUrlState.Active },
-    })
-    if (!url) {
-      throw new NotFoundError(
-        `shortUrl not found in database:\tshortUrl=${shortUrl}`,
+  public getLongUrlAndDescription: (
+    shortUrl: string,
+  ) => Promise<{ longUrl: string; description: string }> = async (shortUrl) => {
+    try {
+      // Cache lookup
+      return await this.getLongUrlAndDescriptionFromCache(shortUrl)
+    } catch {
+      // Cache failed, look in database
+      const longUrlAndDescription = await this.getLongUrlAndDescriptionFromDatabase(
+        shortUrl,
       )
+      this.cacheShortUrl(shortUrl, longUrlAndDescription).catch((error) =>
+        logger.error(`Unable to cache short URL: ${error}`),
+      )
+      return longUrlAndDescription
     }
-    return url.description
   }
 
   public plainTextSearch: (
@@ -202,14 +192,14 @@ export class UrlRepository implements UrlRepositoryInterface {
   }
 
   /**
-   * Retrieves the long url which the short url redirects to
+   * Retrieves the long url which the short url redirects to, and description
    * from the database.
    * @param  {string} shortUrl Short url.
-   * @returns The long url that the short url redirects to.
+   * @returns The long url that the short url redirects to, and description.
    */
-  private getLongUrlFromDatabase: (
+  private getLongUrlAndDescriptionFromDatabase: (
     shortUrl: string,
-  ) => Promise<string> = async (shortUrl) => {
+  ) => Promise<{ longUrl: string; description: string }> = async (shortUrl) => {
     const url = await Url.findOne({
       where: { shortUrl, state: StorableUrlState.Active },
     })
@@ -218,51 +208,73 @@ export class UrlRepository implements UrlRepositoryInterface {
         `shortUrl not found in database:\tshortUrl=${shortUrl}`,
       )
     }
-    return url.longUrl
+
+    return {
+      longUrl: url.longUrl,
+      description: url.description,
+    }
   }
 
   /**
-   * Retrieves the long url which the short url redirects to
+   * Retrieves the long url which the short url redirects to, and description
    * from the cache.
    * @param  {string} shortUrl Short url.
-   * @returns The long url that the short url redirects to.
+   * @returns The long url that the short url redirects to, and description.
    */
-  private getLongUrlFromCache: (shortUrl: string) => Promise<string> = (
-    shortUrl,
-  ) => {
+  private getLongUrlAndDescriptionFromCache: (
+    shortUrl: string,
+  ) => Promise<{ longUrl: string; description: string }> = (shortUrl) => {
     return new Promise((resolve, reject) =>
-      redirectClient.get(shortUrl, (cacheError, cacheLongUrl) => {
+      redirectClient.get(shortUrl, (cacheError, cacheLongUrlAndDescription) => {
         if (cacheError) {
           logger.error(`Cache lookup failed unexpectedly:\t${cacheError}`)
           reject(cacheError)
         } else {
-          if (!cacheLongUrl) {
+          if (!cacheLongUrlAndDescription) {
             reject(
               new NotFoundError(
-                `longUrl not found in cache:\tshortUrl=${shortUrl}`,
+                `longUrl and description not found in cache:\tshortUrl=${shortUrl}`,
               ),
             )
           }
-          resolve(cacheLongUrl)
+
+          try {
+            const { longUrl, description } = JSON.parse(
+              cacheLongUrlAndDescription,
+            )
+            resolve({ longUrl, description })
+          } catch (ex) {
+            reject(
+              new InvalidFormatError(
+                `Failed to parse json for cached longUrl and description:\tshortUrl=${shortUrl}`,
+              ),
+            )
+          }
         }
       }),
     )
   }
 
   /**
-   * Caches the input short url to long url mapping in redis cache.
+   * Caches the input short url to long url and description mapping in redis cache.
    * @param  {string} shortUrl Short url.
-   * @param  {string} longUrl Long url.
+   * @param  {longUrl:string;description:string;} longUrlAndDescription Object of long url and description.
    */
   private cacheShortUrl: (
     shortUrl: string,
-    longUrl: string,
-  ) => Promise<void> = (shortUrl, longUrl) => {
+    longUrlAndDescription: { longUrl: string; description: string },
+  ) => Promise<void> = (shortUrl, longUrlAndDescription) => {
     return new Promise((resolve, reject) => {
-      redirectClient.set(shortUrl, longUrl, 'EX', redirectExpiry, (err) => {
-        if (err) reject(err)
-        else resolve()
-      })
+      redirectClient.set(
+        shortUrl,
+        JSON.stringify(longUrlAndDescription),
+        'EX',
+        redirectExpiry,
+        (err) => {
+          if (err) reject(err)
+          else resolve()
+        },
+      )
     })
   }
 

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -134,6 +134,25 @@ export class UrlRepository implements UrlRepositoryInterface {
     }
   }
 
+  /**
+   * Retrieves the description of the short url from the database.
+   * @param  {string} shortUrl Short url.
+   * @returns The description of the short url.
+   */
+  public getDescription: (shortUrl: string) => Promise<string> = async (
+    shortUrl,
+  ) => {
+    const url = await Url.findOne({
+      where: { shortUrl, state: StorableUrlState.Active },
+    })
+    if (!url) {
+      throw new NotFoundError(
+        `shortUrl not found in database:\tshortUrl=${shortUrl}`,
+      )
+    }
+    return url.description
+  }
+
   public plainTextSearch: (
     query: string,
     order: SearchResultsSortOrder,

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -42,6 +42,14 @@ export interface UrlRepositoryInterface {
   getLongUrl: (shortUrl: string) => Promise<string>
 
   /**
+   * Looks up the description given a shortUrl from the database.
+   * @param {string} shortUrl The shortUrl.
+   * @returns Promise that resolves to the description.
+   * @throws {NotFoundError}
+   */
+  getDescription: (shortUrl: string) => Promise<string>
+
+  /**
    * Performs plain text search on Urls based on their shortUrl and
    * description. The results are ranked in order of relevance based
    * on click count, length and cover density.

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -32,22 +32,16 @@ export interface UrlRepositoryInterface {
   ): Promise<StorableUrl>
 
   /**
-   * Looks up the longUrl given a shortUrl from the cache, falling back
+   * Looks up the longUrl and description given a shortUrl from the cache, falling back
    * to the database. The cache is re-populated if the database lookup is
    * performed successfully.
    * @param {string} shortUrl The shortUrl.
-   * @returns Promise that resolves to the longUrl.
+   * @returns Promise that resolves to the longUrl and description.
    * @throws {NotFoundError}
    */
-  getLongUrl: (shortUrl: string) => Promise<string>
-
-  /**
-   * Looks up the description given a shortUrl from the database.
-   * @param {string} shortUrl The shortUrl.
-   * @returns Promise that resolves to the description.
-   * @throws {NotFoundError}
-   */
-  getDescription: (shortUrl: string) => Promise<string>
+  getLongUrlAndDescription: (
+    shortUrl: string,
+  ) => Promise<{ longUrl: string; description: string }>
 
   /**
    * Performs plain text search on Urls based on their shortUrl and

--- a/src/server/services/RedirectService.ts
+++ b/src/server/services/RedirectService.ts
@@ -54,6 +54,8 @@ export class RedirectService implements RedirectServiceInterface {
 
     // Find longUrl to redirect to
     const longUrl = await this.urlRepository.getLongUrl(shortUrl)
+    // Find description of the shortUrl
+    const description = await this.urlRepository.getDescription(shortUrl)
 
     // Update clicks and click statistics in database.
     this.linkStatisticsService.updateLinkStatistics(shortUrl, userAgent)
@@ -61,6 +63,7 @@ export class RedirectService implements RedirectServiceInterface {
     if (this.crawlerCheckService.isCrawler(userAgent)) {
       return {
         longUrl,
+        description,
         visitedUrls: pastVisits,
         redirectType: RedirectType.Direct,
       }
@@ -81,6 +84,7 @@ export class RedirectService implements RedirectServiceInterface {
 
     return {
       longUrl,
+      description,
       visitedUrls: newVisits,
       redirectType: renderTransitionPage
         ? RedirectType.TransitionPage

--- a/src/server/services/RedirectService.ts
+++ b/src/server/services/RedirectService.ts
@@ -52,10 +52,11 @@ export class RedirectService implements RedirectServiceInterface {
 
     const shortUrl = rawShortUrl.toLowerCase()
 
-    // Find longUrl to redirect to
-    const longUrl = await this.urlRepository.getLongUrl(shortUrl)
-    // Find description of the shortUrl
-    const description = await this.urlRepository.getDescription(shortUrl)
+    // Find longUrl to redirect to, and description of the shortUrl
+    const {
+      longUrl,
+      description,
+    } = await this.urlRepository.getLongUrlAndDescription(shortUrl)
 
     // Update clicks and click statistics in database.
     this.linkStatisticsService.updateLinkStatistics(shortUrl, userAgent)

--- a/src/server/services/types.ts
+++ b/src/server/services/types.ts
@@ -9,7 +9,7 @@ export enum RedirectType {
 export type RedirectResult = {
   visitedUrls: string[]
   longUrl: string
-  description: string | null
+  description: string
   redirectType: RedirectType
 }
 

--- a/src/server/services/types.ts
+++ b/src/server/services/types.ts
@@ -9,6 +9,7 @@ export enum RedirectType {
 export type RedirectResult = {
   visitedUrls: string[]
   longUrl: string
+  description: string | null
   redirectType: RedirectType
 }
 

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -8,6 +8,14 @@ export class NotFoundError extends Error {
   }
 }
 
+export class InvalidFormatError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidFormatError'
+    Object.setPrototypeOf(this, InvalidFormatError.prototype)
+  }
+}
+
 export class InvalidOtpError extends Error {
   public retries: number
 

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -3,6 +3,7 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0">
+    <%- metaTagDescription %>
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta http-equiv="Content-Language" content="en">
     <meta charset="UTF-8">

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -137,6 +137,7 @@ export const urlModelMock = sequelizeMock.define(
     longUrl: 'aa',
     state: ACTIVE,
     clicks: 8,
+    description: 'bb',
   },
   {
     instanceMethods: {

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -331,7 +331,8 @@ describe('redirect API tests', () => {
     const req = createRequestWithShortUrl('Aaa')
     const res = httpMocks.createResponse()
 
-    redisMockClient.set('aaa', 'aa')
+    const longUrlAndDescription = { longUrl: 'aa', description: 'bbb' }
+    redisMockClient.set('aaa', JSON.stringify(longUrlAndDescription))
     mockDbEmpty()
 
     await container
@@ -349,7 +350,8 @@ describe('redirect API tests', () => {
     const res = httpMocks.createResponse()
 
     mockDbDown()
-    redisMockClient.set('aaa', 'aa')
+    const longUrlAndDescription = { longUrl: 'aa', description: 'bbb' }
+    redisMockClient.set('aaa', JSON.stringify(longUrlAndDescription))
 
     await container
       .get<RedirectController>(DependencyIds.redirectController)

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -35,6 +35,12 @@ export class UrlRepositoryMock implements UrlRepositoryInterface {
     throw new Error('Not implemented')
   }
 
+  getLongUrlAndDescription: (
+    shortUrl: string,
+  ) => Promise<{ longUrl: string; description: string }> = () => {
+    throw new Error('Not implemented')
+  }
+
   plainTextSearch: (
     query: string,
     order: SearchResultsSortOrder,

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -307,7 +307,8 @@ describe('UrlRepository', () => {
     })
 
     it('should return from cache when cache is filled', async () => {
-      redisMockClient.set('a', 'aaa')
+      const longUrlAndDescription = { longUrl: 'aaa', description: 'bbb' }
+      redisMockClient.set('a', JSON.stringify(longUrlAndDescription))
       await expect(repository.getLongUrl('a')).resolves.toBe('aaa')
     })
 
@@ -332,10 +333,10 @@ describe('UrlRepository', () => {
     })
 
     it('should return from cache when cache is filled', async () => {
-      const json = JSON.stringify({ longUrl: 'aaa', description: 'bbb' })
-      redisMockClient.set('a', json)
+      const longUrlAndDescription = { longUrl: 'aaa', description: 'bbb' }
+      redisMockClient.set('a', JSON.stringify(longUrlAndDescription))
       await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
-        json,
+        longUrlAndDescription,
       )
     })
 

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -353,6 +353,15 @@ describe('UrlRepository', () => {
         description: 'bb',
       })
     })
+
+    it('should return from db when cache value is in the old format (backwards compatible)', async () => {
+      // old format - key: short url, value: long url
+      redisMockClient.set('a', 'aa')
+      const longUrlAndDescription = { longUrl: 'aa', description: 'bb' }
+      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
+        longUrlAndDescription,
+      )
+    })
   })
 
   describe('plainTextSearch', () => {

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -355,12 +355,23 @@ describe('UrlRepository', () => {
     })
 
     it('should return from db when cache value is in the old format (backwards compatible)', async () => {
+      // Added `<any, any>` so that private methods can be spied on.
+      const getLongUrlAndDescriptionFromDatabase = jest.spyOn<any, any>(
+        repository,
+        'getLongUrlAndDescriptionFromDatabase',
+      )
+      const findOne = jest.spyOn(urlModelMock, 'findOne')
+
       // old format - key: short url, value: long url
       redisMockClient.set('a', 'aa')
       const longUrlAndDescription = { longUrl: 'aa', description: 'bb' }
       await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
         longUrlAndDescription,
       )
+      expect(getLongUrlAndDescriptionFromDatabase).toHaveBeenCalledWith('a')
+      expect(findOne).toHaveBeenCalledWith({
+        where: { shortUrl: 'a', state: 'ACTIVE' },
+      })
     })
   })
 

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -323,6 +323,37 @@ describe('UrlRepository', () => {
     })
   })
 
+  describe('getLongUrlAndDescription', () => {
+    it('should return from db when cache is empty', async () => {
+      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual({
+        longUrl: 'aa',
+        description: 'bb',
+      })
+    })
+
+    it('should return from cache when cache is filled', async () => {
+      const json = JSON.stringify({ longUrl: 'aaa', description: 'bbb' })
+      redisMockClient.set('a', json)
+      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
+        json,
+      )
+    })
+
+    it('should return from db when cache is down', async () => {
+      cacheGetSpy.mockImplementationOnce((_, callback) => {
+        if (!callback) {
+          return false
+        }
+        callback(new Error('Cache down'), 'Error')
+        return false
+      })
+      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual({
+        longUrl: 'aa',
+        description: 'bb',
+      })
+    })
+  })
+
   describe('plainTextSearch', () => {
     beforeEach(() => {
       mockQuery.mockClear()

--- a/test/server/services/UrlManagementService.test.ts
+++ b/test/server/services/UrlManagementService.test.ts
@@ -19,6 +19,7 @@ describe('UrlManagementService', () => {
     create: jest.fn(),
     findByShortUrl: jest.fn(),
     getLongUrl: jest.fn(),
+    getLongUrlAndDescription: jest.fn(),
     plainTextSearch: jest.fn(),
   }
 


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/GoGovSG/issues/546

## Solution
Implement `getLongUrlAndDescription` to retrieve long url and description for a given short url. It tries to fetch from redis cache first before falling back to fetching from database.
Injecting description meta tag to transition page is done in transition-page template.

Note:
Changes to the format of existing cache value

**Old**
cache key: short url
cache value: long url

**New**
cache key: short url
cache value: JSON.stringify({ longUrl: longUrl, description: description }) 

This change is backward compatible. Old cache value (ie. long url) will fail when it is parsed as json string, throwing `InvalidFormatError`. System will then read from database and update the cache value to the new format. Subsequent read from redis will be parsed successfully based on the new format.

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/6182649/93670808-acf37780-fad0-11ea-9c90-d2a137391621.png)

## Tests
Refer to the changes related to tests in this commit.

## Deploy Notes
Monitor for backward compatibility in case anything goes wrong unexpectedly.
