### PR TITLE
Revert "Add description meta tag to transition page"

### DIFF
--- a/src/server/controllers/RedirectController.ts
+++ b/src/server/controllers/RedirectController.ts
@@ -1,6 +1,5 @@
 import Express from 'express'
 import { inject, injectable } from 'inversify'
-import { escape } from 'lodash'
 import { gaTrackingId, logger } from '../config'
 import { NotFoundError } from '../util/error'
 import parseDomain from '../util/domain'
@@ -69,11 +68,10 @@ export class RedirectController implements RedirectControllerInterface {
       return
     }
 
-    // Find longUrl to redirect to and description.
+    // Find longUrl to redirect to.
     try {
       const {
         longUrl,
-        description,
         visitedUrls,
         redirectType,
       } = await this.redirectService.redirectFor(
@@ -97,9 +95,6 @@ export class RedirectController implements RedirectControllerInterface {
         const rootDomain: string = parseDomain(longUrl)
 
         res.status(200).render(TRANSITION_PATH, {
-          metaTagDescription: RedirectController.renderMetaTagDescription(
-            description,
-          ),
           escapedLongUrl: RedirectController.encodeLongUrl(longUrl),
           rootDomain,
           gaTrackingId,
@@ -131,14 +126,6 @@ export class RedirectController implements RedirectControllerInterface {
    */
   private static encodeLongUrl(longUrl: string) {
     return longUrl.replace(/["]/g, encodeURIComponent)
-  }
-
-  private static renderMetaTagDescription(description: string) {
-    if (!description) {
-      return ''
-    }
-
-    return `<meta name="description" content="${escape(description)}" />`
   }
 }
 

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -32,16 +32,14 @@ export interface UrlRepositoryInterface {
   ): Promise<StorableUrl>
 
   /**
-   * Looks up the longUrl and description given a shortUrl from the cache, falling back
+   * Looks up the longUrl given a shortUrl from the cache, falling back
    * to the database. The cache is re-populated if the database lookup is
    * performed successfully.
    * @param {string} shortUrl The shortUrl.
-   * @returns Promise that resolves to the longUrl and description.
+   * @returns Promise that resolves to the longUrl.
    * @throws {NotFoundError}
    */
-  getLongUrlAndDescription: (
-    shortUrl: string,
-  ) => Promise<{ longUrl: string; description: string }>
+  getLongUrl: (shortUrl: string) => Promise<string>
 
   /**
    * Performs plain text search on Urls based on their shortUrl and

--- a/src/server/services/RedirectService.ts
+++ b/src/server/services/RedirectService.ts
@@ -52,11 +52,8 @@ export class RedirectService implements RedirectServiceInterface {
 
     const shortUrl = rawShortUrl.toLowerCase()
 
-    // Find longUrl to redirect to, and description of the shortUrl
-    const {
-      longUrl,
-      description,
-    } = await this.urlRepository.getLongUrlAndDescription(shortUrl)
+    // Find longUrl to redirect to
+    const longUrl = await this.urlRepository.getLongUrl(shortUrl)
 
     // Update clicks and click statistics in database.
     this.linkStatisticsService.updateLinkStatistics(shortUrl, userAgent)
@@ -64,7 +61,6 @@ export class RedirectService implements RedirectServiceInterface {
     if (this.crawlerCheckService.isCrawler(userAgent)) {
       return {
         longUrl,
-        description,
         visitedUrls: pastVisits,
         redirectType: RedirectType.Direct,
       }
@@ -85,7 +81,6 @@ export class RedirectService implements RedirectServiceInterface {
 
     return {
       longUrl,
-      description,
       visitedUrls: newVisits,
       redirectType: renderTransitionPage
         ? RedirectType.TransitionPage

--- a/src/server/services/types.ts
+++ b/src/server/services/types.ts
@@ -9,7 +9,6 @@ export enum RedirectType {
 export type RedirectResult = {
   visitedUrls: string[]
   longUrl: string
-  description: string
   redirectType: RedirectType
 }
 

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -8,14 +8,6 @@ export class NotFoundError extends Error {
   }
 }
 
-export class InvalidFormatError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'InvalidFormatError'
-    Object.setPrototypeOf(this, InvalidFormatError.prototype)
-  }
-}
-
 export class InvalidOtpError extends Error {
   public retries: number
 

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -3,7 +3,6 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0">
-    <%- metaTagDescription %>
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta http-equiv="Content-Language" content="en">
     <meta charset="UTF-8">

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -137,7 +137,6 @@ export const urlModelMock = sequelizeMock.define(
     longUrl: 'aa',
     state: ACTIVE,
     clicks: 8,
-    description: 'bb',
   },
   {
     instanceMethods: {

--- a/test/server/controllers/RedirectController.test.ts
+++ b/test/server/controllers/RedirectController.test.ts
@@ -331,8 +331,7 @@ describe('redirect API tests', () => {
     const req = createRequestWithShortUrl('Aaa')
     const res = httpMocks.createResponse()
 
-    const longUrlAndDescription = { longUrl: 'aa', description: 'bbb' }
-    redisMockClient.set('aaa', JSON.stringify(longUrlAndDescription))
+    redisMockClient.set('aaa', 'aa')
     mockDbEmpty()
 
     await container
@@ -350,8 +349,7 @@ describe('redirect API tests', () => {
     const res = httpMocks.createResponse()
 
     mockDbDown()
-    const longUrlAndDescription = { longUrl: 'aa', description: 'bbb' }
-    redisMockClient.set('aaa', JSON.stringify(longUrlAndDescription))
+    redisMockClient.set('aaa', 'aa')
 
     await container
       .get<RedirectController>(DependencyIds.redirectController)

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -35,12 +35,6 @@ export class UrlRepositoryMock implements UrlRepositoryInterface {
     throw new Error('Not implemented')
   }
 
-  getLongUrlAndDescription: (
-    shortUrl: string,
-  ) => Promise<{ longUrl: string; description: string }> = () => {
-    throw new Error('Not implemented')
-  }
-
   plainTextSearch: (
     query: string,
     order: SearchResultsSortOrder,

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -307,8 +307,7 @@ describe('UrlRepository', () => {
     })
 
     it('should return from cache when cache is filled', async () => {
-      const longUrlAndDescription = { longUrl: 'aaa', description: 'bbb' }
-      redisMockClient.set('a', JSON.stringify(longUrlAndDescription))
+      redisMockClient.set('a', 'aaa')
       await expect(repository.getLongUrl('a')).resolves.toBe('aaa')
     })
 
@@ -321,57 +320,6 @@ describe('UrlRepository', () => {
         return false
       })
       await expect(repository.getLongUrl('a')).resolves.toBe('aa')
-    })
-  })
-
-  describe('getLongUrlAndDescription', () => {
-    it('should return from db when cache is empty', async () => {
-      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual({
-        longUrl: 'aa',
-        description: 'bb',
-      })
-    })
-
-    it('should return from cache when cache is filled', async () => {
-      const longUrlAndDescription = { longUrl: 'aaa', description: 'bbb' }
-      redisMockClient.set('a', JSON.stringify(longUrlAndDescription))
-      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
-        longUrlAndDescription,
-      )
-    })
-
-    it('should return from db when cache is down', async () => {
-      cacheGetSpy.mockImplementationOnce((_, callback) => {
-        if (!callback) {
-          return false
-        }
-        callback(new Error('Cache down'), 'Error')
-        return false
-      })
-      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual({
-        longUrl: 'aa',
-        description: 'bb',
-      })
-    })
-
-    it('should return from db when cache value is in the old format (backwards compatible)', async () => {
-      // Added `<any, any>` so that private methods can be spied on.
-      const getLongUrlAndDescriptionFromDatabase = jest.spyOn<any, any>(
-        repository,
-        'getLongUrlAndDescriptionFromDatabase',
-      )
-      const findOne = jest.spyOn(urlModelMock, 'findOne')
-
-      // old format - key: short url, value: long url
-      redisMockClient.set('a', 'aa')
-      const longUrlAndDescription = { longUrl: 'aa', description: 'bb' }
-      await expect(repository.getLongUrlAndDescription('a')).resolves.toEqual(
-        longUrlAndDescription,
-      )
-      expect(getLongUrlAndDescriptionFromDatabase).toHaveBeenCalledWith('a')
-      expect(findOne).toHaveBeenCalledWith({
-        where: { shortUrl: 'a', state: 'ACTIVE' },
-      })
     })
   })
 

--- a/test/server/services/UrlManagementService.test.ts
+++ b/test/server/services/UrlManagementService.test.ts
@@ -19,7 +19,6 @@ describe('UrlManagementService', () => {
     create: jest.fn(),
     findByShortUrl: jest.fn(),
     getLongUrl: jest.fn(),
-    getLongUrlAndDescription: jest.fn(),
     plainTextSearch: jest.fn(),
   }
 


### PR DESCRIPTION
Following discussion with @liangyuanruo , we are reverting this PR given that Go actually redirects crawlers immediately on to the destination, identifying them through `CrawlerCheckService.isCrawler()`

Reverts opengovsg/GoGovSG#610