### PR TITLE
feat(links): disclose owner on dup creation

### DIFF
--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -75,6 +75,16 @@ export class UserRepository implements UserRepositoryInterface {
     return this.urlMapper.persistenceToDto(url)
   }
 
+  public findUserByUrl: (
+    shortUrl: string,
+  ) => Promise<StorableUser | null> = async (shortUrl) => {
+    const user = await User.scope({
+      method: ['includeShortUrl', shortUrl],
+    }).findOne()
+
+    return this.userMapper.persistenceToDto(user)
+  }
+
   public findUrlsForUser: (
     conditions: UserUrlsQueryConditions,
   ) => Promise<UrlsPaginated> = async (conditions) => {

--- a/src/server/repositories/interfaces/UserRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UserRepositoryInterface.ts
@@ -45,6 +45,13 @@ export interface UserRepositoryInterface {
   ): Promise<StorableUrl | null>
 
   /**
+   * Find the user who created a given url.
+   * @param  {string} shortUrl The shortUrl of the Url to find.
+   * @returns Promise that resolves to the user, if any, or null.
+   */
+  findUserByUrl(shortUrl: string): Promise<StorableUser | null>
+
+  /**
    * Find the urls belonging to a user which matches the given query conditions.
    * The total count of rows matching the query (both in and outside the limit) is also returned.
    * @param  {UserUrlsQueryConditions} conditions Query conditions.

--- a/src/server/services/UrlManagementService.ts
+++ b/src/server/services/UrlManagementService.ts
@@ -45,11 +45,10 @@ export class UrlManagementService implements UrlManagementServiceInterface {
       throw new NotFoundError('User not found')
     }
 
-    const existsShortUrl = await this.urlRepository.findByShortUrl(shortUrl)
-    if (existsShortUrl) {
-      const owner = await this.userRepository.findUserByUrl(shortUrl)
+    const owner = await this.userRepository.findUserByUrl(shortUrl)
+    if (owner) {
       throw new AlreadyExistsError(
-        `Short link "${shortUrl}" is owned by ${owner?.email}`,
+        `Short link "${shortUrl}" is owned by ${owner.email}`,
       )
     }
 

--- a/src/server/services/UrlManagementService.ts
+++ b/src/server/services/UrlManagementService.ts
@@ -47,7 +47,10 @@ export class UrlManagementService implements UrlManagementServiceInterface {
 
     const existsShortUrl = await this.urlRepository.findByShortUrl(shortUrl)
     if (existsShortUrl) {
-      throw new AlreadyExistsError(`Short link "${shortUrl}" already exists`)
+      const owner = await this.userRepository.findUserByUrl(shortUrl)
+      throw new AlreadyExistsError(
+        `Short link "${shortUrl}" is owned by ${owner?.email}`,
+      )
     }
 
     const storableFile: StorableFile | undefined = file

--- a/test/server/mocks/repositories/UserRepository.ts
+++ b/test/server/mocks/repositories/UserRepository.ts
@@ -56,6 +56,10 @@ export class MockUserRepository implements UserRepositoryInterface {
     } as StorableUrl)
   }
 
+  findUserByUrl(_shortUrl: string): Promise<StorableUser | null> {
+    return Promise.resolve(null)
+  }
+
   findUrlsForUser(conditions: UserUrlsQueryConditions): Promise<UrlsPaginated> {
     this.conditions = conditions
     return Promise.resolve({ count: 0, urls: [] })

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -143,6 +143,32 @@ describe('UserRepository', () => {
     })
   })
 
+  describe('findUserByUrl', () => {
+    const { scope } = userModelMock
+    const findOne = jest.fn()
+
+    beforeEach(() => {
+      scope.mockReset()
+      findOne.mockReset()
+      scope.mockReturnValue({ findOne })
+    })
+
+    it('returns user for url', async () => {
+      const user = {
+        id: 2,
+        email: 'user@agency.gov.sg',
+        Urls: [url],
+      }
+      findOne.mockResolvedValue(user)
+      await expect(userRepo.findUserByUrl(url.shortUrl)).resolves.toStrictEqual(
+        expect.objectContaining({ id: user.id, email: user.email }),
+      )
+      expect(scope).toHaveBeenCalledWith({
+        method: ['includeShortUrl', url.shortUrl],
+      })
+    })
+  })
+
   describe('findUrlsForUser', () => {
     const { scope } = userModelMock
     const findAndCountAll = jest.fn()

--- a/test/server/services/UrlManagementService.test.ts
+++ b/test/server/services/UrlManagementService.test.ts
@@ -32,6 +32,7 @@ describe('UrlManagementService', () => {
 
     beforeEach(() => {
       userRepository.findById.mockReset()
+      userRepository.findUserByUrl.mockReset()
       urlRepository.findByShortUrl.mockReset()
       urlRepository.create.mockReset()
     })
@@ -42,22 +43,22 @@ describe('UrlManagementService', () => {
         service.createUrl(userId, shortUrl, longUrl),
       ).rejects.toBeInstanceOf(NotFoundError)
       expect(userRepository.findById).toHaveBeenCalledWith(userId)
-      expect(urlRepository.findByShortUrl).not.toHaveBeenCalled()
+      expect(userRepository.findUserByUrl).not.toHaveBeenCalled()
       expect(urlRepository.create).not.toHaveBeenCalled()
     })
 
     it('throws AlreadyExistsError on existing url', async () => {
       userRepository.findById.mockResolvedValue({ id: userId })
-      urlRepository.findByShortUrl.mockResolvedValue({
+      userRepository.findUserByUrl.mockResolvedValue({
         shortUrl,
         longUrl,
-        userId,
+        email: userId,
       })
       await expect(
         service.createUrl(userId, shortUrl, longUrl),
       ).rejects.toBeInstanceOf(AlreadyExistsError)
       expect(userRepository.findById).toHaveBeenCalledWith(userId)
-      expect(urlRepository.findByShortUrl).toHaveBeenCalledWith(shortUrl)
+      expect(userRepository.findUserByUrl).toHaveBeenCalledWith(shortUrl)
       expect(urlRepository.create).not.toHaveBeenCalled()
     })
 
@@ -69,7 +70,7 @@ describe('UrlManagementService', () => {
         service.createUrl(userId, shortUrl, longUrl),
       ).resolves.toStrictEqual({ userId, longUrl, shortUrl })
       expect(userRepository.findById).toHaveBeenCalledWith(userId)
-      expect(urlRepository.findByShortUrl).toHaveBeenCalledWith(shortUrl)
+      expect(userRepository.findUserByUrl).toHaveBeenCalledWith(shortUrl)
       expect(urlRepository.create).toHaveBeenCalledWith(
         { userId, longUrl, shortUrl },
         undefined,
@@ -89,7 +90,7 @@ describe('UrlManagementService', () => {
         service.createUrl(userId, shortUrl, longUrl, file),
       ).resolves.toStrictEqual({ userId, longUrl, shortUrl })
       expect(userRepository.findById).toHaveBeenCalledWith(userId)
-      expect(urlRepository.findByShortUrl).toHaveBeenCalledWith(shortUrl)
+      expect(userRepository.findUserByUrl).toHaveBeenCalledWith(shortUrl)
       expect(urlRepository.create).toHaveBeenCalledWith(
         { userId, longUrl, shortUrl },
         {

--- a/test/server/services/UrlManagementService.test.ts
+++ b/test/server/services/UrlManagementService.test.ts
@@ -10,6 +10,7 @@ describe('UrlManagementService', () => {
     findById: jest.fn(),
     findByEmail: jest.fn(),
     findOneUrlForUser: jest.fn(),
+    findUserByUrl: jest.fn(),
     findUrlsForUser: jest.fn(),
     findOrCreateWithEmail: jest.fn(),
   }


### PR DESCRIPTION
## Problem
It is not obvious to the user who they should speak to
when a link they are trying to create already exists. They
often have to turn to support, which then would have to do a
manual lookup via a database query.

## Solution

If the user attempts to create a link that already exists,
disclose the owner's e-mail

- Declare and implement `UserRepository.findUserByUrl()`
- Lookup owner if link already exists on creation, and disclose e-mail
  to user

## Screenshot
![image](https://user-images.githubusercontent.com/10572368/94143893-07128500-fea3-11ea-856e-2859f4c3e250.png)
