### PR TITLE
chore(monitoring): Logging logins, introduce HTTP 403 Forbidden responses when updating links

### DIFF
--- a/src/server/controllers/LoginController.ts
+++ b/src/server/controllers/LoginController.ts
@@ -65,6 +65,7 @@ export class LoginController implements LoginControllerInterface {
       const user = await this.authService.verifyOtp(email, otp)
       req.session!.user = user
       res.ok(jsonMessage('OTP hash verification ok.'))
+      console.info(`Login success for user:\t${user.email}`)
       return
     } catch (error) {
       if (error instanceof InvalidOtpError) {
@@ -73,10 +74,12 @@ export class LoginController implements LoginControllerInterface {
             `OTP hash verification failed, ${error.retries} attempt(s) remaining.`,
           ),
         )
+        console.info(`Login OTP verification failed for user:\t${email}`)
         return
       }
       if (error instanceof NotFoundError) {
         res.unauthorized(jsonMessage('OTP expired/not found.'))
+        console.info(`Login email not found for user:\t${email}`)
         return
       }
       res.serverError(jsonMessage(error.message))

--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -114,7 +114,7 @@ export class UserController implements UserControllerInterface {
       return
     } catch (error) {
       if (error instanceof NotFoundError) {
-        res.notFound(jsonMessage(error.message))
+        res.forbidden(jsonMessage(error.message))
         return
       }
       logger.error(`Error editing URL:\t${error}`)

--- a/src/server/util/response.ts
+++ b/src/server/util/response.ts
@@ -16,6 +16,9 @@ response.badRequest = function (content) {
 response.unauthorized = function (content) {
   this.status(401).send(content)
 }
+response.forbidden = function (content) {
+  this.status(403).send(content)
+}
 response.notFound = function (content) {
   this.status(404).send(content)
 }

--- a/src/types/server/api/express.d.ts
+++ b/src/types/server/api/express.d.ts
@@ -11,6 +11,7 @@ declare global {
       created(content?: Buffer | object | string): void
       badRequest(content?: Buffer | object | string): void
       unauthorized(content?: Buffer | object | string): void
+      forbidden(content?: Buffer | object | string): void
       notFound(content?: Buffer | object | string): void
       unsupportedMediaType(content?: Buffer | object | string): void
       unprocessableEntity(content?: Buffer | object | string): void


### PR DESCRIPTION
## Problem

The problems are twofold:

1. Login emails can be clearly logged when attempting to login.

2. HTTP 404 Not Found response is technically incorrect when a short link & user email URL object cannot be found. The better security posture is to treat it as an unauthorized attempt to modify a URL that does not belong to said user.

## Solution

1. Log all emails when OTP verification takes place, for both success and failure cases.

2. Use HTTP 403 Forbidden response if a short link cannot be found by the URL management service.


**Improvements**:

- Login logging
- Improved security posture

