### PR TITLE
fix: stop client from repeatedly calling endpoint

### DIFF
--- a/src/client/components/HomePage/StatisticsSliver.jsx
+++ b/src/client/components/HomePage/StatisticsSliver.jsx
@@ -89,10 +89,11 @@ const StatisticsSliver = (props) => {
     { label: 'CLICKS', number: clickCount },
   ]
 
+  const { loadStats } = props
+  // Call once
   useEffect(() => {
-    const { loadStats } = props
     loadStats()
-  })
+  }, [loadStats])
 
   return (
     <>

--- a/src/server/repositories/StatisticsRepository.ts
+++ b/src/server/repositories/StatisticsRepository.ts
@@ -31,7 +31,8 @@ export class StatisticsRepository implements StatisticsRepositoryInterface {
     }
 
     if (clickCount == null) {
-      clickCount = await Url.sum('clicks')
+      // Replace Nan with 0 if there is no data
+      clickCount = (await Url.sum('clicks')) || 0
       this.trySetCache(CLICK_COUNT_KEY, clickCount.toString())
     }
 


### PR DESCRIPTION
## Problem

To stop runaway API calls to /api/stats in development environment on fresh install

Reasons:
1. server returns wrong values
2. client having unlimited retries

Steps involved:

1. opening homepage 
2. in StatisticsSilver.jsx > useEffect runs on mount
3. loadStats() was called
4. checks for any NULL values in userCount, linkCount and clickCount.
5. confirmed that all values are NULL > call /api/stats endpoint
6. received userCount = 0, linkCount = 0 and clickCount = NULL
7. apply changes and re-renders
8. re-rendering triggers useEffect
9. loadstats() called again
10. checks that confirmed that clickCount is NULL > call /api/stats/ endpoint
11. repeat step 6


#659 

## Solution

To address both the client side and server side issues.

For the client side, we will prevent it from calling the endpoint multiple times.  

- useEffect in StatisticSilver.js will only be called once on mount.

For the server side, we will ensure clickCount returns 0 instead of NaN.
- The function, getGlobalStatistics, in StatisticsRepository.ts will return 0 for clickCount instead of NaN 

