### PR TITLE
chore(sql-fns): add isSearchable to url_histories insert

### DIFF
--- a/scripts/migrate_url_to_user.sql
+++ b/scripts/migrate_url_to_user.sql
@@ -12,6 +12,8 @@
 --   31 July 2019 github.com/jeantanzj: Function created
 --   12 June 2020 Foo Yong Jie:         Update function's url_history insertion step to include compulsory
 --                                      isFile column
+--   07 Oct  2020 @LoneRifle:           Update function's url_history insertion step to include compulsory
+--                                      isSearchable column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_url_to_user(short_url_value text, to_user_email text) RETURNS void AS
 $BODY$
@@ -43,8 +45,8 @@ BEGIN
         RAISE EXCEPTION 'No transferring of links to the same user';
     END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","isSearchable","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "isSearchable", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "shortUrl" = short_url LIMIT 1;
 -- Update the link in the URL table

--- a/scripts/migrate_user_links.sql
+++ b/scripts/migrate_user_links.sql
@@ -14,6 +14,8 @@
 --   11 July 2019 Yuanruo Liang: Function created
 --   12 June 2020 Foo Yong Jie: Update function's url_history insertion step to include
 --                              compulsory isFile column
+--   07 Oct  2020 @LoneRifle: Update function's url_history insertion step to include
+--                            compulsory isSearchable column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS void AS
 $BODY$
@@ -39,8 +41,8 @@ BEGIN
 		RAISE EXCEPTION 'No transferring of links to the same user';
 	END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","isSearchable","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "isSearchable", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "userId" = from_user_id;
 -- Update the links in the URL table


### PR DESCRIPTION
## Problem and Solution

Add the missing `isSearchable` column to the insert statement into `url_histories`
when migrating links via sql fn