### PR TITLE
bug: ellipsis for extra long shortened links

### DIFF
--- a/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.tsx
+++ b/src/client/components/UserPage/UserLinkTable/UrlTable/EnhancedTableBody/index.tsx
@@ -134,7 +134,12 @@ const useStyles = makeStyles((theme) => {
       textTransform: 'capitalize',
     },
     shortUrl: {
-      width: 'calc(100% - 32px)',
+      [theme.breakpoints.up('md')]: {
+        maxWidth: '400px',
+      },
+      [theme.breakpoints.down('sm')]: {
+        width: 'calc(100% - 32px)',
+      },
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
@@ -203,9 +208,11 @@ export default function EnhancedTableBody() {
             <TableCell align="left" className={classes.urlCell}>
               <Grid container direction="column">
                 <Grid item className={classes.shortUrlGrid}>
+                <Tooltip title={row.shortUrl} placement="top-start" arrow>
                   <Typography variant="h6" className={classes.shortUrl}>
                     /{row.shortUrl}
                   </Typography>
+                </Tooltip>
                 </Grid>
                 <Hidden smDown>
                   <Grid item className={classes.longUrlGrid}>


### PR DESCRIPTION
## Problem

When user create an extra long link, the user table will overflow and this pushes the other columns out of sight.

Closes https://github.com/opengovsg/GoGovSG/issues/411

## Solution

Set `maxWidth = 400px` to the `shortUrl` div for viewport bigger than `md`. Also add tooltip to show the full URL when hover above the short URL.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/5955220/95654256-76d67000-0b31-11eb-8c70-cf1a384839e0.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/5955220/95654229-4d1d4900-0b31-11eb-8a63-a0f536dbda9c.png)
![image](https://user-images.githubusercontent.com/5955220/95654247-68885400-0b31-11eb-86e1-35325b6c8263.png)

