### PR TITLE
fix(announcements): tweak padding for message

### DIFF
--- a/src/client/components/UserPage/AnnouncementModal/index.tsx
+++ b/src/client/components/UserPage/AnnouncementModal/index.tsx
@@ -43,6 +43,10 @@ const useStyles = makeStyles((theme) =>
       justifyContent: 'center',
       width: '100%',
     },
+    messagePadding: {
+      paddingLeft: theme.spacing(4),
+      paddingRight: theme.spacing(4),
+    },
     closeIconButton: {
       fill: (props) =>
         // @ts-ignore
@@ -174,9 +178,10 @@ export default function AnnouncementModal() {
           alt=""
           src={announcement.image}
         />
-      ) : 
-      (
-        <div className={`${classes.justifyCenter} ${classes.announcementPadding}`} />
+      ) : (
+        <div
+          className={`${classes.justifyCenter} ${classes.announcementPadding}`}
+        />
       )}
       {announcement?.subtitle ? (
         <Typography
@@ -188,7 +193,10 @@ export default function AnnouncementModal() {
         </Typography>
       ) : null}
       {announcement?.message ? (
-        <Typography className={classes.justifyCenter} variant="body2">
+        <Typography
+          className={`${classes.justifyCenter} ${classes.messagePadding}`}
+          variant="body2"
+        >
           {announcement.message}
         </Typography>
       ) : null}


### PR DESCRIPTION
## Problem and Solution

Introduce some padding for announcement modal message to provide some alignment

![image](https://user-images.githubusercontent.com/10572368/96092312-49a50b80-0efd-11eb-8dfc-a5f7e660ea58.png)

![image](https://user-images.githubusercontent.com/10572368/96092451-79ecaa00-0efd-11eb-927e-3776d4feec9a.png)

Addresses part of #733 
