### PR TITLE
feat: ga and sentry tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22121,6 +22121,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-ga": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.1.2.tgz",
+      "integrity": "sha512-OJrMqaHEHbodm+XsnjA6ISBEHTwvpFrxco65mctzl/v3CASMSLSyUkFqz9yYrPDKGBUfNQzKCjuMJwctjlWBbw=="
+    },
     "react-i18next": {
       "version": "11.7.3",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react": "^16.13.1",
     "react-chartjs-2": "^2.10.0",
     "react-dom": "^16.13.1",
+    "react-ga": "^3.1.2",
     "react-i18next": "^11.7.3",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",

--- a/src/client/actions/ga/index.tsx
+++ b/src/client/actions/ga/index.tsx
@@ -16,18 +16,18 @@ const getGaId = async () => {
   }
 /**
  * Send GA Event to record click - customise the category, action and label name to record multiple uniques per session
- * @param {string} categoryName
- * @param {string} eventName
+ * @param {string} category
+ * @param {string} action
  * @param {string} [label='nothing']
  */
-export const GAEvent = async (categoryName:string, eventName:string, label?: string| undefined) => {
+export const GAEvent = async (category:string, action:string, label: string = 'nothing') => {
     if (!hasInit) {
         await getGaId()
     }
     ReactGA.event({       
-        category: categoryName,  // Required
-        action: eventName,       // Required
-        label: label || 'nothing',       
+        category: category,  // Required
+        action: action,       // Required
+        label: label,       
         value: 10,       
         nonInteraction: false     
     }); 

--- a/src/client/actions/ga/index.tsx
+++ b/src/client/actions/ga/index.tsx
@@ -14,8 +14,13 @@ const getGaId = async () => {
       }
     })
   }
-// Records clicks - customise action and label name to record multiple uniques per session
-export const GAevent = async (categoryName:string, eventName:string, label?: string| undefined) => {
+/**
+ * Send GA Event to record click - customise the category, action and label name to record multiple uniques per session
+ * @param {string} categoryName
+ * @param {string} eventName
+ * @param {string} [label='nothing']
+ */
+export const GAEvent = async (categoryName:string, eventName:string, label?: string| undefined) => {
     if (!hasInit) {
         await getGaId()
     }
@@ -27,9 +32,12 @@ export const GAevent = async (categoryName:string, eventName:string, label?: str
         nonInteraction: false     
     }); 
 }
-
-// Records clicks and time on page - once per session
-export const GApageView = async (page:string, title?:string) => {   
+/**
+ * Send GA Pageview to record time on page - once per session
+ * @param {string} page
+ * @param {string} [title=undefined]
+ */
+export const GAPageView = async (page:string, title?:string) => {   
     if (!hasInit) {
         await getGaId()
     }

--- a/src/client/actions/gaEvents/index.tsx
+++ b/src/client/actions/gaEvents/index.tsx
@@ -1,0 +1,37 @@
+import ReactGA from 'react-ga'
+import { get } from '../../util/requests'
+
+// Checks if reactga has initalised
+let hasInit = false
+
+const getGaId = async () => {
+    await get('/api/ga').then(async (response) => {
+      if(response.ok) {
+        await response.text().then((gaid) => {
+            ReactGA.initialize(gaid)
+            hasInit = true
+        })
+      }
+    })
+  }
+// Records clicks - customise action and label name to record multiple uniques per session
+export const GAevent = async (categoryName:string, eventName:string, label?: string| undefined) => {
+    if (!hasInit) {
+        await getGaId()
+    }
+    ReactGA.event({       
+        category: categoryName,  // Required
+        action: eventName,       // Required
+        label: label || 'nothing',       
+        value: 10,       
+        nonInteraction: false     
+    }); 
+}
+
+// Records clicks and time on page - once per session
+export const GApageView = async (page:string, title?:string) => {   
+    if (!hasInit) {
+        await getGaId()
+    }
+    ReactGA.pageview(page, undefined ,title);  
+}

--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -2,7 +2,8 @@ import { Minimatch } from 'minimatch'
 import { Dispatch } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 import validator from 'validator'
-
+import * as Sentry from '@sentry/browser'
+import { GAevent } from '../gaEvents'
 import {
   EmailValidatorType,
   GET_OTP_EMAIL_ERROR,
@@ -260,6 +261,10 @@ const verifyOTP = () => (
         )
         dispatch<void>(isLoggedIn())
       } else {
+        // Sentry analytics and Google Analytics: otp fail > sign in fails
+        Sentry.captureMessage('submit otp unsuccessful')
+        GAevent('LOGIN PAGE', 'otp', 'unsuccessful')
+
         const { message } = json
         dispatch<VerifyOtpErrorAction>(isVerifyOTPError())
         dispatch<SetErrorMessageAction>(rootActions.setErrorMessage(message))

--- a/src/client/actions/login/index.ts
+++ b/src/client/actions/login/index.ts
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 import validator from 'validator'
 import * as Sentry from '@sentry/browser'
-import { GAevent } from '../gaEvents'
+import { GAEvent } from '../ga'
 import {
   EmailValidatorType,
   GET_OTP_EMAIL_ERROR,
@@ -263,7 +263,7 @@ const verifyOTP = () => (
       } else {
         // Sentry analytics and Google Analytics: otp fail > sign in fails
         Sentry.captureMessage('submit otp unsuccessful')
-        GAevent('LOGIN PAGE', 'otp', 'unsuccessful')
+        GAEvent('login page', 'otp', 'unsuccessful')
 
         const { message } = json
         dispatch<VerifyOtpErrorAction>(isVerifyOTPError())

--- a/src/client/actions/search/index.ts
+++ b/src/client/actions/search/index.ts
@@ -14,7 +14,7 @@ import { SearchResultsSortOrder } from '../../../shared/search'
 import { UrlTypePublic } from '../../reducers/search/types'
 import { get } from '../../util/requests'
 import { SEARCH_PAGE } from '../../util/types'
-import { GAevent } from '../gaEvents'
+import { GAEvent } from '../ga'
 
 function setSearchResults(payload: {
   count: number
@@ -62,7 +62,7 @@ const getSearchResults = (
     )
     return
   }
-  GAevent('SEARCH PAGE', query)
+  GAEvent('search page', query)
   dispatch(
     setSearchResults({
       count: json.count,

--- a/src/client/actions/search/index.ts
+++ b/src/client/actions/search/index.ts
@@ -14,6 +14,7 @@ import { SearchResultsSortOrder } from '../../../shared/search'
 import { UrlTypePublic } from '../../reducers/search/types'
 import { get } from '../../util/requests'
 import { SEARCH_PAGE } from '../../util/types'
+import { GAevent } from '../gaEvents'
 
 function setSearchResults(payload: {
   count: number
@@ -61,7 +62,7 @@ const getSearchResults = (
     )
     return
   }
-
+  GAevent('SEARCH PAGE', query)
   dispatch(
     setSearchResults({
       count: json.count,

--- a/src/client/actions/user/index.ts
+++ b/src/client/actions/user/index.ts
@@ -77,7 +77,7 @@ import {
 import { GetReduxState } from '../types'
 import { GoGovReduxState } from '../../reducers/types'
 import { MessageType } from '../../../shared/util/messages'
-import { GAevent } from '../gaEvents'
+import { GAEvent } from '../ga'
 
 const isFetchingUrls: (payload: boolean) => IsFetchingUrlsAction = (
   payload,
@@ -569,7 +569,7 @@ const createUrlOrRedirect = (history: History) => async (
   if (!/^[a-z0-9-]/.test(shortUrl)) {
     // Sentry analytics: create link with url fail
     Sentry.captureMessage('create link with url unsuccessful')
-    GAevent('MODAL PAGE', 'create link from url', 'unsuccessful')
+    GAEvent('modal page', 'create link from url', 'unsuccessful')
 
     dispatch<SetErrorMessageAction>(
       rootActions.setErrorMessage(
@@ -588,7 +588,7 @@ const createUrlOrRedirect = (history: History) => async (
   if (!isValidUrl(longUrl)) {
     // Sentry analytics: create link with url fail
     Sentry.captureMessage('create link with url unsuccessful')
-    GAevent('MODAL PAGE', 'create link from url', 'unsuccessful')
+    GAEvent('modal page', 'create link from url', 'unsuccessful')
 
     dispatch<SetErrorMessageAction>(
       rootActions.setErrorMessage('URL is invalid.'),
@@ -601,7 +601,7 @@ const createUrlOrRedirect = (history: History) => async (
   if (!response.ok) {
     // Sentry analytics: create link with url fail
     Sentry.captureMessage('create link with url unsuccessful')
-    GAevent('MODAL PAGE', 'create link from url', 'unsuccessful')
+    GAEvent('modal page', 'create link from url', 'unsuccessful')
 
     if (response.status === 401) {
       history.push(LOGIN_PAGE)
@@ -630,8 +630,8 @@ const transferOwnership = (
     (response) => {
       if (response.ok) {
         // Google Analytics: Transfer ownership - success and shorturl are combined together to create unique actions
-        GAevent(
-          'TRANSFER LINK OWNERSHIP',
+        GAEvent(
+          'transfer link ownership',
           'successful',
           `/${shortUrl.toString()}`,
         )
@@ -644,8 +644,8 @@ const transferOwnership = (
       } else {
         // Sentry analytics: transfer ownership fail
         Sentry.captureMessage('transfer ownership unsuccessful')
-        GAevent(
-          'TRANSFER LINK OWNERSHIP',
+        GAEvent(
+          'transfer link ownership',
           'unsuccessful',
           `/${shortUrl.toString()}`,
         )
@@ -684,7 +684,7 @@ const uploadFile = (file: File) => async (
   if (file == null) {
     // Sentry analytics: create link with file fail
     Sentry.captureMessage('create link with file unsuccessful')
-    GAevent('MODAL PAGE', 'create link from file', 'unsuccessful')
+    GAEvent('modal page', 'create link from file', 'unsuccessful')
 
     dispatch<SetErrorMessageAction>(
       rootActions.setErrorMessage('File is missing.'),
@@ -700,7 +700,7 @@ const uploadFile = (file: File) => async (
   if (!response.ok) {
     // Sentry analytics: create link with file fail
     Sentry.captureMessage('create link with file unsuccessful')
-    GAevent('MODAL PAGE', 'create link from file', 'unsuccessful')
+    GAEvent('modal page', 'create link from file', 'unsuccessful')
 
     await handleError(dispatch, response)
     return false

--- a/src/client/components/HomePage/index.jsx
+++ b/src/client/components/HomePage/index.jsx
@@ -15,6 +15,7 @@ import LandingGraphicSilver from './LandingGraphicSilver'
 import IntegratedSearchLandingGraphic from './IntegratedSearchLandingGraphic'
 import BaseLayout from '../BaseLayout'
 import { IS_SEARCH_HIDDEN } from '../../util/config'
+import { GAevent, GApageView } from '../../actions/gaEvents'
 
 const mapDispatchToProps = (dispatch) => ({
   getLinksToRotate: () => dispatch(homeActions.getLinksToRotate()),
@@ -32,6 +33,12 @@ const HomePage = (props) => {
   const { isLoggedIn } = props
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+
+  // Google Analytics: Home Page
+  useEffect(() => {
+    GApageView('HOME PAGE')
+    GAevent('HOME PAGE', 'Entering home page')
+  }, [])
 
   useEffect(() => {
     const { getLinksToRotate, getIsLoggedIn } = props

--- a/src/client/components/HomePage/index.jsx
+++ b/src/client/components/HomePage/index.jsx
@@ -15,7 +15,7 @@ import LandingGraphicSilver from './LandingGraphicSilver'
 import IntegratedSearchLandingGraphic from './IntegratedSearchLandingGraphic'
 import BaseLayout from '../BaseLayout'
 import { IS_SEARCH_HIDDEN } from '../../util/config'
-import { GAevent, GApageView } from '../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../actions/ga'
 
 const mapDispatchToProps = (dispatch) => ({
   getLinksToRotate: () => dispatch(homeActions.getLinksToRotate()),
@@ -36,8 +36,8 @@ const HomePage = (props) => {
 
   // Google Analytics: Home Page
   useEffect(() => {
-    GApageView('HOME PAGE')
-    GAevent('HOME PAGE', 'Entering home page')
+    GAPageView('HOME PAGE')
+    GAEvent('home page', 'Entering home page')
   }, [])
 
   useEffect(() => {

--- a/src/client/components/LoginPage/LoginForm.jsx
+++ b/src/client/components/LoginPage/LoginForm.jsx
@@ -7,7 +7,7 @@ import { Button, TextField, createStyles, makeStyles } from '@material-ui/core'
 import { loginFormVariants } from '~/util/types'
 import loginActions from '~/actions/login'
 import TextButton from './widgets/TextButton'
-import { GAevent, GApageView } from '../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../actions/ga'
 
 const mapDispatchToProps = (dispatch) => ({
   getOTPEmail: (value) => dispatch(loginActions.getOTPEmail(value)),
@@ -69,8 +69,8 @@ const LoginForm = ({
         submit()
         // Google Analytics: OTP page, Transition from email > OTP page
         if (isEmailView) {
-          GApageView('OTP LOGIN PAGE')
-          GAevent('LOGIN PAGE', 'otp', 'successful')
+          GAPageView('OTP LOGIN PAGE')
+          GAEvent('login page', 'otp', 'successful')
         }
       }}
       hidden={hidden}

--- a/src/client/components/LoginPage/LoginForm.jsx
+++ b/src/client/components/LoginPage/LoginForm.jsx
@@ -7,6 +7,7 @@ import { Button, TextField, createStyles, makeStyles } from '@material-ui/core'
 import { loginFormVariants } from '~/util/types'
 import loginActions from '~/actions/login'
 import TextButton from './widgets/TextButton'
+import { GAevent, GApageView } from '../../actions/gaEvents'
 
 const mapDispatchToProps = (dispatch) => ({
   getOTPEmail: (value) => dispatch(loginActions.getOTPEmail(value)),
@@ -66,6 +67,11 @@ const LoginForm = ({
       onSubmit={(e) => {
         e.preventDefault()
         submit()
+        // Google Analytics: OTP page, Transition from email > OTP page
+        if (isEmailView) {
+          GApageView('OTP LOGIN PAGE')
+          GAevent('LOGIN PAGE', 'otp', 'successful')
+        }
       }}
       hidden={hidden}
       autoComplete={autoComplete}

--- a/src/client/components/LoginPage/index.jsx
+++ b/src/client/components/LoginPage/index.jsx
@@ -21,6 +21,7 @@ import { get } from '../../util/requests'
 import LoginForm from './LoginForm'
 import Section from '../Section'
 import BaseLayout from '../BaseLayout'
+import { GAevent, GApageView } from '../../actions/gaEvents'
 
 const mapDispatchToProps = (dispatch) => ({
   getOTPEmail: (value) => dispatch(loginActions.getOTPEmail(value)),
@@ -120,6 +121,13 @@ const LoginPage = ({
   setLoginInfoMessage,
 }) => {
   const classes = useStyles()
+
+  useEffect(() => {
+    // Google Analytics: Move into login page
+    GApageView('EMAIL LOGIN PAGE')
+    GAevent('LOGIN PAGE', 'email')
+  }, [])
+
   // Display a login message from the server
   useEffect(() => {
     let cancelled = false

--- a/src/client/components/LoginPage/index.jsx
+++ b/src/client/components/LoginPage/index.jsx
@@ -21,7 +21,7 @@ import { get } from '../../util/requests'
 import LoginForm from './LoginForm'
 import Section from '../Section'
 import BaseLayout from '../BaseLayout'
-import { GAevent, GApageView } from '../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../actions/ga'
 
 const mapDispatchToProps = (dispatch) => ({
   getOTPEmail: (value) => dispatch(loginActions.getOTPEmail(value)),
@@ -124,8 +124,8 @@ const LoginPage = ({
 
   useEffect(() => {
     // Google Analytics: Move into login page
-    GApageView('EMAIL LOGIN PAGE')
-    GAevent('LOGIN PAGE', 'email')
+    GAPageView('EMAIL LOGIN PAGE')
+    GAEvent('login page', 'email')
   }, [])
 
   // Display a login message from the server

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -27,7 +27,7 @@ import CollapsibleMessage from '../../CollapsibleMessage'
 import { CollapsibleMessageType } from '../../CollapsibleMessage/types'
 import FileInputField from '../widgets/FileInputField'
 import userActions from '~/actions/user'
-import { GAevent } from '../../../actions/gaEvents'
+import { GAEvent } from '../../../actions/ga'
 
 // Height of the text field in the create link dialog.
 const TEXT_FIELD_HEIGHT = 44
@@ -96,10 +96,10 @@ function CreateLinkForm({
   useEffect(() => {
     if (isFile) {
       // Google Analytics: click on 'from file' tab
-      GAevent('MODAL PAGE', 'click file tab')
+      GAEvent('modal page', 'click file tab')
     } else {
       // Google Analytics: click on 'from url' tab
-      GAevent('MODAL PAGE', 'click url tab')
+      GAEvent('modal page', 'click url tab')
     }
   }, [isFile])
 

--- a/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/CreateLinkForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import i18next from 'i18next'
@@ -27,6 +27,7 @@ import CollapsibleMessage from '../../CollapsibleMessage'
 import { CollapsibleMessageType } from '../../CollapsibleMessage/types'
 import FileInputField from '../widgets/FileInputField'
 import userActions from '~/actions/user'
+import { GAevent } from '../../../actions/gaEvents'
 
 // Height of the text field in the create link dialog.
 const TEXT_FIELD_HEIGHT = 44
@@ -91,6 +92,17 @@ function CreateLinkForm({
     (isFile && !!uploadFileError) ||
     isUploading ||
     !!createShortLinkError
+
+  useEffect(() => {
+    if (isFile) {
+      // Google Analytics: click on 'from file' tab
+      GAevent('MODAL PAGE', 'click file tab')
+    } else {
+      // Google Analytics: click on 'from url' tab
+      GAevent('MODAL PAGE', 'click url tab')
+    }
+  }, [isFile])
+
   return (
     <>
       <Hidden smUp>

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -16,7 +16,7 @@ import useFullScreenDialog from '../helpers/fullScreenDialog'
 import ModalMargins from './ModalMargins'
 import userActions from '../../../actions/user'
 import AddDescriptionForm from './AddDescriptionForm'
-import { GAevent, GApageView } from '../../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../../actions/ga'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -75,10 +75,10 @@ const CreateUrlModal = ({
     if (proceed) {
       if (args.length) {
         // Google Analytics: create link from file in modal page
-        GAevent('MODAL PAGE', 'create link from file', 'successful')
+        GAEvent('modal page', 'create link from file', 'successful')
       } else {
         // Google Analytics: create link from url in modal page
-        GAevent('MODAL PAGE', 'create link from url', 'successful')
+        GAEvent('modal page', 'create link from url', 'successful')
       }
       closeCreateUrlModal()
     }
@@ -92,12 +92,12 @@ const CreateUrlModal = ({
     if (createUrlModal) {
       setStep(0)
       // Google Analytics: open link creation modal in user page
-      GApageView('CREATE LINK PAGE')
-      GAevent('USER PAGE', 'open link creation modal')
+      GAPageView('CREATE LINK PAGE')
+      GAEvent('user page', 'open link creation modal')
 
       return () => {
         // Google Analytics: close link creation modal in user page
-        GApageView('USER PAGE')
+        GAPageView('USER PAGE')
       }
     }
     return undefined

--- a/src/client/components/UserPage/CreateUrlModal/index.jsx
+++ b/src/client/components/UserPage/CreateUrlModal/index.jsx
@@ -16,6 +16,7 @@ import useFullScreenDialog from '../helpers/fullScreenDialog'
 import ModalMargins from './ModalMargins'
 import userActions from '../../../actions/user'
 import AddDescriptionForm from './AddDescriptionForm'
+import { GAevent, GApageView } from '../../../actions/gaEvents'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -72,6 +73,13 @@ const CreateUrlModal = ({
   const incrementDecorator = (func) => async (...args) => {
     const proceed = await func(...args)
     if (proceed) {
+      if (args.length) {
+        // Google Analytics: create link from file in modal page
+        GAevent('MODAL PAGE', 'create link from file', 'successful')
+      } else {
+        // Google Analytics: create link from url in modal page
+        GAevent('MODAL PAGE', 'create link from url', 'successful')
+      }
       closeCreateUrlModal()
     }
   }
@@ -81,7 +89,18 @@ const CreateUrlModal = ({
 
   // Reset step when modal closes and reopens
   useEffect(() => {
-    if (createUrlModal) setStep(0)
+    if (createUrlModal) {
+      setStep(0)
+      // Google Analytics: open link creation modal in user page
+      GApageView('CREATE LINK PAGE')
+      GAevent('USER PAGE', 'open link creation modal')
+
+      return () => {
+        // Google Analytics: close link creation modal in user page
+        GApageView('USER PAGE')
+      }
+    }
+    return undefined
   }, [createUrlModal])
   return (
     <Dialog

--- a/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/index.tsx
@@ -22,7 +22,7 @@ import devicesLogo from './assets/devices-logo.svg'
 import clicksLogo from './assets/chart-logo.svg'
 import trafficLogo from './assets/traffic-logo.svg'
 import BetaTag from '../../../../widgets/BetaTag'
-import { GAevent, GApageView } from '../../../../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../../../../actions/ga'
 
 const useLinkAnalyticsStyles = makeStyles((theme) =>
   createStyles({
@@ -224,11 +224,11 @@ function Graphs(props: GraphsProps) {
 
   useEffect(() => {
     // Google Analytics: default device page and event on opening drawer
-    GApageView('DEVICE PAGE')
-    GAevent('DRAWER PAGE Analytics Data', 'device', '/' + props.shortUrl)
+    GAPageView('DEVICE PAGE')
+    GAEvent('drawer page analytics data', 'device', '/' + props.shortUrl)
 
     return () => {
-      GApageView('USER PAGE')
+      GAPageView('USER PAGE')
     }
   }, [])
 
@@ -237,8 +237,8 @@ function Graphs(props: GraphsProps) {
 
     // Google Analytics: analytics data on device, clicks and traffics
     const daType:string = daMap.get(newValue) || 'DEVICE PAGE'
-    GApageView(daType.toUpperCase() + ' PAGE')
-    GAevent('DRAWER PAGE Analytics Data', daType, '/' + props.shortUrl)
+    GAPageView(daType.toUpperCase() + ' PAGE')
+    GAEvent('drawer page analytics data', daType, '/' + props.shortUrl)
   }
 
   const getIconStyle = (index: number) => {

--- a/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/index.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Typography,
   createStyles,
@@ -22,6 +22,7 @@ import devicesLogo from './assets/devices-logo.svg'
 import clicksLogo from './assets/chart-logo.svg'
 import trafficLogo from './assets/traffic-logo.svg'
 import BetaTag from '../../../../widgets/BetaTag'
+import { GAevent, GApageView } from '../../../../../actions/gaEvents'
 
 const useLinkAnalyticsStyles = makeStyles((theme) =>
   createStyles({
@@ -126,7 +127,7 @@ function LinkStatisticsGraphs() {
     )
   }
 
-  return <Graphs data={linkStatistics.contents!} />
+  return <Graphs data={linkStatistics.contents!} shortUrl={shortUrl} />
 }
 
 export type TabPanelProps = {
@@ -207,6 +208,7 @@ const useStyles = makeStyles(() => ({
 
 export type GraphsProps = {
   data: LinkStatisticsInterface
+  shortUrl : string
 }
 
 function Graphs(props: GraphsProps) {
@@ -214,8 +216,29 @@ function Graphs(props: GraphsProps) {
   const theme = useTheme()
   const [tabValue, setTabValue] = useState<number>(0)
 
+  // Map number to type for display
+  const daMap = new Map<Number, string>()
+  daMap.set(0, 'device')
+  daMap.set(1, 'clicks')
+  daMap.set(2, 'traffic')
+
+  useEffect(() => {
+    // Google Analytics: default device page and event on opening drawer
+    GApageView('DEVICE PAGE')
+    GAevent('DRAWER PAGE Analytics Data', 'device', '/' + props.shortUrl)
+
+    return () => {
+      GApageView('USER PAGE')
+    }
+  }, [])
+
   const handleChange = (_: React.ChangeEvent<{}>, newValue: number) => {
     setTabValue(newValue)
+
+    // Google Analytics: analytics data on device, clicks and traffics
+    const daType:string = daMap.get(newValue) || 'DEVICE PAGE'
+    GApageView(daType.toUpperCase() + ' PAGE')
+    GAevent('DRAWER PAGE Analytics Data', daType, '/' + props.shortUrl)
   }
 
   const getIconStyle = (index: number) => {

--- a/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/util/statistics.ts
+++ b/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/util/statistics.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import * as Sentry from '@sentry/browser'
 import { get } from '../../../../../../util/requests'
 import { LinkStatisticsInterface } from '../../../../../../../shared/interfaces/link-statistics'
-import { GAevent } from '../../../../../../actions/gaEvents'
+import { GAEvent } from '../../../../../../actions/ga'
 
 export type LinkStatistics = {
   status: number | null
@@ -26,8 +26,8 @@ export const useStatistics = (shortUrl: string) => {
       if (response.status !== 200) {
         // Sentry analytics: fetching analytics fail
         Sentry.captureMessage(`fetching analytics data unsuccessful`)
-        GAevent(
-          'DRAWER PAGE Analytics Data',
+        GAEvent(
+          'drawer page analytics data',
           'fetch analytics data',
           'unsuccessful',
         )

--- a/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/util/statistics.ts
+++ b/src/client/components/UserPage/Drawer/ControlPanel/LinkAnalytics/util/statistics.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 
+import * as Sentry from '@sentry/browser'
 import { get } from '../../../../../../util/requests'
 import { LinkStatisticsInterface } from '../../../../../../../shared/interfaces/link-statistics'
+import { GAevent } from '../../../../../../actions/gaEvents'
 
 export type LinkStatistics = {
   status: number | null
@@ -20,6 +22,17 @@ export const useStatistics = (shortUrl: string) => {
     const fetchStatistics = async () => {
       const endpoint = `/api/link-stats?url=${shortUrl}`
       const response = await get(endpoint)
+
+      if (response.status !== 200) {
+        // Sentry analytics: fetching analytics fail
+        Sentry.captureMessage(`fetching analytics data unsuccessful`)
+        GAevent(
+          'DRAWER PAGE Analytics Data',
+          'fetch analytics data',
+          'unsuccessful',
+        )
+      }
+
       const linkStatistics: LinkStatistics = {
         status: response.status,
         contents: await response.json(),

--- a/src/client/components/UserPage/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -13,6 +13,8 @@ import downloadIcon from '../assets/download-icon.svg'
 import { useDrawerState } from '../..'
 import ImageFormat from '../../../../../../shared/util/image-format'
 import { get } from '../../../../../util/requests'
+import { GAevent } from '../../../../../actions/gaEvents'
+import * as Sentry from '@sentry/browser'
 
 // Gets file extension from content-type.
 function getFileExtension(format: ImageFormat) {
@@ -39,6 +41,8 @@ async function downloadServerQrCode(
   )}&format=${encodeURIComponent(format)}`
   const response: Response = await get(endpoint)
   if (response.ok) {
+    // Google Analytics: QR Code generation - actions are stringed by shortlink and format
+    GAevent('QR CODE GENERATION', format.toString(), 'succesful')
     // Use filename from response for filename, fallbacks to endpoint.
     const fileName = response.headers.get('Filename') ?? url
     const bodyBlob = await response.blob()
@@ -46,6 +50,10 @@ async function downloadServerQrCode(
       type: response.headers.get('content-type') || format,
     })
     FileSaver.saveAs(blob, `${fileName}.${getFileExtension(format)}`)
+  } else {
+    // Sentry analytics: qr code download fail
+    Sentry.captureMessage(`generate qr code for ${format} unsuccessful`)
+    GAevent('QR CODE GENERATION', format.toString(), 'unsuccesful')
   }
 }
 

--- a/src/client/components/UserPage/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -13,7 +13,7 @@ import downloadIcon from '../assets/download-icon.svg'
 import { useDrawerState } from '../..'
 import ImageFormat from '../../../../../../shared/util/image-format'
 import { get } from '../../../../../util/requests'
-import { GAevent } from '../../../../../actions/gaEvents'
+import { GAEvent } from '../../../../../actions/ga'
 import * as Sentry from '@sentry/browser'
 
 // Gets file extension from content-type.
@@ -42,7 +42,7 @@ async function downloadServerQrCode(
   const response: Response = await get(endpoint)
   if (response.ok) {
     // Google Analytics: QR Code generation - actions are stringed by shortlink and format
-    GAevent('QR CODE GENERATION', format.toString(), 'succesful')
+    GAEvent('qr code generation', format.toString(), 'succesful')
     // Use filename from response for filename, fallbacks to endpoint.
     const fileName = response.headers.get('Filename') ?? url
     const bodyBlob = await response.blob()
@@ -53,7 +53,7 @@ async function downloadServerQrCode(
   } else {
     // Sentry analytics: qr code download fail
     Sentry.captureMessage(`generate qr code for ${format} unsuccessful`)
-    GAevent('QR CODE GENERATION', format.toString(), 'unsuccesful')
+    GAEvent('qr code generation', format.toString(), 'unsuccesful')
   }
 }
 

--- a/src/client/components/UserPage/index.jsx
+++ b/src/client/components/UserPage/index.jsx
@@ -11,7 +11,7 @@ import UserLinkTable from './UserLinkTable'
 import EmptyState from './EmptyState'
 import useIsFiltered from './EmptyState/isFiltered'
 import loginActions from '~/actions/login'
-import { GAevent, GApageView } from '../../actions/gaEvents'
+import { GAEvent, GAPageView } from '../../actions/ga'
 
 /**
  * List URLs belonging to the user in a table.
@@ -66,8 +66,8 @@ const UserPage = ({
   useEffect(() => {
     if (isLoggedIn) {
       // Google Analytics: User page, to record sign in - act as exit for otp, devices, clicks and traffic page
-      GApageView('USER PAGE')
-      GAevent('USER PAGE', 'main')
+      GAPageView('USER PAGE')
+      GAEvent('user page', 'main')
     }
   }, [isLoggedIn])
 

--- a/src/client/components/UserPage/index.jsx
+++ b/src/client/components/UserPage/index.jsx
@@ -11,6 +11,7 @@ import UserLinkTable from './UserLinkTable'
 import EmptyState from './EmptyState'
 import useIsFiltered from './EmptyState/isFiltered'
 import loginActions from '~/actions/login'
+import { GAevent, GApageView } from '../../actions/gaEvents'
 
 /**
  * List URLs belonging to the user in a table.
@@ -61,6 +62,14 @@ const UserPage = ({
     message,
     getUserMessage,
   ])
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      // Google Analytics: User page, to record sign in - act as exit for otp, devices, clicks and traffic page
+      GApageView('USER PAGE')
+      GAevent('USER PAGE', 'main')
+    }
+  }, [isLoggedIn])
 
   if (isLoggedIn) {
     return (

--- a/src/client/util/download.js
+++ b/src/client/util/download.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser'
 import rootActions from '~/actions/root'
 import userActions from '~/actions/user'
 import { useIsIE } from '../components/BaseLayout/util/ie'
-import { GAevent } from '../actions/gaEvents'
+import { GAEvent } from '../actions/ga'
 
 export const downloadUrls = async (urlCount, tableConfig) => {
   const urlsArr = []
@@ -54,14 +54,14 @@ export const downloadUrls = async (urlCount, tableConfig) => {
       } else if (!isOk && json) {
         // Sentry analytics: download links fail
         Sentry.captureMessage('download links unsuccessful')
-        GAevent('USER PAGE', 'download links', 'unsuccessful')
+        GAEvent('user page', 'download links', 'unsuccessful')
 
         rootActions.setErrorMessage(json.message)
         return null
       } else {
         // Sentry analytics: download links fail
         Sentry.captureMessage('download links unsuccessful')
-        GAevent('USER PAGE', 'download links', 'unsuccessful')
+        GAEvent('user page', 'download links', 'unsuccessful')
 
         rootActions.setErrorMessage('Error downloading urls.')
         return null
@@ -80,7 +80,7 @@ export const downloadUrls = async (urlCount, tableConfig) => {
   }
 
   // Google Analytics: Download links button events
-  GAevent('USER PAGE', 'download links button', 'successful')
+  GAEvent('user page', 'download links button', 'successful')
   return null
 }
 

--- a/src/client/util/download.js
+++ b/src/client/util/download.js
@@ -1,7 +1,9 @@
 import { saveAs } from 'file-saver'
+import * as Sentry from '@sentry/browser'
 import rootActions from '~/actions/root'
 import userActions from '~/actions/user'
 import { useIsIE } from '../components/BaseLayout/util/ie'
+import { GAevent } from '../actions/gaEvents'
 
 export const downloadUrls = async (urlCount, tableConfig) => {
   const urlsArr = []
@@ -50,9 +52,17 @@ export const downloadUrls = async (urlCount, tableConfig) => {
           ])
         })
       } else if (!isOk && json) {
+        // Sentry analytics: download links fail
+        Sentry.captureMessage('download links unsuccessful')
+        GAevent('USER PAGE', 'download links', 'unsuccessful')
+
         rootActions.setErrorMessage(json.message)
         return null
       } else {
+        // Sentry analytics: download links fail
+        Sentry.captureMessage('download links unsuccessful')
+        GAevent('USER PAGE', 'download links', 'unsuccessful')
+
         rootActions.setErrorMessage('Error downloading urls.')
         return null
       }
@@ -68,6 +78,9 @@ export const downloadUrls = async (urlCount, tableConfig) => {
   } else {
     saveAs(blob, 'urls.csv')
   }
+
+  // Google Analytics: Download links button events
+  GAevent('USER PAGE', 'download links button', 'successful')
   return null
 }
 

--- a/src/server/api/ga.ts
+++ b/src/server/api/ga.ts
@@ -1,0 +1,17 @@
+import Express from 'express'
+import { container } from '../util/inversify'
+import { GaControllerInterface } from '../controllers/interfaces/GaControllerInterface'
+import { DependencyIds } from '../constants'
+
+const router = Express.Router()
+
+const gaController = container.get<GaControllerInterface>(
+  DependencyIds.gaController,
+)
+
+/**
+ * Requests for the Google Analytics id.
+ */
+router.get('/', gaController.getGaId)
+
+module.exports = router

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -11,6 +11,7 @@ router.use('/stats', require('./statistics'))
 router.use('/sentry', require('./sentry'))
 router.use('/links', require('./links'))
 router.use('/search', require('./search'))
+router.use('/ga', require('./ga'))
 
 /**
  * To protect private user routes.

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -21,6 +21,7 @@ export const DependencyIds = {
   statisticsService: Symbol.for('repositoryService'),
   statisticsController: Symbol.for('statisticsController'),
   sentryController: Symbol.for('sentryController'),
+  gaController: Symbol.for('gaController'),
   linksController: Symbol.for('linksController'),
   authService: Symbol.for('authService'),
   loginController: Symbol.for('loginController'),

--- a/src/server/controllers/GaController.ts
+++ b/src/server/controllers/GaController.ts
@@ -1,0 +1,15 @@
+/* eslint-disable class-methods-use-this */
+import Express from 'express'
+import { injectable } from 'inversify'
+import { gaTrackingId } from '../config'
+import { GaControllerInterface } from './interfaces/GaControllerInterface'
+
+@injectable()
+export class GaController implements GaControllerInterface {
+  getGaId(_: Express.Request, res: Express.Response) {
+    res.send(gaTrackingId)
+    return
+  }
+}
+
+export default GaController

--- a/src/server/controllers/interfaces/GaControllerInterface.ts
+++ b/src/server/controllers/interfaces/GaControllerInterface.ts
@@ -1,0 +1,8 @@
+import Express from 'express'
+
+export interface GaControllerInterface {
+  /**
+   * Requests for the Google Analytics ID.
+   */
+  getGaId(req: Express.Request, res: Express.Response): void
+}

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -29,6 +29,7 @@ import { UserMapper } from './mappers/UserMapper'
 import { OtpMapper } from './mappers/OtpMapper'
 import { RedirectService } from './services/RedirectService'
 import { RedirectController } from './controllers/RedirectController'
+import { GaController } from './controllers/GaController'
 import { CrawlerCheckService } from './services/CrawlerCheckService'
 import { StatisticsRepository } from './repositories/StatisticsRepository'
 import { StatisticsService } from './services/StatisticsService'
@@ -85,6 +86,7 @@ export default () => {
   bindIfUnbound(DependencyIds.userRepository, UserRepository)
   bindIfUnbound(DependencyIds.cryptography, CryptographyBcrypt)
   bindIfUnbound(DependencyIds.redirectController, RedirectController)
+  bindIfUnbound(DependencyIds.gaController, GaController)
   bindIfUnbound(DependencyIds.redirectService, RedirectService)
   bindIfUnbound(DependencyIds.crawlerCheckService, CrawlerCheckService)
   bindIfUnbound(DependencyIds.statisticsController, StatisticsController)


### PR DESCRIPTION
## Problem

To understand user's behaviour, we need to track their actions for both success and error cases with Google Analytics (GA) and Sentry IO

This closes #700 

## Solution

Send pageview hit to GA on page change
Send event hit to GA on click or state change, for both success and error cases
Send event hit to Sentry on state change for error cases

Error cases will be send to both GA and Sentry for experimentation 

**New dependencies**:

- react-ga

**Features**:

New endpoint to send GA id over to client for react-ga initialisation

GA pageviews:
- home page
- email login page
- otp login page
- link analytics device page
- link analytics clicks page
- link analytics traffic page
- create link modal page

GA events:
- enter home page
- enter login page to fill email
- enter login page to fill otp
- enter user page
- click on file tab in create link modal
- click on url tab in create link modal
- click on 'create link' button
- create link with file
- create link with url
- click and view device tab in drawer
- click and view clicks tab in drawer
- click and view traffic tab in drawer
- successfully generate qr code for either svg or png
- click on download links button
- search queries
- unsuccessful otp verification
- unsuccessful creation of link with url
- unsuccessful creation of link with file
- unsuccessful transfer of link ownership
- unsuccessful generation of qr code
- unable to download links
- unable to fetch analytics data

Sentry events:
- unsuccessful otp verification
- unsuccessful creation of link with url
- unsuccessful creation of link with file
- unsuccessful transfer of link ownership
- unsuccessful generation of qr code
- unable to download links
- unable to fetch analytics data
