### PR TITLE
feat(sql): create update_link_statistics only if exists

### DIFF
--- a/src/server/repositories/LinkStatisticsRepository.ts
+++ b/src/server/repositories/LinkStatisticsRepository.ts
@@ -22,45 +22,52 @@ const timeZone = 'Asia/Singapore'
 /**
  * This function is used to update the relevant link statistics tables, when called.
  */
-export const updateLinkStatistics = `CREATE OR REPLACE FUNCTION update_link_statistics (inputShortUrl text, device text)
-RETURNS void AS $$
+export const updateLinkStatistics = `DO $_$
 BEGIN
--- Update total clicks.
-UPDATE "${urlTable}" SET "clicks" = "${urlTable}"."clicks" + 1
-WHERE "shortUrl" = inputShortUrl;
--- Update devices clicks.
-IF device='mobile' THEN
-  INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
-  VALUES (inputShortUrl, 1, 0, 0, 0, current_timestamp, current_timestamp)
-  ON CONFLICT ("shortUrl")
-  DO UPDATE SET "mobile" = "${devicesTable}"."mobile" + 1;
-ELSIF device='tablet' THEN
-  INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
-  VALUES (inputShortUrl, 0, 1, 0, 0, current_timestamp, current_timestamp)
-  ON CONFLICT ("shortUrl")
-  DO UPDATE SET "tablet" = "${devicesTable}"."tablet" + 1;
-ELSIF device='desktop' THEN
-  INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
-  VALUES (inputShortUrl, 0, 0, 1, 0, current_timestamp, current_timestamp)
-  ON CONFLICT ("shortUrl")
-  DO UPDATE SET "desktop" = "${devicesTable}"."desktop" + 1;
-ELSIF device='others' THEN
-  INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
-  VALUES (inputShortUrl, 0, 0, 0, 1, current_timestamp, current_timestamp)
-  ON CONFLICT ("shortUrl")
-  DO UPDATE SET "others" = "${devicesTable}"."others" + 1;
-END IF;
--- Update daily clicks.
-INSERT INTO "${clicksTable}" ("shortUrl", "date", "clicks", "createdAt", "updatedAt")
-VALUES (inputShortUrl, date(current_timestamp at time zone '${timeZone}'), 1, current_timestamp, current_timestamp)
-ON CONFLICT ("shortUrl", "date")
-DO UPDATE SET "clicks" = "${clicksTable}"."clicks" + 1;
--- Update weekday clicks.
-INSERT INTO "${weekdayTable}" ("shortUrl", "weekday", "hours", "clicks", "createdAt", "updatedAt")
-VALUES (inputShortUrl, extract(dow from date(current_timestamp at time zone '${timeZone}')), extract(hour from current_timestamp at time zone '${timeZone}'), 1, current_timestamp, current_timestamp)
-ON CONFLICT ("shortUrl", "weekday", "hours")
-DO UPDATE SET "clicks" = "${weekdayTable}"."clicks" + 1;
-END; $$ LANGUAGE plpgsql;
+  BEGIN
+    PERFORM 'public.update_link_statistics(text,text)'::regprocedure;
+  EXCEPTION WHEN undefined_function THEN
+    CREATE OR REPLACE FUNCTION update_link_statistics (inputShortUrl text, device text)
+    RETURNS void AS $$
+    BEGIN
+    -- Update total clicks.
+    UPDATE "${urlTable}" SET "clicks" = "${urlTable}"."clicks" + 1
+    WHERE "shortUrl" = inputShortUrl;
+    -- Update devices clicks.
+    IF device='mobile' THEN
+      INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
+      VALUES (inputShortUrl, 1, 0, 0, 0, current_timestamp, current_timestamp)
+      ON CONFLICT ("shortUrl")
+      DO UPDATE SET "mobile" = "${devicesTable}"."mobile" + 1;
+    ELSIF device='tablet' THEN
+      INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
+      VALUES (inputShortUrl, 0, 1, 0, 0, current_timestamp, current_timestamp)
+      ON CONFLICT ("shortUrl")
+      DO UPDATE SET "tablet" = "${devicesTable}"."tablet" + 1;
+    ELSIF device='desktop' THEN
+      INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
+      VALUES (inputShortUrl, 0, 0, 1, 0, current_timestamp, current_timestamp)
+      ON CONFLICT ("shortUrl")
+      DO UPDATE SET "desktop" = "${devicesTable}"."desktop" + 1;
+    ELSIF device='others' THEN
+      INSERT INTO "${devicesTable}" ("shortUrl", "mobile", "tablet", "desktop", "others", "createdAt", "updatedAt")
+      VALUES (inputShortUrl, 0, 0, 0, 1, current_timestamp, current_timestamp)
+      ON CONFLICT ("shortUrl")
+      DO UPDATE SET "others" = "${devicesTable}"."others" + 1;
+    END IF;
+    -- Update daily clicks.
+    INSERT INTO "${clicksTable}" ("shortUrl", "date", "clicks", "createdAt", "updatedAt")
+    VALUES (inputShortUrl, date(current_timestamp at time zone '${timeZone}'), 1, current_timestamp, current_timestamp)
+    ON CONFLICT ("shortUrl", "date")
+    DO UPDATE SET "clicks" = "${clicksTable}"."clicks" + 1;
+    -- Update weekday clicks.
+    INSERT INTO "${weekdayTable}" ("shortUrl", "weekday", "hours", "clicks", "createdAt", "updatedAt")
+    VALUES (inputShortUrl, extract(dow from date(current_timestamp at time zone '${timeZone}')), extract(hour from current_timestamp at time zone '${timeZone}'), 1, current_timestamp, current_timestamp)
+    ON CONFLICT ("shortUrl", "weekday", "hours")
+    DO UPDATE SET "clicks" = "${weekdayTable}"."clicks" + 1;
+    END; $$ LANGUAGE plpgsql;
+  END;
+END $_$;
 `
 
 export type UrlStats = UrlType & {


### PR DESCRIPTION
## Problem

If postgres functions were created by other users, Go would not be able
`CREATE OR REPLACE FUNCTION` for those that it usually does at runtime.
This halts the application, even if the postgres user Go has been given can
actually use the database and even execute the function created by the other user

## Solution

Perform a check for existence of `update_link_statistics()`, and if
absent, catch the SQL exception and create it from scratch

## Tests
Query plan tested in staging
