### PR TITLE
feat: fixed banner

### DIFF
--- a/src/client/components/BaseLayout/BannerForIE.tsx
+++ b/src/client/components/BaseLayout/BannerForIE.tsx
@@ -4,6 +4,10 @@ import { makeStyles, createStyles } from '@material-ui/core'
 import cautionLogo from './assets/ie-banner-caution.svg'
 import Banner from './widgets/Banner'
 
+type BannerForIEProps = {
+  isSticky: boolean
+}
+
 const BANNER_TEXT =
   'Go.gov.sg is not supported on Internet Explorer. Some features may not work correctly.'
 
@@ -15,10 +19,10 @@ const useStyles = makeStyles(() =>
   }),
 )
 
-export default function BannerForIE() {
+export default function BannerForIE({ isSticky }: BannerForIEProps) {
   const classes = useStyles()
   const icon = (
     <img className={classes.icon} src={cautionLogo} draggable={false} />
   )
-  return <Banner icon={icon} text={BANNER_TEXT} />
+  return <Banner icon={icon} text={BANNER_TEXT} isSticky={isSticky}/>
 }

--- a/src/client/components/BaseLayout/BaseLayoutHeader.jsx
+++ b/src/client/components/BaseLayout/BaseLayoutHeader.jsx
@@ -83,6 +83,12 @@ const useStyles = makeStyles((theme) =>
         minWidth: theme.spacing(6),
       },
     },
+    sectionPageSticky: {
+      paddingTop: '43px',
+    },
+    sectionPage: {
+      paddingTop: '0px',
+    },
   }),
 )
 
@@ -99,6 +105,7 @@ const BaseLayoutHeader = ({
   isLoggedIn,
   logout,
   hideNavButtons,
+  isSticky,
 }) => {
   const isLightItems = backgroundType === 'darkest'
   const theme = useTheme()
@@ -173,6 +180,7 @@ const BaseLayoutHeader = ({
       backgroundType={backgroundType}
       verticalMultiplier={0}
       shadow={!isLoggedIn && isMobileVariant}
+      className={isSticky ? classes.sectionPageSticky : classes.sectionPage}
     >
       <AppBar position="static" color="transparent" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>
@@ -225,10 +233,12 @@ BaseLayoutHeader.propTypes = {
   isLoggedIn: PropTypes.bool.isRequired,
   logout: PropTypes.func.isRequired,
   hideNavButtons: PropTypes.bool,
+  isSticky: PropTypes.bool,
 }
 
 BaseLayoutHeader.defaultProps = {
   hideNavButtons: false,
+  isSticky: false,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(BaseLayoutHeader)

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useLocation } from 'react-router-dom'
 import { CssBaseline, createStyles, makeStyles } from '@material-ui/core'
@@ -53,16 +53,41 @@ const BaseLayout = ({
   const path = useLocation().pathname
   const isIE = useIsIE()
   const message = useSelector((state) => state.user.message)
+
+  // To store y-position to trigger useEffect
+  const prevScrollY = useRef(0)
+  const [isSticky, setIsSticky] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY
+      // height of mast
+      if (currentScrollY >= 28) {
+        setIsSticky(true)
+      } else {
+        setIsSticky(false)
+      }
+      prevScrollY.current = currentScrollY
+    }
+
+    window.addEventListener('scroll', handleScroll)
+
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [prevScrollY])
+
   return (
     <>
       <CssBaseline />
       <Masthead />
-      {path === USER_PAGE && isIE && <BannerForIE />}
-      {path === USER_PAGE && message && <Banner text={message} />}
+      {path === USER_PAGE && isIE && <BannerForIE isSticky={isSticky} />}
+      {path === USER_PAGE && message && (
+        <Banner text={message} isSticky={isSticky} />
+      )}
       {withHeader && (
         <BaseLayoutHeader
           backgroundType={headerBackgroundType}
           hideNavButtons={hideNavButtons}
+          isSticky={isSticky}
         />
       )}
       <div className={classes.layout}>{children}</div>

--- a/src/client/components/BaseLayout/widgets/Banner.tsx
+++ b/src/client/components/BaseLayout/widgets/Banner.tsx
@@ -3,15 +3,29 @@ import { makeStyles, createStyles, Typography } from '@material-ui/core'
 
 import { ApplyAppMargins } from '../../AppMargins'
 
-type BannerForIEProps = {
+type BannerForProps = {
   text: string
   icon?: React.ReactElement
+  isSticky: boolean
 }
 
 const useStyles = makeStyles((theme) =>
   createStyles({
     bannerContainer: {
       display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      minHeight: 50,
+      backgroundColor: theme.palette.primary.main,
+      color: '#F9F9F9',
+      paddingTop: 15,
+      paddingBottom: 15,
+    },
+    bannerContainerSticky: {
+      display: 'flex',
+      position: 'fixed',
+      zIndex: 20,
       justifyContent: 'center',
       alignItems: 'center',
       width: '100%',
@@ -41,10 +55,10 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-export default function Banner({ text, icon }: BannerForIEProps) {
+export default function Banner({ text, icon, isSticky }: BannerForProps) {
   const classes = useStyles()
   return (
-    <div className={classes.bannerContainer}>
+    <div className={isSticky? classes.bannerContainerSticky: classes.bannerContainer}>
       <ApplyAppMargins className={classes.appMargins}>
         <div className={classes.bannerContent}>
           {icon}

--- a/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
+++ b/src/client/components/UserPage/Drawer/ControlPanel/DrawerHeader.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme) =>
     },
     copyButtonWrapper: {
       marginLeft: -8,
+      overflow: 'hidden',
     },
     headerText: {
       marginBottom: '6px',


### PR DESCRIPTION
## Problem

1. The banner is suppose to make announcement but it disappears after user scrolls down
2. Text overflow for long 'shorturl' in drawer

Closes #802 

## Solution

Add an event listener to the page to track the scroll for Y-axis. It will fix the banner's position after scrolling past the mast

**Bug Fixes**:

- add 'overflow: hidden' to the text wrapper
- rename banner's props accordingly

## Before & After Screenshots

**BEFORE**:
Desktop banner at the top
<img width="1437" alt="desktop_top_banner" src="https://user-images.githubusercontent.com/29625514/97548264-dfff2400-1a09-11eb-9f75-92a7ec91b8e9.png">

Desktop banner when user scrolls to bottom
<img width="1437" alt="desktop_bottom_banner" src="https://user-images.githubusercontent.com/29625514/97548390-08871e00-1a0a-11eb-8bb4-4109b6c72009.png">

Mobile banner at the top
<img width="439" alt="mobile_top_banner" src="https://user-images.githubusercontent.com/29625514/97548409-0f159580-1a0a-11eb-83ef-b3236f871cc0.png">

Mobile banner when user scrolls to bottom
<img width="439" alt="mobile_bottom_banner" src="https://user-images.githubusercontent.com/29625514/97548425-150b7680-1a0a-11eb-9b4b-bc94aedf2713.png">

Overflow text before
<img width="439" alt="copybutton_overflow_before" src="https://user-images.githubusercontent.com/29625514/97548470-218fcf00-1a0a-11eb-893a-ab9695e92742.png">

No overflow text after
<img width="439" alt="copybutton_overflow_after" src="https://user-images.githubusercontent.com/29625514/97548492-281e4680-1a0a-11eb-8fbf-ed7ca5bdac28.png">


