### PR TITLE
build(ci): add lockfile-lint to CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
             ${{ runner.OS }}-
       - run: npm ci
       - run: npm run lint
+      - run: npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
       - run: npm run build
   test:
     name: Test


### PR DESCRIPTION
## Problem and Solution

Run lockfile-lint from npx, to ensure that the package lockfile
is properly scrutinised with every CI run