### PR TITLE
fix: banner and tracking

### DIFF
--- a/src/client/components/BaseLayout/BaseLayoutHeader.jsx
+++ b/src/client/components/BaseLayout/BaseLayoutHeader.jsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) =>
       width: '24px',
     },
     sectionPageSticky: {
-      paddingTop: '43px',
+      paddingTop: '76px',
     },
     sectionPage: {
       paddingTop: '0px',

--- a/src/client/components/BaseLayout/BaseLayoutHeader.jsx
+++ b/src/client/components/BaseLayout/BaseLayoutHeader.jsx
@@ -94,11 +94,8 @@ const useStyles = makeStyles((theme) =>
     logoutIcon: {
       width: '24px',
     },
-    sectionPageSticky: {
-      paddingTop: '76px',
-    },
     sectionPage: {
-      paddingTop: '0px',
+      paddingTop: (props) => (props.isSticky && props.message ? '76px' : '0px'),
     },
   }),
 )
@@ -117,12 +114,12 @@ const BaseLayoutHeader = ({
   logout,
   hideNavButtons,
   isSticky,
+  message,
 }) => {
   const isLightItems = backgroundType === 'darkest'
   const theme = useTheme()
   const isMobileVariant = useMediaQuery(theme.breakpoints.down('sm'))
-  const classes = useStyles({ isLoggedIn, isLightItems })
-
+  const classes = useStyles({ isLoggedIn, isLightItems, isSticky, message })
   const headers = [
     {
       text: 'Directory',
@@ -220,7 +217,7 @@ const BaseLayoutHeader = ({
       backgroundType={backgroundType}
       verticalMultiplier={0}
       shadow={!isLoggedIn && isMobileVariant}
-      className={isSticky ? classes.sectionPageSticky : classes.sectionPage}
+      className={classes.sectionPage}
     >
       <AppBar position="static" color="transparent" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>

--- a/src/client/components/BaseLayout/BaseLayoutHeader.jsx
+++ b/src/client/components/BaseLayout/BaseLayoutHeader.jsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) =>
       width: '24px',
     },
     sectionPage: {
-      paddingTop: (props) => (props.isSticky && props.message ? '76px' : '0px'),
+      paddingTop: (props) => (props.isSticky && props.toStick ? '76px' : '0px'),
     },
   }),
 )
@@ -114,12 +114,12 @@ const BaseLayoutHeader = ({
   logout,
   hideNavButtons,
   isSticky,
-  message,
+  toStick,
 }) => {
   const isLightItems = backgroundType === 'darkest'
   const theme = useTheme()
   const isMobileVariant = useMediaQuery(theme.breakpoints.down('sm'))
-  const classes = useStyles({ isLoggedIn, isLightItems, isSticky, message })
+  const classes = useStyles({ isLoggedIn, isLightItems, isSticky, toStick })
   const headers = [
     {
       text: 'Directory',

--- a/src/client/components/BaseLayout/Masthead.tsx
+++ b/src/client/components/BaseLayout/Masthead.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { Theme, createStyles, makeStyles } from '@material-ui/core'
 type MastheadProps = {
   isSticky: boolean
-  message: object
+  toStick: object
 }
 const useStyles = makeStyles<Theme, MastheadProps>(() =>
   createStyles({
     masthead: {
       zIndex: 2,
-      position: (props) => (props.isSticky && props.message)? 'absolute':'relative',
+      position: (props) => (props.isSticky && props.toStick)? 'absolute':'relative',
       backgroundColor: '#F0F0F0',
       height: 'auto',
       padding: '4px 0',
@@ -45,8 +45,8 @@ const useStyles = makeStyles<Theme, MastheadProps>(() =>
     },
   }),
 )
-const Masthead = ({ isSticky, message }: MastheadProps) => {
-  const classes = useStyles({ isSticky, message })
+const Masthead = ({ isSticky, toStick }: MastheadProps) => {
+  const classes = useStyles({ isSticky, toStick })
   return (
     <div className={classes.masthead}>
       <a

--- a/src/client/components/BaseLayout/Masthead.tsx
+++ b/src/client/components/BaseLayout/Masthead.tsx
@@ -1,24 +1,15 @@
 import React from 'react'
-import { createStyles, makeStyles } from '@material-ui/core/styles'
-
+import { Theme, createStyles, makeStyles } from '@material-ui/core'
 type MastheadProps = {
   isSticky: boolean
+  message: object
 }
-
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles<Theme, MastheadProps>(() =>
   createStyles({
     masthead: {
       zIndex: 2,
-      position: 'relative',
-      backgroundColor: '#f0f0f0',
-      height: 'auto',
-      padding: '4px 0',
-      fontSize: '14px',
-    },
-    mastheadsticky: {
-      zIndex: 2,
-      position: 'absolute',
-      backgroundColor: '#f0f0f0',
+      position: (props) => (props.isSticky && props.message)? 'absolute':'relative',
+      backgroundColor: '#F0F0F0',
       height: 'auto',
       padding: '4px 0',
       fontSize: '14px',
@@ -54,11 +45,10 @@ const useStyles = makeStyles(() =>
     },
   }),
 )
-
-const Masthead = ({ isSticky }: MastheadProps) => {
-  const classes = useStyles()
+const Masthead = ({ isSticky, message }: MastheadProps) => {
+  const classes = useStyles({ isSticky, message })
   return (
-    <div className={isSticky? classes.mastheadsticky : classes.masthead}>
+    <div className={classes.masthead}>
       <a
         href="https://www.gov.sg"
         target="_blank"
@@ -73,5 +63,4 @@ const Masthead = ({ isSticky }: MastheadProps) => {
     </div>
   )
 }
-
 export default Masthead

--- a/src/client/components/BaseLayout/Masthead.tsx
+++ b/src/client/components/BaseLayout/Masthead.tsx
@@ -1,11 +1,23 @@
 import React from 'react'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 
+type MastheadProps = {
+  isSticky: boolean
+}
+
 const useStyles = makeStyles(() =>
   createStyles({
     masthead: {
       zIndex: 2,
       position: 'relative',
+      backgroundColor: '#f0f0f0',
+      height: 'auto',
+      padding: '4px 0',
+      fontSize: '14px',
+    },
+    mastheadsticky: {
+      zIndex: 2,
+      position: 'absolute',
       backgroundColor: '#f0f0f0',
       height: 'auto',
       padding: '4px 0',
@@ -43,10 +55,10 @@ const useStyles = makeStyles(() =>
   }),
 )
 
-const Masthead = () => {
+const Masthead = ({ isSticky }: MastheadProps) => {
   const classes = useStyles()
   return (
-    <div className={classes.masthead}>
+    <div className={isSticky? classes.mastheadsticky : classes.masthead}>
       <a
         href="https://www.gov.sg"
         target="_blank"

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -60,7 +60,7 @@ const BaseLayout = ({
 
   useEffect(() => {
     const handleScroll = () => {
-      const currentScrollY = window.scrollY
+      const currentScrollY = window.pageYOffset
       // height of mast
       if (currentScrollY >= 28) {
         setIsSticky(true)
@@ -78,7 +78,7 @@ const BaseLayout = ({
   return (
     <>
       <CssBaseline />
-      <Masthead />
+      <Masthead isSticky={isSticky} />
       {path === USER_PAGE && isIE && <BannerForIE isSticky={isSticky} />}
       {path === USER_PAGE && message && (
         <Banner text={message} isSticky={isSticky} />

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -54,6 +54,7 @@ const BaseLayout = ({
   const isIE = useIsIE()
   const message = useSelector((state) => state.user.message)
 
+  const toStick = isIE || message
   // To store y-position to trigger useEffect
   const prevScrollY = useRef(0)
   const [isSticky, setIsSticky] = useState(false)
@@ -78,7 +79,7 @@ const BaseLayout = ({
   return (
     <>
       <CssBaseline />
-      <Masthead isSticky={isSticky} message={message} />
+      <Masthead isSticky={isSticky} toStick={toStick} />
       {path === USER_PAGE && isIE && <BannerForIE isSticky={isSticky} />}
       {path === USER_PAGE && message && (
         <Banner text={message} isSticky={isSticky} />
@@ -88,7 +89,7 @@ const BaseLayout = ({
           backgroundType={headerBackgroundType}
           hideNavButtons={hideNavButtons}
           isSticky={isSticky}
-          message={message}
+          toStick={toStick}
         />
       )}
       <div className={classes.layout}>{children}</div>

--- a/src/client/components/BaseLayout/index.jsx
+++ b/src/client/components/BaseLayout/index.jsx
@@ -78,7 +78,7 @@ const BaseLayout = ({
   return (
     <>
       <CssBaseline />
-      <Masthead isSticky={isSticky} />
+      <Masthead isSticky={isSticky} message={message} />
       {path === USER_PAGE && isIE && <BannerForIE isSticky={isSticky} />}
       {path === USER_PAGE && message && (
         <Banner text={message} isSticky={isSticky} />
@@ -88,6 +88,7 @@ const BaseLayout = ({
           backgroundType={headerBackgroundType}
           hideNavButtons={hideNavButtons}
           isSticky={isSticky}
+          message={message}
         />
       )}
       <div className={classes.layout}>{children}</div>

--- a/src/client/components/BaseLayout/widgets/Banner.tsx
+++ b/src/client/components/BaseLayout/widgets/Banner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { makeStyles, createStyles, Typography } from '@material-ui/core'
+import { Theme, makeStyles, createStyles, Typography } from '@material-ui/core'
 
 import { ApplyAppMargins } from '../../AppMargins'
 
@@ -9,23 +9,12 @@ type BannerForProps = {
   isSticky: boolean
 }
 
-const useStyles = makeStyles((theme) =>
+const useStyles = makeStyles<Theme, BannerForProps>((theme) =>
   createStyles({
     bannerContainer: {
       display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      width: '100%',
-      minHeight: 50,
-      backgroundColor: theme.palette.primary.main,
-      color: '#F9F9F9',
-      paddingTop: 15,
-      paddingBottom: 15,
-    },
-    bannerContainerSticky: {
-      display: 'flex',
-      position: 'fixed',
-      zIndex: 20,
+      position: (props) => props.isSticky? 'fixed' : 'relative',
+      zIndex: (props) => props.isSticky? 20 : 1,
       justifyContent: 'center',
       alignItems: 'center',
       width: '100%',
@@ -56,9 +45,9 @@ const useStyles = makeStyles((theme) =>
 )
 
 export default function Banner({ text, icon, isSticky }: BannerForProps) {
-  const classes = useStyles()
+  const classes = useStyles({ text, isSticky })
   return (
-    <div className={isSticky? classes.bannerContainerSticky: classes.bannerContainer}>
+    <div className={classes.bannerContainer}>
       <ApplyAppMargins className={classes.appMargins}>
         <div className={classes.bannerContent}>
           {icon}

--- a/src/client/components/UserPage/AnnouncementModal/index.tsx
+++ b/src/client/components/UserPage/AnnouncementModal/index.tsx
@@ -14,6 +14,7 @@ import { GoGovReduxState } from '../../../reducers/types'
 import userActions from '../../../actions/user'
 import useFullScreenDialog from '../helpers/fullScreenDialog'
 import CloseIcon from '../../widgets/CloseIcon'
+import { GAEvent } from '../../../actions/ga'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -229,6 +230,7 @@ export default function AnnouncementModal() {
             size="large"
             variant="text"
             className={classes.learnMoreButton}
+            onClick={()=> {GAEvent('Announcement Page', 'redirected to GoDirectory')}}
           >
             Try it now
           </Button>

--- a/src/client/components/UserPage/AnnouncementModal/index.tsx
+++ b/src/client/components/UserPage/AnnouncementModal/index.tsx
@@ -230,7 +230,7 @@ export default function AnnouncementModal() {
             size="large"
             variant="text"
             className={classes.learnMoreButton}
-            onClick={()=> {GAEvent('Announcement Page', 'redirected to GoDirectory')}}
+            onClick={()=> {GAEvent('Announcement Page', announcement?.title || 'successful' )}}
           >
             Try it now
           </Button>


### PR DESCRIPTION
## Problem

IE Banner does not follow the vertical scroll
No tracking implemented for announcement modal

Closes #849 

## Solution

change the window.scrollY to window.pageYoffset as scrollY is incompatible with IE
change masthead's position to absolute as it does not disappear on scroll in IE
send GA event when announcement modal's button is clicked

## After Screenshots
IE top view
![ie_top](https://user-images.githubusercontent.com/29625514/98079716-3d362200-1eaf-11eb-8f6d-bb78efeece7b.jpg)

IE bottom view after scrolling
![ie_buttom](https://user-images.githubusercontent.com/29625514/98079728-42936c80-1eaf-11eb-86c6-b8a9a54c3aef.jpg)




