### PR TITLE
feat(tp): remove timeout for skip button

### DIFF
--- a/public/assets/transition-page/styles/transition-page.css
+++ b/public/assets/transition-page/styles/transition-page.css
@@ -78,7 +78,7 @@ body {
 
 #skip {
   padding-top: 50px;
-  opacity: 0;
+  opacity: 1;
   display: block;
   cursor: pointer;
 }

--- a/src/server/views/redirect.ejs
+++ b/src/server/views/redirect.ejs
@@ -22,12 +22,6 @@ function proceedToDestination() {
     window.location = document.getElementById('url').getAttribute('data-href')
 }
 
-setTimeout(function(){
-    var skipButton = document.getElementById('skip')
-    skipButton.style.opacity = '1'
-    skipButton.style.transition = 'opacity 0.4s'
-}, 2000)
-
 var secondsUntilRedirect = 6
 
 function handlePlural() {


### PR DESCRIPTION
## Problem

Current skip ahead link only appears after 2 seconds as it was meant for the public to read the message before skipping ahead.

As the number of complains tapers down and transition page drop off has been consistent, this 2 seconds wait should be removed. That means the skip ahead link will appear the moment transition page is loaded.

Closes #877 

## Solution

_How did you solve the problem?_

Remove the `setTimeout` call and set the CSS of the skip button to be visible from the very beginning.

