### PR TITLE
refactor(search): remove isSearchable, index conditions

### DIFF
--- a/scripts/migrate_url_to_user.sql
+++ b/scripts/migrate_url_to_user.sql
@@ -14,6 +14,8 @@
 --                                      isFile column
 --   07 Oct  2020 @LoneRifle:           Update function's url_history insertion step to include compulsory
 --                                      isSearchable column
+--   16 Nov  2020 @LoneRifle:           Update function's url_history insertion step to remove 
+--                                      isSearchable column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_url_to_user(short_url_value text, to_user_email text) RETURNS void AS
 $BODY$
@@ -45,8 +47,8 @@ BEGIN
         RAISE EXCEPTION 'No transferring of links to the same user';
     END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","isSearchable","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "isSearchable", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "shortUrl" = short_url LIMIT 1;
 -- Update the link in the URL table

--- a/scripts/migrate_user_links.sql
+++ b/scripts/migrate_user_links.sql
@@ -16,6 +16,8 @@
 --                              compulsory isFile column
 --   07 Oct  2020 @LoneRifle: Update function's url_history insertion step to include
 --                            compulsory isSearchable column
+--   16 Nov  2020 @LoneRifle: Update function's url_history insertion step to remove 
+--                            isSearchable column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS void AS
 $BODY$
@@ -41,8 +43,8 @@ BEGIN
 		RAISE EXCEPTION 'No transferring of links to the same user';
 	END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","isSearchable","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "isSearchable", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "userId" = from_user_id;
 -- Update the links in the URL table

--- a/src/client/user/actions/index.ts
+++ b/src/client/user/actions/index.ts
@@ -491,29 +491,6 @@ const toggleUrlState = (shortUrl: string, state: UrlState) => (
   })
 }
 
-const toggleIsSearchable = (shortUrl: string, isSearchable: boolean) => (
-  dispatch: ThunkDispatch<
-    GoGovReduxState,
-    void,
-    SetErrorMessageAction | SetSuccessMessageAction
-  >,
-) => {
-  patch('/api/user/url', { shortUrl, isSearchable }).then((response) => {
-    if (response.ok) {
-      dispatch<void>(getUrlsForUser())
-      dispatch<SetSuccessMessageAction>(
-        rootActions.setSuccessMessage('Your link visibility has been updated.'),
-      )
-      return null
-    }
-
-    return response.json().then((json) => {
-      dispatch<SetErrorMessageAction>(rootActions.setErrorMessage(json.message))
-      return null
-    })
-  })
-}
-
 const openCreateUrlModal: () => OpenCreateUrlModalAction = () => ({
   type: OPEN_CREATE_URL_MODAL,
 })
@@ -733,7 +710,6 @@ export default {
   setCreateShortLinkError,
   setUrlFilter,
   replaceFile,
-  toggleIsSearchable,
   setEditedContactEmail,
   setEditedDescription,
   getUserMessage,

--- a/src/client/user/components/CreateUrlModal/AddDescriptionForm.tsx
+++ b/src/client/user/components/CreateUrlModal/AddDescriptionForm.tsx
@@ -46,7 +46,6 @@ export default function AddDescriptionForm() {
   const [isContactEmailValid, setIsContactEmailValid] = useState(true)
   const [description, setDescription] = useState('')
   const [isDescriptionValid, setIsDescriptionValid] = useState(true)
-  const [isSearchable, setIsSearchable] = useState(true)
   const onContactEmailChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setContactEmail(event.target.value)
   const onDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) =>
@@ -74,27 +73,6 @@ export default function AddDescriptionForm() {
     const jsonResponse = await response.json()
     dispatch(rootActions.setErrorMessage(jsonResponse.message))
   }
-  const toggleLinkSearchable = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const newIsSearchable = event.target.checked
-    const response = await patch('/api/user/url', {
-      isSearchable: newIsSearchable,
-      shortUrl,
-    })
-
-    if (response.ok) {
-      dispatch(userActions.getUrlsForUser())
-      dispatch(
-        rootActions.setSuccessMessage('Your link visibility has been updated.'),
-      )
-      setIsSearchable(newIsSearchable)
-      return
-    }
-
-    const jsonResponse = await response.json()
-    dispatch(rootActions.setErrorMessage(jsonResponse.message))
-  }
 
   const isBothFieldsBlank = contactEmail === '' && description === ''
   const isContainsInvalidField = !(isContactEmailValid && isDescriptionValid)
@@ -116,8 +94,6 @@ export default function AddDescriptionForm() {
           onDescriptionChange={onDescriptionChange}
           onContactEmailValidation={setIsContactEmailValid}
           onDescriptionValidation={setIsDescriptionValid}
-          isSearchable={isSearchable}
-          onIsSearchableChange={toggleLinkSearchable}
           isMountedOnCreateUrlModal
         />
         <div className={classes.buttonWrapper}>

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -197,7 +197,6 @@ export default function ControlPanel() {
   } = useShortLink(drawerStates.relevantShortLink!)
 
   // Manage values in our text fields.
-  const isSearchable = shortLinkState?.isSearchable || false
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
   const editedLongUrl = shortLinkState?.editedLongUrl || ''
   const editedContactEmail = shortLinkState?.editedContactEmail || ''
@@ -445,10 +444,8 @@ export default function ControlPanel() {
           <div className={classes.inactiveDesc}>
           <Divider className={classes.dividerInformation} />
           <LinkInfoEditor
-            isSearchable={isSearchable}
             contactEmail={editedContactEmail} 
             description={editedDescription}
-            onIsSearchableChange={(event) => shortLinkDispatch?.toggleIsSearchable(event.target.checked)}
             onContactEmailChange={(event) => shortLinkDispatch?.setEditContactEmail(event.target.value)} 
             onDescriptionChange={(event) =>
               shortLinkDispatch?.setEditDescription(

--- a/src/client/user/components/Drawer/ControlPanel/util/shortlink.ts
+++ b/src/client/user/components/Drawer/ControlPanel/util/shortlink.ts
@@ -30,9 +30,6 @@ export default function useShortLink(shortLink: string) {
   const dispatchOptions = {
     toggleStatus: () =>
       dispatch(userActions.toggleUrlState(shortLink, urlState.state)),
-    toggleIsSearchable: (isSearchable: boolean) => {
-      dispatch(userActions.toggleIsSearchable(shortLink, isSearchable))
-    },
     setEditLongUrl: (editedUrl: string) => {
       dispatch(userActions.setEditedLongUrl(shortLink, editedUrl))
     },

--- a/src/client/user/reducers/types.ts
+++ b/src/client/user/reducers/types.ts
@@ -32,7 +32,6 @@ export type UrlType = {
   state: UrlState
   updatedAt: string
   userId: number
-  isSearchable: boolean
   description: string
   editedDescription: string
   contactEmail: string

--- a/src/client/user/widgets/LinkInfoEditor.tsx
+++ b/src/client/user/widgets/LinkInfoEditor.tsx
@@ -19,7 +19,6 @@ import BetaTag from '../../app/components/widgets/BetaTag'
 import CollapsibleMessage from '../../app/components/CollapsibleMessage'
 import ConfigOption, { TrailingPosition } from './ConfigOption'
 import PrefixableTextField from './PrefixableTextField'
-import GoSwitch from './GoSwitch'
 import {
   CollapsibleMessagePosition,
   CollapsibleMessageType,
@@ -70,10 +69,8 @@ const useStyles = makeStyles((theme) =>
 )
 
 type LinkInfoEditorProps = {
-  isSearchable: boolean
   contactEmail: string
   description: string
-  onIsSearchableChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onContactEmailChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onDescriptionChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onContactEmailValidation: (isContactEmailValid: boolean) => void
@@ -82,10 +79,8 @@ type LinkInfoEditorProps = {
 }
 
 export default function LinkInfoEditor({
-  isSearchable,
   contactEmail,
   description,
-  onIsSearchableChange,
   onContactEmailChange,
   onDescriptionChange,
   onContactEmailValidation,
@@ -162,33 +157,6 @@ export default function LinkInfoEditor({
           className={classes.linkInformationHeader}
           color="primary"
         >
-        <ConfigOption
-            title={
-              isSearchable
-                ? (
-                  <>
-                    Your link is <span className={classes.activeText}>visible</span> in
-                    GoSearch results
-                  </>
-                )
-                : (
-                  <>
-                    Your link is <span className={classes.inactiveText}>not visible</span> in
-                    GoSearch results
-                  </>
-                )
-            }
-            titleVariant="h6"
-            titleClassName={isMobileView ? classes.regularText : ''}
-            trailing={
-              <GoSwitch
-                color="primary"
-                checked={isSearchable}
-                onChange={onIsSearchableChange}
-              />
-            }
-            trailingPosition={TrailingPosition.center}
-          />
       </Typography>
       <ConfigOption
         title={contactEmailHelp}

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -57,7 +57,6 @@ export const urlEditSchema = Joi.object({
     file: Joi.object().keys().required(),
   }),
   state: Joi.string().allow(ACTIVE, INACTIVE).only(),
-  isSearchable: Joi.boolean(),
   description: Joi.string()
     .allow('')
     .max(LINK_DESCRIPTION_MAX_LENGTH)

--- a/src/server/controllers/UserController.ts
+++ b/src/server/controllers/UserController.ts
@@ -96,7 +96,6 @@ export class UserController implements UserControllerInterface {
       longUrl,
       shortUrl,
       state,
-      isSearchable,
       description,
       contactEmail,
     }: UrlEditRequest = req.body
@@ -126,7 +125,6 @@ export class UserController implements UserControllerInterface {
         longUrl,
         state: urlState,
         file,
-        isSearchable,
         contactEmail: newContactEmail,
         description: description?.trim(),
       })

--- a/src/server/db_migrations/20201116_remove_isSearchable.sql
+++ b/src/server/db_migrations/20201116_remove_isSearchable.sql
@@ -1,0 +1,22 @@
+-- This migration script removes Urls.isSearchable with a default
+-- of true and changes the index to index unconditionally
+-- sql statements in scripts/ should be run to update functions too
+BEGIN TRANSACTION;
+
+-- Set "isSearchable" in url_histories to be false
+ALTER TABLE url_histories DROP COLUMN "isSearchable";
+ALTER TABLE urls DROP COLUMN "isSearchable";
+
+
+DROP INDEX IF EXISTS urls_weighted_search_idx;
+
+-- Search will be run on a concatenation of vectors formed from short links and their
+-- description. Descriptions are given a lower weight than short links as short link
+-- words can be taken as the title and words there are likely to be more important than
+-- those in their corresponding description.
+-- Search queries will have to use this exact expresion to be able to utilize the index.
+CREATE INDEX urls_weighted_search_idx ON urls USING gin ((setweight(to_tsvector(
+'english', urls."shortUrl"), 'A') || setweight(to_tsvector('english',
+urls."description"), 'B')));
+
+COMMIT;

--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -19,7 +19,6 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
       isFile: urlType.isFile,
       createdAt: urlType.createdAt,
       updatedAt: urlType.updatedAt,
-      isSearchable: urlType.isSearchable,
       description: urlType.description,
       contactEmail: urlType.contactEmail,
     }

--- a/src/server/models/search.ts
+++ b/src/server/models/search.ts
@@ -7,4 +7,4 @@ export const urlSearchVector = `
   setweight(to_tsvector('english', urls."description"), 'B')
 `
 
-export const urlSearchConditions = `urls.state = '${StorableUrlState.Active}' AND urls."isSearchable"=true`
+export const urlSearchConditions = `urls.state = '${StorableUrlState.Active}' AND urls.description != ''`

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -167,17 +167,7 @@ export const Url = <UrlTypeStatic>sequelize.define(
         name: 'urls_weighted_search_idx',
         unique: false,
         using: 'GIN',
-        fields: [
-          // Type definition on sequelize seems to be inaccurate.
-          // @ts-ignore
-          Sequelize.literal(`(${urlSearchVector})`),
-        ],
-        where: {
-          state: ACTIVE,
-          description: {
-            [Sequelize.Op.ne]: '',
-          },
-        },
+        fields: [Sequelize.literal(`(${urlSearchVector})`)],
       },
     ],
   },

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -17,7 +17,6 @@ interface UrlBaseType extends IdType {
   readonly longUrl: string
   readonly state: StorableUrlState
   readonly isFile: boolean
-  readonly isSearchable: boolean
   readonly contactEmail: string | null
   readonly description: string
 }
@@ -102,11 +101,6 @@ export const Url = <UrlTypeStatic>sequelize.define(
       type: Sequelize.BOOLEAN,
       allowNull: false,
     },
-    isSearchable: {
-      type: Sequelize.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-    },
     contactEmail: {
       type: Sequelize.TEXT,
       allowNull: true,
@@ -180,7 +174,9 @@ export const Url = <UrlTypeStatic>sequelize.define(
         ],
         where: {
           state: ACTIVE,
-          isSearchable: true,
+          description: {
+            [Sequelize.Op.ne]: '',
+          },
         },
       },
     ],
@@ -214,10 +210,6 @@ export const UrlHistory = <UrlHistoryStatic>sequelize.define('url_history', {
     type: Sequelize.BOOLEAN,
     allowNull: false,
   },
-  isSearchable: {
-    type: Sequelize.BOOLEAN,
-    allowNull: false,
-  },
   contactEmail: {
     type: Sequelize.TEXT,
     allowNull: true,
@@ -244,7 +236,6 @@ const writeToUrlHistory = async (
       urlShortUrl: urlObj.shortUrl,
       longUrl: urlObj.longUrl,
       isFile: urlObj.isFile,
-      isSearchable: urlObj.isSearchable,
       contactEmail: urlObj.contactEmail,
       description: urlObj.description,
     },

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -12,7 +12,6 @@ export type StorableUrl = Pick<
   | 'isFile'
   | 'createdAt'
   | 'updatedAt'
-  | 'isSearchable'
   | 'description'
   | 'contactEmail'
 >

--- a/src/server/services/UrlManagementService.ts
+++ b/src/server/services/UrlManagementService.ts
@@ -78,14 +78,7 @@ export class UrlManagementService implements UrlManagementServiceInterface {
     shortUrl: string,
     options: UpdateUrlOptions,
   ) => Promise<StorableUrl> = async (userId, shortUrl, options) => {
-    const {
-      state,
-      longUrl,
-      file,
-      isSearchable,
-      description,
-      contactEmail,
-    } = options
+    const { state, longUrl, file, description, contactEmail } = options
 
     const url = await this.userRepository.findOneUrlForUser(userId, shortUrl)
 
@@ -103,7 +96,7 @@ export class UrlManagementService implements UrlManagementServiceInterface {
 
     return this.urlRepository.update(
       url,
-      { longUrl, state, isSearchable, description, contactEmail },
+      { longUrl, state, description, contactEmail },
       storableFile,
     )
   }

--- a/src/server/services/UrlSearchService.ts
+++ b/src/server/services/UrlSearchService.ts
@@ -24,23 +24,16 @@ export class UrlSearchService {
       urls: privateUrls,
       count,
     } = await this.urlRepository.plainTextSearch(query, order, limit, offset)
+
     return {
       // Specific click counts are classified for certain government links
       urls: privateUrls.map(
-        ({
+        ({ longUrl, shortUrl, contactEmail, description, isFile }) => ({
           longUrl,
           shortUrl,
           contactEmail,
           description,
           isFile,
-          isSearchable,
-        }) => ({
-          longUrl,
-          shortUrl,
-          contactEmail,
-          description,
-          isFile,
-          isSearchable,
         }),
       ),
       count,

--- a/src/server/services/types.ts
+++ b/src/server/services/types.ts
@@ -13,10 +13,7 @@ export type RedirectResult = {
 }
 
 export type UpdateUrlOptions = Partial<
-  Pick<
-    StorableUrl,
-    'state' | 'longUrl' | 'isSearchable' | 'description' | 'contactEmail'
-  > & {
+  Pick<StorableUrl, 'state' | 'longUrl' | 'description' | 'contactEmail'> & {
     file: GoUploadedFile
   }
 >

--- a/src/types/server/controllers/UserController.d.ts
+++ b/src/types/server/controllers/UserController.d.ts
@@ -11,7 +11,6 @@ type ShortUrlProperty = {
 }
 
 type LinkInformationProperties = {
-  isSearchable: boolean
   contactEmail: string
   description: string
 }

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -257,7 +257,6 @@ mockQuery.mockImplementation((query: string) => {
       isFile: false,
       createdAt: 'fakedate',
       updatedAt: 'fakedate',
-      isSearchable: true,
       description: 'desc',
       contactEmail: 'aa@aa.com',
     },

--- a/test/server/controllers/UserController.test.ts
+++ b/test/server/controllers/UserController.test.ts
@@ -89,7 +89,6 @@ describe('UserController', () => {
     const userId = 2
     const shortUrl = 'abcdef'
     const longUrl = 'https://www.agency.gov.sg'
-    const isSearchable = true
     const description = 'A Description'
 
     it('rejects multiple file uploads', async () => {
@@ -114,7 +113,6 @@ describe('UserController', () => {
           userId,
           shortUrl,
           longUrl,
-          isSearchable,
           description,
         },
       })
@@ -133,7 +131,6 @@ describe('UserController', () => {
           longUrl,
           state: undefined,
           file: undefined,
-          isSearchable,
           contactEmail: undefined,
           description,
         },
@@ -146,7 +143,6 @@ describe('UserController', () => {
           userId,
           shortUrl,
           longUrl,
-          isSearchable,
           description,
           contactEmail: null,
           state: 'ACTIVE',
@@ -167,7 +163,6 @@ describe('UserController', () => {
           longUrl,
           state: StorableUrlState.Active,
           file: undefined,
-          isSearchable,
           contactEmail: null,
           description,
         },
@@ -181,7 +176,6 @@ describe('UserController', () => {
           userId,
           shortUrl,
           longUrl,
-          isSearchable,
           description,
           contactEmail,
           state: 'INACTIVE',
@@ -202,7 +196,6 @@ describe('UserController', () => {
           longUrl,
           state: StorableUrlState.Inactive,
           file: undefined,
-          isSearchable,
           contactEmail,
           description,
         },

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -68,7 +68,6 @@ export class UrlRepositoryMock implements UrlRepositoryInterface {
           isFile: false,
           createdAt: '2020-04-17T09:10:07.491Z',
           updatedAt: '2020-06-09T10:07:07.557Z',
-          isSearchable: true,
           description: '',
           contactEmail: null,
           clicks: 0,

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -97,7 +97,6 @@ describe('UrlRepository', () => {
         isFile: false,
         createdAt: new Date(),
         updatedAt: new Date(),
-        isSearchable: true,
         description: 'An agency of the Singapore Government',
         contactEmail: 'contact-us@agency.gov.sg',
       }
@@ -131,7 +130,6 @@ describe('UrlRepository', () => {
         isFile: true,
         createdAt: new Date(),
         updatedAt: new Date(),
-        isSearchable: true,
         description: 'An agency of the Singapore Government',
         contactEmail: 'contact-us@agency.gov.sg',
       }
@@ -347,7 +345,6 @@ describe('UrlRepository', () => {
             state: 'ACTIVE',
             clicks: 0,
             isFile: false,
-            isSearchable: true,
             createdAt: 'fakedate',
             updatedAt: 'fakedate',
             description: 'desc',
@@ -363,7 +360,7 @@ describe('UrlRepository', () => {
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
-) AND urls.state = 'ACTIVE' AND urls."isSearchable"=true
+) AND urls.state = 'ACTIVE' AND urls.description != ''
     `,
         { bind: { query: 'query' }, raw: true, type: QueryTypes.SELECT },
       )
@@ -375,7 +372,7 @@ describe('UrlRepository', () => {
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
-) AND urls.state = 'ACTIVE' AND urls."isSearchable"=true
+) AND urls.state = 'ACTIVE' AND urls.description != ''
       ORDER BY (urls.clicks) DESC
       LIMIT $limit
       OFFSET $offset`,
@@ -403,7 +400,7 @@ describe('UrlRepository', () => {
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
-) AND urls.state = 'ACTIVE' AND urls."isSearchable"=true
+) AND urls.state = 'ACTIVE' AND urls.description != ''
       ORDER BY (ts_rank_cd('{0, 0, 0.4, 1}',
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
@@ -434,7 +431,7 @@ describe('UrlRepository', () => {
       WHERE query @@ (
   setweight(to_tsvector('english', urls."shortUrl"), 'A') ||
   setweight(to_tsvector('english', urls."description"), 'B')
-) AND urls.state = 'ACTIVE' AND urls."isSearchable"=true
+) AND urls.state = 'ACTIVE' AND urls.description != ''
       ORDER BY (urls."createdAt") DESC
       LIMIT $limit
       OFFSET $offset`,

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -21,7 +21,6 @@ const url = {
   isFile: false,
   createdAt: Date.now(),
   updatedAt: Date.now(),
-  isSearchable: true,
   description: 'An agency of the Singapore Government',
   contactEmail: 'contact-us@agency.gov.sg',
 }

--- a/test/server/services/UrlManagementService.test.ts
+++ b/test/server/services/UrlManagementService.test.ts
@@ -109,7 +109,6 @@ describe('UrlManagementService', () => {
     const options = {
       longUrl: 'https://www.agency.gov.sg',
       state: undefined,
-      isSearchable: true,
       description: 'An agency',
       contactEmail: 'contact-us@agency.gov.sg',
     }

--- a/test/server/services/UrlSearchService.test.ts
+++ b/test/server/services/UrlSearchService.test.ts
@@ -22,7 +22,6 @@ describe('UrlSearchService tests', () => {
           {
             shortUrl: 'test-moh',
             longUrl: 'https://www.moh.gov.sg/covid-19',
-            isSearchable: true,
             description: '',
             contactEmail: null,
             isFile: false,


### PR DESCRIPTION
## Problem

Given that GoSearch will be decommissioned, we have to backout its changes.
Start with removing references to isSearchable, and making the index unconditionally index the urls table.

## Solution

- Revert 4efddc9, and remove references to isSearchable in tests and sql fns
- index shortUrl and desc unconditionally, and copy `urlSearchVector` into `UrlRepository` so that it is easier to
  remove `models/search` later on