### PR TITLE
refactor(directory): redirect with exact changes in query

### DIFF
--- a/src/client/directory/index.tsx
+++ b/src/client/directory/index.tsx
@@ -61,12 +61,7 @@ const redirectWithParams = (newParams: GoSearchParams, history: History) => {
   
   const queryObject: any = { query: newParams.query }
   for (const [ key, value ] of Object.entries(newParams)) {
-    // Always ensure that the query is populated.
-    if (key === 'query') {
-      if (value && value !== (defaultParams as any)[key]) {
-        queryObject[key] = value
-      }
-    } else {
+    if (value && value !== (defaultParams as any)[key]) {
       queryObject[key] = value
     }
   }


### PR DESCRIPTION
## Problem

The directory page's query string display the entire query parameter. 

## Solution
Change the query string to display the exact changes

When the link is shared to someone else, the other party will have an easier time identifying the search query and the relevant filters/sort that was applied. 

This will be much harder to do when the entire query parameter is stuck onto the query string.

## Before & After Screenshots

**BEFORE**:
With query as 'test' and select 'link'
![Screenshot 2020-11-17 at 9 19 45 AM](https://user-images.githubusercontent.com/29625514/99328947-1537bd00-28b8-11eb-9c87-2d9232034377.png)

**AFTER**:
With query as 'test' and select 'link'
![Screenshot 2020-11-17 at 9 18 33 AM](https://user-images.githubusercontent.com/29625514/99328935-10730900-28b8-11eb-9aee-0a27d0cbb871.png)

