### PR TITLE
refactor(redux): move creation of the Redux store singleton into its own file

### DIFF
--- a/src/client/app/index.tsx
+++ b/src/client/app/index.tsx
@@ -5,7 +5,7 @@ import { render } from 'react-dom'
 import Root from './components/pages/RootPage'
 import { get } from './util/requests'
 import './i18n'
-import { store } from './store'
+import store from './store'
 
 // If SENTRY_DNS env var is specified, init sentry.
 get('/api/sentry/').then((response) => {

--- a/src/client/app/index.tsx
+++ b/src/client/app/index.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import * as Sentry from '@sentry/browser'
 import { render } from 'react-dom'
-import { applyMiddleware, createStore } from 'redux'
-import thunk from 'redux-thunk'
 
 import Root from './components/pages/RootPage'
 import { get } from './util/requests'
-import reducer from './reducers'
 import './i18n'
+import { store } from './store'
 
 // If SENTRY_DNS env var is specified, init sentry.
 get('/api/sentry/').then((response) => {
@@ -21,7 +19,5 @@ get('/api/sentry/').then((response) => {
     })
   }
 })
-
-const store = createStore(reducer, applyMiddleware(thunk))
 
 render(<Root store={store} />, document.getElementById('root'))

--- a/src/client/app/reducers/index.ts
+++ b/src/client/app/reducers/index.ts
@@ -6,7 +6,7 @@ import home from '../../home/reducers'
 import search from '../../search/reducers'
 import directory from '../../directory/reducers'
 
-const reducer = combineReducers({
+const rootReducer = combineReducers({
   login,
   user,
   root,
@@ -14,4 +14,5 @@ const reducer = combineReducers({
   search,
   directory,
 })
-export default reducer
+
+export default rootReducer

--- a/src/client/app/store.tsx
+++ b/src/client/app/store.tsx
@@ -1,0 +1,5 @@
+import { applyMiddleware, createStore } from 'redux'
+import thunk from 'redux-thunk'
+import reducer from './reducers'
+
+export const store = createStore(reducer, applyMiddleware(thunk))

--- a/src/client/app/store.tsx
+++ b/src/client/app/store.tsx
@@ -1,5 +1,7 @@
 import { applyMiddleware, createStore } from 'redux'
 import thunk from 'redux-thunk'
-import reducer from './reducers'
+import rootReducer from './reducers'
 
-export const store = createStore(reducer, applyMiddleware(thunk))
+const store = createStore(rootReducer, applyMiddleware(thunk))
+
+export default store


### PR DESCRIPTION
Following the [Redux style guide](https://redux.js.org/style-guide/style-guide#only-one-redux-store-per-app), this PR helps to make clear the singleton initialization of the Redux store by placing its creation into its own file and decoupling it from the creation of the React `<Root />` component.

**Improvements**:
- Greater clarity of Redux store creation
- Greater awareness of the use of the root reducer in Redux
