### PR TITLE
fix(gh-actions): set env via GITHUB_ENV instead of stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,6 @@ jobs:
       - run: npm ci
       - name: Select Sentry variables
         shell: python
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         run: |
           import os
           branch = os.environ['GITHUB_REF']
@@ -126,15 +124,17 @@ jobs:
           sentry_dns_production = os.environ['SENTRY_DNS_PRODUCTION']
           sentry_project_uat = os.environ['SENTRY_PROJECT_UAT']
           sentry_dns_uat = os.environ['SENTRY_DNS_UAT']
-          if branch == staging:
-            print('::set-env name=SENTRY_PROJECT::' + sentry_project_staging)
-            print('::set-env name=SENTRY_DNS::' + sentry_dns_staging)
-          elif branch == production:
-            print('::set-env name=SENTRY_PROJECT::' + sentry_project_production)
-            print('::set-env name=SENTRY_DNS::' + sentry_dns_production)
-          elif branch == uat:
-            print('::set-env name=SENTRY_PROJECT::' + sentry_project_uat)
-            print('::set-env name=SENTRY_DNS::' + sentry_dns_uat)
+          github_env = os.environ['GITHUB_ENV']
+          with open(github_env, 'a', encoding='utf-8') as file:
+            if branch == staging:
+              file.write(f'SENTRY_PROJECT={sentry_project_staging}\n')
+              file.write(f'SENTRY_DNS={sentry_dns_staging}\n')
+            elif branch == production:
+              file.write(f'SENTRY_PROJECT={sentry_project_production}\n')
+              file.write(f'SENTRY_DNS={sentry_dns_production}\n')
+            elif branch == uat:
+              file.write(f'SENTRY_PROJECT={sentry_project_uat}\n')
+              file.write(f'SENTRY_DNS={sentry_dns_uat}\n')
       - name: Upload to Sentry
         run: npm run build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
             elif branch == uat:
               file.write(f'SENTRY_PROJECT={sentry_project_uat}\n')
               file.write(f'SENTRY_DNS={sentry_dns_uat}\n')
+      - name: Print env
+        run: echo $SENTRY_PROJECT && echo $SENTRY_DNS
       - name: Upload to Sentry
         run: npm run build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,18 +125,17 @@ jobs:
           sentry_project_uat = os.environ['SENTRY_PROJECT_UAT']
           sentry_dns_uat = os.environ['SENTRY_DNS_UAT']
           github_env = os.environ['GITHUB_ENV']
-          with open(github_env, 'a', encoding='utf-8') as file:
-            if branch == staging:
-              file.write(f'SENTRY_PROJECT={sentry_project_staging}\n')
-              file.write(f'SENTRY_DNS={sentry_dns_staging}\n')
-            elif branch == production:
-              file.write(f'SENTRY_PROJECT={sentry_project_production}\n')
-              file.write(f'SENTRY_DNS={sentry_dns_production}\n')
-            elif branch == uat:
-              file.write(f'SENTRY_PROJECT={sentry_project_uat}\n')
-              file.write(f'SENTRY_DNS={sentry_dns_uat}\n')
-      - name: Print env
-        run: echo $SENTRY_PROJECT && echo $SENTRY_DNS
+          file = open(github_env, 'a')
+          if branch == staging:
+            file.write('SENTRY_PROJECT={}\n'.format(sentry_project_staging))
+            file.write('SENTRY_DNS={}\n'.format(sentry_dns_staging))
+          elif branch == production:
+            file.write('SENTRY_PROJECT={}\n'.format(sentry_project_production))
+            file.write('SENTRY_DNS={}\n'.format(sentry_dns_production))
+          elif branch == uat:
+            file.write('SENTRY_PROJECT={}\n'.format(sentry_project_uat))
+            file.write('SENTRY_DNS={}\n'.format(sentry_dns_uat))
+          file.close()
       - name: Upload to Sentry
         run: npm run build
         env:


### PR DESCRIPTION
## Problem

Github actions has [deprecated the feature](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) of setting environment variables via stdout. A workaround of force-enabling it was made during last release, but should be removed whenever possible.

Closes #942

## Solution

Grab the `$GITHUB_ENV` file from env and append environment variables to it, following the [guide in the docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

