### PR TITLE
fix: backgroundtype as optional

### DIFF
--- a/src/client/app/components/Section.tsx
+++ b/src/client/app/components/Section.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme) =>
 )
 
 type SectionProps = {
-  backgroundType: string,
+  backgroundType?: string,
   verticalMultiplier?: number,
   topMultiplier?: number,
   bottomMultiplier?: number,
@@ -54,7 +54,7 @@ type SectionProps = {
 
 const Section: FunctionComponent<SectionProps> = ({
   children,
-  backgroundType,
+  backgroundType = '',
   verticalMultiplier = 1,
   topMultiplier = 1,
   bottomMultiplier = 1,


### PR DESCRIPTION
## Problem

Uncaught merge error that cause build to fail 

During development, the login index was still in JSX, thus there was no error.
Once merge, the TSX version throws an error.

<img width="1411" alt="Screenshot 2020-11-26 at 3 36 48 PM" src="https://user-images.githubusercontent.com/29625514/100325660-e631f180-3003-11eb-9dc3-484d79174096.png">

## Solution

Change backgroundType as optional and have default argument of empty string

