### PR TITLE
refactor/login: Refactor heavily-entangled LoginForm component

### DIFF
--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -7,7 +7,6 @@ type LoginFormProps = {
   id: string,
   placeholder: string,
   buttonMessage: string,
-  hidden: boolean,
   variant: VariantType,
   autoComplete: string,
   onChange: (email: string) => {},
@@ -43,7 +42,6 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   id,
   placeholder,
   buttonMessage,
-  hidden,
   variant,
   autoComplete,
   onChange,
@@ -57,7 +55,6 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   return (
     <form
       onSubmit={onSubmit}
-      hidden={hidden}
       autoComplete={autoComplete}
     >
       <TextField

--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from 'react'
 
 import { Button, TextField, createStyles, makeStyles } from '@material-ui/core'
 import { loginFormVariants, VariantType } from '../../app/util/types'
-import { GAEvent, GAPageView } from '../../app/util/ga'
 
 type LoginFormProps = {
   id: string,
@@ -11,11 +10,10 @@ type LoginFormProps = {
   hidden: boolean,
   variant: VariantType,
   autoComplete: string,
-  isEmailView?: boolean,
   onChange: (email: string) => {},
   textError: () => boolean,
   textErrorMessage: () => string,
-  submit: () => {},
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void,
 }
 
 const useStyles = makeStyles((theme) =>
@@ -48,26 +46,17 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   hidden,
   variant,
   autoComplete,
-  isEmailView,
   onChange,
   textError,
   textErrorMessage,
-  submit,
+  onSubmit,
   children,
 }) => {
   const classes = useStyles()
   const variantMap = loginFormVariants.map[variant]
   return (
     <form
-      onSubmit={(e) => {
-        e.preventDefault()
-        submit()
-        // Google Analytics: OTP page, Transition from email > OTP page
-        if (isEmailView) {
-          GAPageView('OTP LOGIN PAGE')
-          GAEvent('login page', 'otp', 'successful')
-        }
-      }}
+      onSubmit={onSubmit}
       hidden={hidden}
       autoComplete={autoComplete}
     >
@@ -106,11 +95,6 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
       </section>
     </form>
   )
-}
-
-// By default the login page should first request for email
-LoginForm.defaultProps = {
-  isEmailView: true,
 }
 
 export default LoginForm

--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -1,11 +1,7 @@
 import React, { FunctionComponent } from 'react'
-import classNames from 'classnames'
-import { useDispatch } from 'react-redux'
-import i18next from 'i18next'
+
 import { Button, TextField, createStyles, makeStyles } from '@material-ui/core'
 import { loginFormVariants, VariantType } from '../../app/util/types'
-import loginActions from '../actions'
-import TextButton from '../widgets/TextButton'
 import { GAEvent, GAPageView } from '../../app/util/ga'
 
 type LoginFormProps = {
@@ -41,16 +37,6 @@ const useStyles = makeStyles((theme) =>
       minWidth: '120px',
       marginRight: theme.spacing(2),
     },
-    secondaryButton: {
-      fontWeight: 400,
-      marginLeft: theme.spacing(2),
-    },
-    resendOTPBtn: {
-      marginRight: 'auto',
-      '&:disabled': {
-        opacity: 0.5,
-      },
-    },
   }),
 )
 
@@ -67,10 +53,9 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   textError,
   textErrorMessage,
   submit,
+  children,
 }) => {
   const classes = useStyles()
-  const dispatch = useDispatch()
-  const getOTPEmail = () => dispatch(loginActions.getOTPEmail())
   const variantMap = loginFormVariants.map[variant]
   return (
     <form
@@ -117,25 +102,7 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
         >
           {buttonMessage}
         </Button>
-        {!isEmailView ? (
-          <TextButton
-            className={classNames(
-              classes.secondaryButton,
-              classes.resendOTPBtn,
-            )}
-            disabled={!variantMap.resendEnabled}
-            onClick={getOTPEmail}
-          >
-            Resend OTP
-          </TextButton>
-        ) : (
-          <TextButton
-            className={classes.secondaryButton}
-            href={i18next.t('general.links.faq')}
-          >
-            Need help?
-          </TextButton>
-        )}
+        {children}
       </section>
     </form>
   )

--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -13,6 +13,7 @@ type LoginFormProps = {
   textError: () => boolean,
   textErrorMessage: () => string,
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void,
+  hidden?: boolean
 }
 
 const useStyles = makeStyles((theme) =>
@@ -49,11 +50,13 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   textErrorMessage,
   onSubmit,
   children,
+  hidden
 }) => {
   const classes = useStyles()
   const variantMap = loginFormVariants.map[variant]
   return (
     <form
+      hidden={hidden}
       onSubmit={onSubmit}
       autoComplete={autoComplete}
     >

--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -13,7 +13,7 @@ type LoginFormProps = {
   textError: () => boolean,
   textErrorMessage: () => string,
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void,
-  hidden?: boolean
+  value: string
 }
 
 const useStyles = makeStyles((theme) =>
@@ -50,13 +50,12 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
   textErrorMessage,
   onSubmit,
   children,
-  hidden
+  value
 }) => {
   const classes = useStyles()
   const variantMap = loginFormVariants.map[variant]
   return (
     <form
-      hidden={hidden}
       onSubmit={onSubmit}
       autoComplete={autoComplete}
     >
@@ -79,6 +78,7 @@ const LoginForm : FunctionComponent<LoginFormProps> = ({
         disabled={!variantMap.inputEnabled}
         error={textError()}
         helperText={textErrorMessage()}
+        value={value}
       />
       <section className={classes.buttonRow}>
         <Button

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, FunctionComponent } from 'react'
+import classNames from 'classnames'
 import i18next from 'i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -22,6 +23,7 @@ import Section from '../app/components/Section'
 import BaseLayout from '../app/components/BaseLayout'
 import { GAEvent, GAPageView } from '../app/util/ga'
 import { VariantType } from '../app/util/types'
+import TextButton from './widgets/TextButton'
 
 type LoginPageProps = {
   location?: {
@@ -93,6 +95,16 @@ const useStyles = makeStyles((theme) =>
         marginBottom: '0',
       },
     },
+    secondaryButton: {
+      fontWeight: 400,
+      marginLeft: theme.spacing(2),
+    },
+    resendOTPBtn: {
+      marginRight: 'auto',
+      '&:disabled': {
+        opacity: 0.5,
+      },
+    },
   }),
 )
 
@@ -142,6 +154,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       cancelled = true
     }
   }, [getEmailValidator])
+
+  const getOTPEmail = () => dispatch(loginActions.getOTPEmail())
 
   if (!isLoggedIn) {
     const variantMap = loginFormVariants.map[variant]
@@ -216,8 +230,28 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-                    <LoginForm {...emailFormAttr} />
-                    <LoginForm {...otpFormAttr} />
+                    {isEmailView ?
+                      <LoginForm {...emailFormAttr} >
+                        <TextButton
+                          className={classNames(
+                            classes.secondaryButton,
+                            classes.resendOTPBtn,
+                          )}
+                          disabled={!variantMap.resendEnabled}
+                          onClick={getOTPEmail}
+                        >
+                          Resend OTP
+                        </TextButton>
+                      </LoginForm> :
+                      <LoginForm {...otpFormAttr}>
+                        <TextButton
+                          className={classes.secondaryButton}
+                          href={i18next.t('general.links.faq')}
+                        >
+                          Need help?
+                        </TextButton>
+                      </LoginForm>
+                    }
                     {variantMap.progressBarShown ? (
                       <LinearProgress />
                     ) : null}

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -165,7 +165,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
     const isEmailView = loginFormVariants.isEmailView(variant)
     const emailError = () => !!email && !emailValidator(email)
 
-    const emailFormAttr = {
+    const formAttr = isEmailView ? {
       id: 'email',
       onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
@@ -186,9 +186,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       variant,
       autoComplete: 'on',
       value: email,
-    }
-
-    const otpFormAttr = {
+    } : {
       id: 'otp',
       onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
@@ -202,7 +200,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       onChange: (otp: string) => dispatch(loginActions.setOTP(otp)),
       variant,
       autoComplete: 'off',
-      isEmailView,
       value: otp,
     }
 
@@ -241,29 +238,26 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-                      { isEmailView ?
-                      <LoginForm {...emailFormAttr}>
-                        <TextButton
-                          className={classes.secondaryButton}
-                          href={i18next.t('general.links.faq')}
-                        >
-                          Need help?
-                        </TextButton>
-                      </LoginForm> :
-                      <LoginForm {...otpFormAttr}>
-                        <TextButton
-                          className={classNames(
-                            classes.secondaryButton,
-                            classes.resendOTPBtn,
-                          )}
-                          disabled={!variantMap.resendEnabled}
-                          onClick={getOTPEmail}
-                        >
-                          Resend OTP
-                        </TextButton>
+                      <LoginForm {...formAttr}>
+                        { isEmailView ?
+                          <TextButton
+                            className={classes.secondaryButton}
+                            href={i18next.t('general.links.faq')}
+                          >
+                            Need help?
+                          </TextButton> :
+                          <TextButton
+                            className={classNames(
+                              classes.secondaryButton,
+                              classes.resendOTPBtn,
+                            )}
+                            disabled={!variantMap.resendEnabled}
+                            onClick={getOTPEmail}
+                          >
+                            Resend OTP
+                          </TextButton>
+                        }
                       </LoginForm>
-                      }
-
                     {variantMap.progressBarShown ? (
                       <LinearProgress />
                     ) : null}

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -181,13 +181,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       isEmailView,
     }
 
-    const emailForm = <LoginForm {...emailFormAttr} />
-    const otpForm = <LoginForm {...otpFormAttr} />
-
-    const progressBar = variantMap.progressBarShown ? (
-      <LinearProgress />
-    ) : null
-
     return (
       <BaseLayout withHeader={false} withFooter={false} withLowFooter={false}>
         <div className={classes.container}>
@@ -223,9 +216,11 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-                    {emailForm}
-                    {otpForm}
-                    {progressBar}
+                    <LoginForm {...emailFormAttr} />
+                    <LoginForm {...otpFormAttr} />
+                    {variantMap.progressBarShown ? (
+                      <LinearProgress />
+                    ) : null}
                   </span>
                 </section>
               </Section>

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -164,7 +164,12 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
 
     const emailFormAttr = {
       id: 'email',
-      submit: () => dispatch(loginActions.getOTPEmail()),
+      onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        dispatch(loginActions.getOTPEmail())
+        GAPageView('OTP LOGIN PAGE')
+        GAEvent('login page', 'otp', 'successful')
+      },
       placeholder: `e.g. ${i18next.t('general.placeholders.email')}`,
       buttonMessage: 'Sign in',
       textError: emailError,
@@ -182,7 +187,10 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
 
     const otpFormAttr = {
       id: 'otp',
-      submit: () => dispatch(loginActions.verifyOTP()),
+      onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        dispatch(loginActions.verifyOTP())
+      },
       titleMessage: 'One time password',
       placeholder: 'e.g. 123456',
       buttonMessage: 'Submit',

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -244,6 +244,14 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                       { isEmailView ?
                       <LoginForm {...emailFormAttr}>
                         <TextButton
+                          className={classes.secondaryButton}
+                          href={i18next.t('general.links.faq')}
+                        >
+                          Need help?
+                        </TextButton>
+                      </LoginForm> :
+                      <LoginForm {...otpFormAttr}>
+                        <TextButton
                           className={classNames(
                             classes.secondaryButton,
                             classes.resendOTPBtn,
@@ -252,14 +260,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                           onClick={getOTPEmail}
                         >
                           Resend OTP
-                        </TextButton>
-                      </LoginForm> :
-                      <LoginForm {...otpFormAttr}>
-                        <TextButton
-                          className={classes.secondaryButton}
-                          href={i18next.t('general.links.faq')}
-                        >
-                          Need help?
                         </TextButton>
                       </LoginForm>
                       }

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -236,8 +236,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-                    {isEmailView ?
-                      <LoginForm {...emailFormAttr} >
+
+                      <LoginForm {...emailFormAttr} hidden={!isEmailView}>
                         <TextButton
                           className={classNames(
                             classes.secondaryButton,
@@ -248,8 +248,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                         >
                           Resend OTP
                         </TextButton>
-                      </LoginForm> :
-                      <LoginForm {...otpFormAttr}>
+                      </LoginForm>
+                      <LoginForm {...otpFormAttr} hidden={isEmailView}>
                         <TextButton
                           className={classes.secondaryButton}
                           href={i18next.t('general.links.faq')}
@@ -257,7 +257,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                           Need help?
                         </TextButton>
                       </LoginForm>
-                    }
+
                     {variantMap.progressBarShown ? (
                       <LinearProgress />
                     ) : null}

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -124,6 +124,9 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   const email = useSelector(
     (state: GoGovReduxState) => state.login.email
   )
+  const otp = useSelector(
+    (state: GoGovReduxState) => state.login.otp
+  )
   const variant: VariantType = useSelector(
     (state: GoGovReduxState) => state.login.formVariant
   )
@@ -182,6 +185,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       onChange:  (email: string) => dispatch(loginActions.setEmail(email)),
       variant,
       autoComplete: 'on',
+      value: email,
     }
 
     const otpFormAttr = {
@@ -199,6 +203,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       variant,
       autoComplete: 'off',
       isEmailView,
+      value: otp,
     }
 
     return (
@@ -236,8 +241,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-
-                      <LoginForm {...emailFormAttr} hidden={!isEmailView}>
+                      { isEmailView ?
+                      <LoginForm {...emailFormAttr}>
                         <TextButton
                           className={classNames(
                             classes.secondaryButton,
@@ -248,8 +253,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                         >
                           Resend OTP
                         </TextButton>
-                      </LoginForm>
-                      <LoginForm {...otpFormAttr} hidden={isEmailView}>
+                      </LoginForm> :
+                      <LoginForm {...otpFormAttr}>
                         <TextButton
                           className={classes.secondaryButton}
                           href={i18next.t('general.links.faq')}
@@ -257,6 +262,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                           Need help?
                         </TextButton>
                       </LoginForm>
+                      }
 
                     {variantMap.progressBarShown ? (
                       <LinearProgress />

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -179,7 +179,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
               'general.emailDomain',
             )} email.`
           : '',
-      hidden: !isEmailView,
       onChange:  (email: string) => dispatch(loginActions.setEmail(email)),
       variant,
       autoComplete: 'on',
@@ -196,7 +195,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       buttonMessage: 'Submit',
       textError: () => false,
       textErrorMessage: () => '',
-      hidden: isEmailView,
       onChange: (otp: string) => dispatch(loginActions.setOTP(otp)),
       variant,
       autoComplete: 'off',


### PR DESCRIPTION
## Problem

The login page and its components were heavily entwined. This made it difficult to reason about interactions and dependencies, or to remove its Redux dependenices.

Part of #955

## Solution

Refactor the `LoginForm` component to be fully functional. Instead of having inside knowledge of the login flow, it is now configured from outside the component. Instead of hardcoding if-else statements to decide which components to show, it now accepts `children` as props.

It has been upgraded to become a fully controlled component via the `value` prop, whereas previously it was relying on a hack using the `hidden` property to remove DOM input (i.e. user email) when the login page transits from email stage to the OTP stage.
