### PR TITLE
refactor: remove keystroke updates to Redux on Login page

### DIFF
--- a/src/client/login/actions/index.ts
+++ b/src/client/login/actions/index.ts
@@ -20,12 +20,8 @@ import {
   RESEND_OTP_PENDING,
   ResendOtpDisabledAction,
   ResendOtpPendingAction,
-  SET_EMAIL,
   SET_EMAIL_VALIDATOR,
-  SET_OTP,
-  SetEmailAction,
   SetEmailValidatorAction,
-  SetOtpAction,
   VERIFY_OTP_ERROR,
   VERIFY_OTP_PENDING,
   VerifyOtpErrorAction,
@@ -63,20 +59,10 @@ const isGetOTPError: (errorMessage?: string) => GetOtpEmailErrorAction = (
   payload: errorMessage,
 })
 
-const setEmail: (payload: string) => SetEmailAction = (payload) => ({
-  type: SET_EMAIL,
-  payload,
-})
-
 const setEmailValidator: (
   payload: EmailValidatorType,
 ) => SetEmailValidatorAction = (payload) => ({
   type: SET_EMAIL_VALIDATOR,
-  payload,
-})
-
-const setOTP: (payload: string) => SetOtpAction = (payload) => ({
-  type: SET_OTP,
   payload,
 })
 
@@ -291,8 +277,6 @@ export default {
   getEmailValidationGlobExpression,
   getOTPEmail,
   verifyOTP,
-  setOTP,
-  setEmail,
   isLoggedIn,
   logout,
 }

--- a/src/client/login/actions/index.ts
+++ b/src/client/login/actions/index.ts
@@ -143,7 +143,7 @@ const getEmailValidationGlobExpression = () => (
 /**
  * Called when user enters email and waits for OTP.
  */
-const getOTPEmail = () => (
+const getOTPEmail = (email: string) => (
   dispatch: Dispatch<
     | GetOtpEmailErrorAction
     | CloseSnackbarAction
@@ -159,7 +159,7 @@ const getOTPEmail = () => (
   dispatch<CloseSnackbarAction>(rootActions.closeSnackbar())
 
   const { login } = getState()
-  const { email, formVariant } = login
+  const { formVariant } = login
   let pendingAction: () => void
   let successAction: () => void
   let errorAction: () => void
@@ -234,7 +234,7 @@ const isLoggedIn = () => (
 /**
  * Called when user enters OTP and submits for verification.
  */
-const verifyOTP = () => (
+const verifyOTP = (otp: string) => (
   dispatch: ThunkDispatch<
     GoGovReduxState,
     void,
@@ -249,7 +249,7 @@ const verifyOTP = () => (
   dispatch<CloseSnackbarAction>(rootActions.closeSnackbar())
 
   const { login } = getState()
-  const { email, otp } = login
+  const { email } = login
 
   dispatch<VerifyOtpPendingAction>(isVerifyOTPPending())
   return postJson('/api/login/verify', { email, otp }).then((response) => {

--- a/src/client/login/actions/types.ts
+++ b/src/client/login/actions/types.ts
@@ -5,8 +5,6 @@ export const VERIFY_OTP_ERROR = 'VERIFY_OTP_ERROR'
 export const VERIFY_OTP_PENDING = 'VERIFY_OTP_PENDING'
 export const RESEND_OTP_PENDING = 'RESEND_OTP_PENDING'
 export const RESEND_OTP_DISABLED = 'RESEND_OTP_DISABLED'
-export const SET_OTP = 'SET_OTP'
-export const SET_EMAIL = 'SET_EMAIL'
 export const SET_EMAIL_VALIDATOR = 'SET_EMAIL_VALIDATOR'
 export const IS_LOGGED_IN_SUCCESS = 'IS_LOGGED_IN_SUCCESS'
 export const IS_LOGGED_OUT = 'IS_LOGGED_OUT'
@@ -39,16 +37,6 @@ export type ResendOtpDisabledAction = {
   type: typeof RESEND_OTP_DISABLED
 }
 
-export type SetOtpAction = {
-  type: typeof SET_OTP
-  payload: string
-}
-
-export type SetEmailAction = {
-  type: typeof SET_EMAIL
-  payload: string
-}
-
 export type EmailValidatorType = (email: string) => boolean
 
 export type SetEmailValidatorAction = {
@@ -69,8 +57,6 @@ export type LoginActionType =
   | IsLoggedOutAction
   | IsLoggedInSuccessAction
   | SetEmailValidatorAction
-  | SetEmailAction
-  | SetOtpAction
   | ResendOtpDisabledAction
   | ResendOtpPendingAction
   | VerifyOtpPendingAction

--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -9,7 +9,7 @@ type LoginFormProps = {
   buttonMessage: string,
   variant: VariantType,
   autoComplete: string,
-  onChange: (email: string) => {},
+  onChange: (email: string) => void,
   textError: () => boolean,
   textErrorMessage: () => string,
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void,

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -144,7 +144,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
     get('/api/login/message').then((response) => {
       if (response.ok) {
         response.text().then((text) => {
-          console.log(text)
           if (text && !cancelled) setLoginInfoMessage(text)
         })
       }

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, FunctionComponent } from 'react'
+import React, { useState, useEffect, FunctionComponent } from 'react'
 import classNames from 'classnames'
 import i18next from 'i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -121,12 +121,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   const isLoggedIn = useSelector(
     (state: GoGovReduxState) => state.login.isLoggedIn
   )
-  const email = useSelector(
-    (state: GoGovReduxState) => state.login.email
-  )
-  const otp = useSelector(
-    (state: GoGovReduxState) => state.login.otp
-  )
+  const [email, setEmail] = useState('')
+  const [otp, setOtp] = useState('')
   const variant: VariantType = useSelector(
     (state: GoGovReduxState) => state.login.formVariant
   )
@@ -158,8 +154,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
     }
   }, [getEmailValidator])
 
-  const getOTPEmail = () => dispatch(loginActions.getOTPEmail())
-
   if (!isLoggedIn) {
     const variantMap = loginFormVariants.map[variant]
     const isEmailView = loginFormVariants.isEmailView(variant)
@@ -169,7 +163,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       id: 'email',
       onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
-        dispatch(loginActions.getOTPEmail())
+        dispatch(loginActions.getOTPEmail(email))
         GAPageView('OTP LOGIN PAGE')
         GAEvent('login page', 'otp', 'successful')
       },
@@ -182,7 +176,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
               'general.emailDomain',
             )} email.`
           : '',
-      onChange:  (email: string) => dispatch(loginActions.setEmail(email)),
+      onChange:  (email: string) => setEmail(email),
       variant,
       autoComplete: 'on',
       value: email,
@@ -190,14 +184,14 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
       id: 'otp',
       onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
-        dispatch(loginActions.verifyOTP())
+        dispatch(loginActions.verifyOTP(otp))
       },
       titleMessage: 'One time password',
       placeholder: 'e.g. 123456',
       buttonMessage: 'Submit',
       textError: () => false,
       textErrorMessage: () => '',
-      onChange: (otp: string) => dispatch(loginActions.setOTP(otp)),
+      onChange: (otp: string) => setOtp(otp),
       variant,
       autoComplete: 'off',
       value: otp,
@@ -238,26 +232,26 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                     <Typography variant="body1">
                       {isEmailView ? 'Email' : 'One-time password'}
                     </Typography>
-                      <LoginForm {...formAttr}>
-                        { isEmailView ?
-                          <TextButton
-                            className={classes.secondaryButton}
-                            href={i18next.t('general.links.faq')}
-                          >
-                            Need help?
-                          </TextButton> :
-                          <TextButton
-                            className={classNames(
-                              classes.secondaryButton,
-                              classes.resendOTPBtn,
-                            )}
-                            disabled={!variantMap.resendEnabled}
-                            onClick={getOTPEmail}
-                          >
-                            Resend OTP
-                          </TextButton>
-                        }
-                      </LoginForm>
+                    <LoginForm {...formAttr}>
+                      { isEmailView ?
+                        <TextButton
+                          className={classes.secondaryButton}
+                          href={i18next.t('general.links.faq')}
+                        >
+                          Need help?
+                        </TextButton> :
+                        <TextButton
+                          className={classNames(
+                            classes.secondaryButton,
+                            classes.resendOTPBtn,
+                          )}
+                          disabled={!variantMap.resendEnabled}
+                          onClick={() => dispatch(loginActions.getOTPEmail(email))}
+                        >
+                          Resend OTP
+                        </TextButton>
+                      }
+                    </LoginForm>
                     {variantMap.progressBarShown ? (
                       <LinearProgress />
                     ) : null}

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -126,11 +126,10 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   const variant: VariantType = useSelector(
     (state: GoGovReduxState) => state.login.formVariant
   )
-
+  // Google Analytics
   useEffect(() => {
-    // Google Analytics: Move into login page
-    // Because directory page will redirect to login page first
-    // We need filter that out
+    // Filter out redirects from directory page
+    // TODO (#988): Can this be fixed to cater to all routes?
     if (location?.state?.previous !== '/directory') {
       GAPageView('EMAIL LOGIN PAGE')
       GAEvent('login page', 'email')
@@ -140,7 +139,6 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   // Display a login message from the server
   useEffect(() => {
     let cancelled = false
-    dispatch(loginActions.getEmailValidationGlobExpression())
     get('/api/login/message').then((response) => {
       if (response.ok) {
         response.text().then((text) => {
@@ -151,6 +149,12 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
     return () => {
       cancelled = true
     }
+  }, [])
+
+  // Fetch backend validation expression
+  useEffect(() => {
+    dispatch(loginActions.getEmailValidationGlobExpression())
+    return
   }, [getEmailValidator])
 
   if (!isLoggedIn) {

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -176,7 +176,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
               'general.emailDomain',
             )} email.`
           : '',
-      onChange:  (email: string) => setEmail(email),
+      onChange:  (email: string) => setEmail(email.toLowerCase()),
       variant,
       autoComplete: 'on',
       value: email,

--- a/src/client/login/reducers/index.ts
+++ b/src/client/login/reducers/index.ts
@@ -8,9 +8,7 @@ import {
   LoginActionType,
   RESEND_OTP_DISABLED,
   RESEND_OTP_PENDING,
-  SET_EMAIL,
   SET_EMAIL_VALIDATOR,
-  SET_OTP,
   VERIFY_OTP_ERROR,
   VERIFY_OTP_PENDING,
 } from '../actions/types'
@@ -23,7 +21,6 @@ export const defaultEmailValidator = (email: string) =>
 const initialState: LoginState = {
   email: '',
   emailValidator: defaultEmailValidator,
-  otp: '',
   user: {},
   isLoggedIn: false,
   formVariant: loginFormVariants.types.EMAIL_READY,
@@ -33,16 +30,6 @@ export const login = (state = initialState, action: LoginActionType) => {
   let nextState = {}
 
   switch (action.type) {
-    case SET_EMAIL:
-      nextState = {
-        email: action.payload.toLowerCase(), // Force input to be lowercase
-      }
-      break
-    case SET_OTP:
-      nextState = {
-        otp: action.payload,
-      }
-      break
     case SET_EMAIL_VALIDATOR:
       nextState = {
         emailValidator: action.payload,

--- a/src/client/login/reducers/types.ts
+++ b/src/client/login/reducers/types.ts
@@ -4,7 +4,6 @@ import { EmailValidatorType } from '../actions/types'
 export type LoginState = {
   email: string
   emailValidator: EmailValidatorType
-  otp: string
   user: {
     id?: string
   }


### PR DESCRIPTION
## Problem

Closes #955

## Solution

Login component state management of email and OTP is now managed by `useState` hooks. The user's email is populated in Redux only upon successful login.

Other minor code improvements were also carried out, such as separating the `useEffect` hooks of login glob validation from that of fetching the login page message.

Unused Redux actions and reducers have been removed.