### PR TITLE
Refactor drawer domain

### DIFF
--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -305,13 +305,7 @@ export default function ControlPanel() {
             }
             trailingPosition={TrailingPosition.center}
           />
-          <ConfigOption
-            title="Download QR Code"
-            titleVariant="h6"
-            titleClassName={isMobileView ? classes.regularText : ''}
-            trailing={<DownloadButton />}
-            trailingPosition={TrailingPosition.end}
-          />
+          <DownloadButton />
           <Hidden smDown>
             <div className={classes.textFieldsTopSpacer} />
           </Hidden>

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import {
   Drawer,
   createStyles,
@@ -22,21 +22,22 @@ import LinkAnalytics from './LinkAnalytics'
 import DrawerHeader from './DrawerHeader'
 import ConfigOption, { TrailingPosition } from '../../../widgets/ConfigOption'
 import PrefixableTextField from '../../../widgets/PrefixableTextField'
-import TrailingButton from './widgets/TrailingButton'
 import useShortLink from './util/shortlink'
 import { removeHttpsProtocol } from '../../../../app/util/url'
 import { isValidLongUrl } from '../../../../../shared/util/validation'
+import FileInputField from '../../../widgets/FileInputField'
+import LinkInfoEditor from '../../../widgets/LinkInfoEditor'
+import LinkOwnershipField from './widgets/LinkOwnershipField'
+import TrailingButton from './widgets/TrailingButton'
 import DownloadButton from './widgets/DownloadButton'
 import LinkStateText from './widgets/LinkStateText'
 import helpIcon from '../../../../app/assets/help-icon.svg'
-import FileInputField from '../../../widgets/FileInputField'
 import CollapsibleMessage from '../../../../app/components/CollapsibleMessage'
 import {
   CollapsibleMessageType,
   CollapsibleMessagePosition,
 } from '../../../../app/components/CollapsibleMessage/types'
 import { SEARCH_PAGE } from '../../../../app/util/types'
-import LinkInfoEditor from '../../../widgets/LinkInfoEditor'
 import inProgressGraphic from './assets/in-progress.svg'
 
 const useStyles = makeStyles((theme) =>
@@ -144,7 +145,7 @@ const useStyles = makeStyles((theme) =>
       },
     },
     inactiveDesc: {
-      display: 'none'
+      display: 'none',
     },
     customInformationHeader: {
       marginRight: theme.spacing(2),
@@ -192,7 +193,6 @@ export default function ControlPanel() {
   const editedLongUrl = shortLinkState?.editedLongUrl || ''
   const editedContactEmail = shortLinkState?.editedContactEmail || ''
   const editedDescription = shortLinkState?.editedDescription || ''
-  const [pendingOwner, setPendingOwner] = useState<string>('')
   const originalDescription = shortLinkState?.description || ''
   const originalContactEmail = shortLinkState?.contactEmail || ''
 
@@ -204,28 +204,8 @@ export default function ControlPanel() {
     shortLinkDispatch?.setEditLongUrl(originalLongUrl)
     shortLinkDispatch?.setEditDescription(originalDescription)
     shortLinkDispatch?.setEditContactEmail(originalContactEmail)
-    setPendingOwner('')
     modalDispatch({ type: DrawerActions.closeControlPanel })
   }
-
-  const linkOwnershipHelp = (
-    <>
-      Link owner{' '}
-      <Tooltip
-        title="Links can only be transferred to an existing Go.gov.sg user"
-        arrow
-        placement="top"
-        classes={{ tooltip: classes.drawerTooltip }}
-      >
-        <img
-          className={classes.ownershipHelpIcon}
-          src={helpIcon}
-          alt="Ownership help"
-          draggable={false}
-        />
-      </Tooltip>
-    </>
-  )
 
   const replaceFileHelp = (
     <div className={classes.originalFileLabel}>
@@ -368,33 +348,7 @@ export default function ControlPanel() {
           <Hidden mdUp>
             <Divider className={classes.divider} />
           </Hidden>
-          <ConfigOption
-            title={linkOwnershipHelp}
-            titleVariant="body2"
-            titleClassName={classes.regularText}
-            leading={
-              <PrefixableTextField
-                value={pendingOwner}
-                onChange={(event) => setPendingOwner(event.target.value)}
-                placeholder="Email of link recipient"
-                helperText={' '}
-              />
-            }
-            trailing={
-              <TrailingButton
-                onClick={() => {
-                  shortLinkDispatch?.applyNewOwner(pendingOwner, handleClose)
-                }}
-                disabled={!pendingOwner}
-                variant={isMobileView ? 'contained' : 'outlined'}
-                fullWidth={isMobileView}
-              >
-                Transfer
-              </TrailingButton>
-            }
-            wrapTrailing={isMobileView}
-            trailingPosition={TrailingPosition.end}
-          />
+          <LinkOwnershipField closeModal={handleClose} />
           <div className={classes.inactiveDesc}>
           <Divider className={classes.dividerInformation} />
           <LinkInfoEditor

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -23,11 +23,11 @@ import DrawerHeader from './DrawerHeader'
 import ConfigOption, { TrailingPosition } from '../../../widgets/ConfigOption'
 import PrefixableTextField from '../../../widgets/PrefixableTextField'
 import TrailingButton from './widgets/TrailingButton'
-import GoSwitch from '../../../widgets/GoSwitch'
 import useShortLink from './util/shortlink'
 import { removeHttpsProtocol } from '../../../../app/util/url'
 import { isValidLongUrl } from '../../../../../shared/util/validation'
 import DownloadButton from './widgets/DownloadButton'
+import LinkStateText from './widgets/LinkStateText'
 import helpIcon from '../../../../app/assets/help-icon.svg'
 import FileInputField from '../../../widgets/FileInputField'
 import CollapsibleMessage from '../../../../app/components/CollapsibleMessage'
@@ -87,12 +87,6 @@ const useStyles = makeStyles((theme) =>
         marginBottom: 50,
       },
     },
-    activeText: {
-      color: '#6d9067',
-    },
-    inactiveText: {
-      color: '#c85151',
-    },
     regularText: {
       fontWeight: 400,
     },
@@ -120,9 +114,6 @@ const useStyles = makeStyles((theme) =>
     },
     textFieldsTopSpacer: {
       height: theme.spacing(1),
-    },
-    stateSwitch: {
-      marginBottom: theme.spacing(2),
     },
     originalFileLabel: {
       marginBottom: theme.spacing(1),
@@ -217,20 +208,6 @@ export default function ControlPanel() {
     modalDispatch({ type: DrawerActions.closeControlPanel })
   }
 
-  const stateTitleActive = (
-    <>
-      Your link is <span className={classes.activeText}>active</span> and
-      publicly accessible
-    </>
-  )
-
-  const stateTitleInactive = (
-    <>
-      Your link is <span className={classes.inactiveText}>inactive</span> and
-      not publicly accessible
-    </>
-  )
-
   const linkOwnershipHelp = (
     <>
       Link owner{' '}
@@ -287,24 +264,7 @@ export default function ControlPanel() {
         </IconButton>
         <DrawerMargin>
           <DrawerHeader />
-          <ConfigOption
-            title={
-              shortLinkState?.state === 'ACTIVE'
-                ? stateTitleActive
-                : stateTitleInactive
-            }
-            titleVariant="h6"
-            titleClassName={isMobileView ? classes.regularText : ''}
-            trailing={
-              <GoSwitch
-                color="primary"
-                checked={shortLinkState?.state === 'ACTIVE'}
-                onChange={shortLinkDispatch?.toggleStatus}
-                className={classes.stateSwitch}
-              />
-            }
-            trailingPosition={TrailingPosition.center}
-          />
+          <LinkStateText />
           <DownloadButton />
           <Hidden smDown>
             <div className={classes.textFieldsTopSpacer} />
@@ -438,9 +398,9 @@ export default function ControlPanel() {
           <div className={classes.inactiveDesc}>
           <Divider className={classes.dividerInformation} />
           <LinkInfoEditor
-            contactEmail={editedContactEmail} 
+            contactEmail={editedContactEmail}
             description={editedDescription}
-            onContactEmailChange={(event) => shortLinkDispatch?.setEditContactEmail(event.target.value)} 
+            onContactEmailChange={(event) => shortLinkDispatch?.setEditContactEmail(event.target.value)}
             onDescriptionChange={(event) =>
               shortLinkDispatch?.setEditDescription(
                 event.target.value.replace(/(\r\n|\n|\r)/gm, ''),

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -20,10 +20,8 @@ import CloseIcon from '../../../../app/components/widgets/CloseIcon'
 import LinkAnalytics from './LinkAnalytics'
 import DrawerHeader from './DrawerHeader'
 import ConfigOption, { TrailingPosition } from '../../../widgets/ConfigOption'
-import PrefixableTextField from '../../../widgets/PrefixableTextField'
 import useShortLink from './util/shortlink'
 import { removeHttpsProtocol } from '../../../../app/util/url'
-import { isValidLongUrl } from '../../../../../shared/util/validation'
 import FileInputField from '../../../widgets/FileInputField'
 import LinkInfoEditor from '../../../widgets/LinkInfoEditor'
 import LinkOwnershipField from './widgets/LinkOwnershipField'
@@ -31,6 +29,7 @@ import DrawerTooltip from './widgets/DrawerTooltip'
 import TrailingButton from './widgets/TrailingButton'
 import DownloadButton from './widgets/DownloadButton'
 import LinkStateText from './widgets/LinkStateText'
+import LongUrlEditor from './widgets/LongUrlEditor'
 import CollapsibleMessage from '../../../../app/components/CollapsibleMessage'
 import {
   CollapsibleMessageType,
@@ -176,7 +175,6 @@ export default function ControlPanel() {
 
   // Manage values in our text fields.
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
-  const editedLongUrl = shortLinkState?.editedLongUrl || ''
   const editedContactEmail = shortLinkState?.editedContactEmail || ''
   const editedDescription = shortLinkState?.editedDescription || ''
   const originalDescription = shortLinkState?.description || ''
@@ -231,48 +229,7 @@ export default function ControlPanel() {
           <Hidden mdUp>
             <Divider className={classes.divider} />
           </Hidden>
-          {!shortLinkState?.isFile && (
-            <>
-              <ConfigOption
-                title="Original link"
-                titleVariant="body2"
-                titleClassName={classes.regularText}
-                leading={
-                  <PrefixableTextField
-                    value={editedLongUrl}
-                    onChange={(event) =>
-                      shortLinkDispatch?.setEditLongUrl(event.target.value)
-                    }
-                    placeholder="Original link"
-                    prefix="https://"
-                    error={!isValidLongUrl(editedLongUrl, true)}
-                    helperText={
-                      isValidLongUrl(editedLongUrl, true)
-                        ? ' '
-                        : "This doesn't look like a valid url."
-                    }
-                  />
-                }
-                trailing={
-                  <TrailingButton
-                    disabled={
-                      !isValidLongUrl(editedLongUrl, false) ||
-                      editedLongUrl === originalLongUrl
-                    }
-                    onClick={() =>
-                      shortLinkDispatch?.applyEditLongUrl(editedLongUrl)
-                    }
-                    fullWidth={isMobileView}
-                    variant={isMobileView ? 'contained' : 'outlined'}
-                  >
-                    Save
-                  </TrailingButton>
-                }
-                wrapTrailing={isMobileView}
-                trailingPosition={TrailingPosition.end}
-              />
-            </>
-          )}
+          {!shortLinkState?.isFile && <LongUrlEditor />}
           {shortLinkState?.isFile && (
             <ConfigOption
               title={replaceFileHelp}

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -8,7 +8,6 @@ import {
   IconButton,
   useTheme,
   useMediaQuery,
-  CircularProgress,
   Link,
   Typography,
 } from '@material-ui/core'
@@ -19,22 +18,14 @@ import DrawerMargin from './DrawerMargin'
 import CloseIcon from '../../../../app/components/widgets/CloseIcon'
 import LinkAnalytics from './LinkAnalytics'
 import DrawerHeader from './DrawerHeader'
-import ConfigOption, { TrailingPosition } from '../../../widgets/ConfigOption'
 import useShortLink from './util/shortlink'
-import { removeHttpsProtocol } from '../../../../app/util/url'
-import FileInputField from '../../../widgets/FileInputField'
 import LinkInfoEditor from '../../../widgets/LinkInfoEditor'
 import LinkOwnershipField from './widgets/LinkOwnershipField'
-import DrawerTooltip from './widgets/DrawerTooltip'
+import FileEditor from './widgets/FileEditor'
 import TrailingButton from './widgets/TrailingButton'
 import DownloadButton from './widgets/DownloadButton'
 import LinkStateText from './widgets/LinkStateText'
 import LongUrlEditor from './widgets/LongUrlEditor'
-import CollapsibleMessage from '../../../../app/components/CollapsibleMessage'
-import {
-  CollapsibleMessageType,
-  CollapsibleMessagePosition,
-} from '../../../../app/components/CollapsibleMessage/types'
 import { SEARCH_PAGE } from '../../../../app/util/types'
 import inProgressGraphic from './assets/in-progress.svg'
 
@@ -101,15 +92,6 @@ const useStyles = makeStyles((theme) =>
     textFieldsTopSpacer: {
       height: theme.spacing(1),
     },
-    originalFileLabel: {
-      marginBottom: theme.spacing(1),
-    },
-    fileInputField: {
-      marginBottom: theme.spacing(3),
-      [theme.breakpoints.up('md')]: {
-        marginBottom: 0,
-      },
-    },
     saveLinkInformationButtonWrapper: {
       display: 'flex',
       justifyContent: 'flex-end',
@@ -161,20 +143,13 @@ export default function ControlPanel() {
   const drawerIsOpen = drawerStates.controlPanelIsOpen
   const modalDispatch = useDrawerDispatch()
 
-  // Error from attempt to replace file
-  const uploadFileError = drawerStates.uploadFileError
-  const setUploadFileError = (error: string | null) =>
-    modalDispatch({ type: DrawerActions.setUploadFileError, payload: error })
-
   // Fetch short link state and dispatches from redux store through our helper hook.
   const {
     shortLinkState,
     shortLinkDispatch,
-    isUploading,
   } = useShortLink(drawerStates.relevantShortLink!)
 
   // Manage values in our text fields.
-  const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
   const editedContactEmail = shortLinkState?.editedContactEmail || ''
   const editedDescription = shortLinkState?.editedDescription || ''
   const originalDescription = shortLinkState?.description || ''
@@ -185,23 +160,10 @@ export default function ControlPanel() {
 
   // Disposes any current unsaved changes and closes the modal.
   const handleClose = () => {
-    shortLinkDispatch?.setEditLongUrl(originalLongUrl)
     shortLinkDispatch?.setEditDescription(originalDescription)
     shortLinkDispatch?.setEditContactEmail(originalContactEmail)
     modalDispatch({ type: DrawerActions.closeControlPanel })
   }
-
-  const replaceFileHelp = (
-    <div className={classes.originalFileLabel}>
-      Original file{' '}
-      <DrawerTooltip
-        title={
-          'Original file will be replaced after you select file. Maximum file size is 10mb.'
-        }
-        imageAltText={'Replace file help'}
-      />
-    </div>
-  )
 
   return (
     <Drawer
@@ -229,58 +191,7 @@ export default function ControlPanel() {
           <Hidden mdUp>
             <Divider className={classes.divider} />
           </Hidden>
-          {!shortLinkState?.isFile && <LongUrlEditor />}
-          {shortLinkState?.isFile && (
-            <ConfigOption
-              title={replaceFileHelp}
-              titleVariant="body2"
-              titleClassName={classes.regularText}
-              leading={
-                <>
-                  <FileInputField
-                    className={classes.fileInputField}
-                    uploadFileError={uploadFileError}
-                    textFieldHeight="44px"
-                    inputId="replace-file-input"
-                    text={originalLongUrl}
-                    setFile={(newFile) => {
-                      shortLinkDispatch?.replaceFile(
-                        newFile,
-                        setUploadFileError,
-                      )
-                    }}
-                    setUploadFileError={setUploadFileError}
-                  />
-                  <CollapsibleMessage
-                    type={CollapsibleMessageType.Error}
-                    visible={!!uploadFileError}
-                    position={CollapsibleMessagePosition.Absolute}
-                  >
-                    {uploadFileError}
-                  </CollapsibleMessage>
-                </>
-              }
-              trailing={
-                <label htmlFor="replace-file-input">
-                  <TrailingButton
-                    onClick={() => {}}
-                    disabled={isUploading}
-                    variant={isMobileView ? 'contained' : 'outlined'}
-                    fullWidth={isMobileView}
-                    component="span"
-                  >
-                    {isUploading ? (
-                      <CircularProgress color="primary" size={20} />
-                    ) : (
-                      'Replace file'
-                    )}
-                  </TrailingButton>
-                </label>
-              }
-              wrapTrailing={isMobileView}
-              trailingPosition={TrailingPosition.end}
-            />
-          )}
+          {shortLinkState?.isFile ? <FileEditor /> : <LongUrlEditor />}
           <Hidden mdUp>
             <Divider className={classes.divider} />
           </Hidden>

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -6,7 +6,6 @@ import {
   Hidden,
   Divider,
   IconButton,
-  Tooltip,
   useTheme,
   useMediaQuery,
   CircularProgress,
@@ -28,10 +27,10 @@ import { isValidLongUrl } from '../../../../../shared/util/validation'
 import FileInputField from '../../../widgets/FileInputField'
 import LinkInfoEditor from '../../../widgets/LinkInfoEditor'
 import LinkOwnershipField from './widgets/LinkOwnershipField'
+import DrawerTooltip from './widgets/DrawerTooltip'
 import TrailingButton from './widgets/TrailingButton'
 import DownloadButton from './widgets/DownloadButton'
 import LinkStateText from './widgets/LinkStateText'
-import helpIcon from '../../../../app/assets/help-icon.svg'
 import CollapsibleMessage from '../../../../app/components/CollapsibleMessage'
 import {
   CollapsibleMessageType,
@@ -90,19 +89,6 @@ const useStyles = makeStyles((theme) =>
     },
     regularText: {
       fontWeight: 400,
-    },
-    ownershipHelpIcon: {
-      width: '14px',
-      verticalAlign: 'middle',
-    },
-    drawerTooltip: {
-      // margin: theme.spacing(1.5, 1, 1.5, 1),
-      whiteSpace: 'nowrap',
-      maxWidth: 'unset',
-      [theme.breakpoints.up('md')]: {
-        marginTop: '-12px',
-        padding: '16px',
-      },
     },
     topBar: {
       width: '100%',
@@ -210,19 +196,12 @@ export default function ControlPanel() {
   const replaceFileHelp = (
     <div className={classes.originalFileLabel}>
       Original file{' '}
-      <Tooltip
-        title="Original file will be replaced after you select file. Maximum file size is 10mb."
-        arrow
-        placement="top"
-        classes={{ tooltip: classes.drawerTooltip }}
-      >
-        <img
-          className={classes.ownershipHelpIcon}
-          src={helpIcon}
-          alt="Replace file help"
-          draggable={false}
-        />
-      </Tooltip>
+      <DrawerTooltip
+        title={
+          'Original file will be replaced after you select file. Maximum file size is 10mb.'
+        }
+        imageAltText={'Replace file help'}
+      />
     </div>
   )
 

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -173,7 +173,7 @@ export default function DownloadButton() {
       title="Download QR Code"
       titleVariant="h6"
       titleClassName={isMobileView ? classes.regularText : ''}
-      trailing={{button}}
+      trailing={button}
       trailingPosition={TrailingPosition.end}
     />
   )

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core'
 import FileSaver from 'file-saver'
 
-
 import TrailingButton from './TrailingButton'
 import downloadIcon from '../assets/download-icon.svg'
 import { useDrawerState } from '../..'

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -163,7 +163,7 @@ export default function DownloadButton() {
   return (
     <ConfigOption
       title="Download QR Code"
-      isTitleMobileResponsive
+      mobile
       trailing={button}
       trailingPosition={TrailingPosition.end}
     />

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -5,13 +5,17 @@ import {
   Menu,
   MenuItem,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@material-ui/core'
 import FileSaver from 'file-saver'
+
 
 import TrailingButton from './TrailingButton'
 import downloadIcon from '../assets/download-icon.svg'
 import { useDrawerState } from '../..'
 import ImageFormat from '../../../../../../shared/util/image-format'
+import ConfigOption, { TrailingPosition } from '../../../../widgets/ConfigOption'
 import { get } from '../../../../../app/util/requests'
 import { GAEvent } from '../../../../../app/util/ga'
 import * as Sentry from '@sentry/browser'
@@ -77,6 +81,9 @@ const useStyles = makeStyles(() =>
     menuItemRoot: {
       height: '50%',
     },
+    regularText: {
+      fontWeight: 400,
+    },
   }),
 )
 
@@ -86,6 +93,8 @@ type Option = {
 }
 
 export default function DownloadButton() {
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const classes = useStyles()
   const modalState = useDrawerState()
   const shortLink = modalState.relevantShortLink!
@@ -116,7 +125,7 @@ export default function DownloadButton() {
     },
   ]
 
-  return (
+  const button = (
     <>
       <TrailingButton onClick={handleClick} variant="outlined">
         <div className={classes.textDiv}>Download</div>
@@ -157,5 +166,15 @@ export default function DownloadButton() {
         })}
       </Menu>
     </>
+  )
+
+  return (
+    <ConfigOption
+      title="Download QR Code"
+      titleVariant="h6"
+      titleClassName={isMobileView ? classes.regularText : ''}
+      trailing={{button}}
+      trailingPosition={TrailingPosition.end}
+    />
   )
 }

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DownloadButton.tsx
@@ -5,8 +5,6 @@ import {
   Menu,
   MenuItem,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from '@material-ui/core'
 import FileSaver from 'file-saver'
 
@@ -80,9 +78,6 @@ const useStyles = makeStyles(() =>
     menuItemRoot: {
       height: '50%',
     },
-    regularText: {
-      fontWeight: 400,
-    },
   }),
 )
 
@@ -92,8 +87,6 @@ type Option = {
 }
 
 export default function DownloadButton() {
-  const theme = useTheme()
-  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const classes = useStyles()
   const modalState = useDrawerState()
   const shortLink = modalState.relevantShortLink!
@@ -170,8 +163,7 @@ export default function DownloadButton() {
   return (
     <ConfigOption
       title="Download QR Code"
-      titleVariant="h6"
-      titleClassName={isMobileView ? classes.regularText : ''}
+      isTitleMobileResponsive
       trailing={button}
       trailingPosition={TrailingPosition.end}
     />

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DrawerTooltip.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DrawerTooltip.tsx
@@ -1,0 +1,52 @@
+import React, { FunctionComponent } from 'react'
+import { Tooltip, createStyles, makeStyles } from '@material-ui/core'
+
+import helpIcon from '../../../../../app/assets/help-icon.svg'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    drawerTooltip: {
+      // margin: theme.spacing(1.5, 1, 1.5, 1),
+      whiteSpace: 'nowrap',
+      maxWidth: 'unset',
+      [theme.breakpoints.up('md')]: {
+        marginTop: '-12px',
+        padding: '16px',
+      },
+    },
+    ownershipHelpIcon: {
+      width: '14px',
+      verticalAlign: 'middle',
+    },
+  }),
+)
+
+type DrawerTooltipProps = {
+  title: string
+  imageAltText: string
+}
+
+const DrawerTooltip: FunctionComponent<DrawerTooltipProps> = ({
+  title,
+  imageAltText,
+}) => {
+  const classes = useStyles()
+
+  return (
+    <Tooltip
+      title={title}
+      arrow
+      placement="top"
+      classes={{ tooltip: classes.drawerTooltip }}
+    >
+      <img
+        className={classes.ownershipHelpIcon}
+        src={helpIcon}
+        alt={imageAltText}
+        draggable={false}
+      />
+    </Tooltip>
+  )
+}
+
+export default DrawerTooltip

--- a/src/client/user/components/Drawer/ControlPanel/widgets/DrawerTooltip.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/DrawerTooltip.tsx
@@ -6,7 +6,6 @@ import helpIcon from '../../../../../app/assets/help-icon.svg'
 const useStyles = makeStyles((theme) =>
   createStyles({
     drawerTooltip: {
-      // margin: theme.spacing(1.5, 1, 1.5, 1),
       whiteSpace: 'nowrap',
       maxWidth: 'unset',
       [theme.breakpoints.up('md')]: {

--- a/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
@@ -62,8 +62,6 @@ export default function FileEditor() {
   return (
     <ConfigOption
       title={replaceFileHelp}
-      titleVariant="body2"
-      titleClassName={classes.regularText}
       leading={
         <>
           <FileInputField

--- a/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react'
+import {
+  CircularProgress,
+  createStyles,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+import FileInputField from '../../../../widgets/FileInputField'
+import CollapsibleMessage from '../../../../../app/components/CollapsibleMessage'
+import {
+  CollapsibleMessagePosition,
+  CollapsibleMessageType,
+} from '../../../../../app/components/CollapsibleMessage/types'
+import TrailingButton from './TrailingButton'
+import ConfigOption, {
+  TrailingPosition,
+} from '../../../../widgets/ConfigOption'
+import DrawerTooltip from './DrawerTooltip'
+import useShortLink from '../util/shortlink'
+import { useDrawerState } from '../../index'
+import { removeHttpsProtocol } from '../../../../../app/util/url'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    fileInputField: {
+      marginBottom: theme.spacing(3),
+      [theme.breakpoints.up('md')]: {
+        marginBottom: 0,
+      },
+    },
+    regularText: {
+      fontWeight: 400,
+    },
+    originalFileLabel: {
+      marginBottom: theme.spacing(1),
+    },
+  }),
+)
+
+export default function FileEditor() {
+  const classes = useStyles()
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+  const drawerStates = useDrawerState()
+  const { shortLinkDispatch, shortLinkState, isUploading } = useShortLink(
+    drawerStates.relevantShortLink!,
+  )
+  const [uploadFileError, setUploadFileError] = useState<string | null>(null)
+  const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
+
+  const replaceFileHelp = (
+    <div className={classes.originalFileLabel}>
+      Original file{' '}
+      <DrawerTooltip
+        title="Original file will be replaced after you select file. Maximum file size is 10mb."
+        imageAltText="Replace file help"
+      />
+    </div>
+  )
+
+  return (
+    <ConfigOption
+      title={replaceFileHelp}
+      titleVariant="body2"
+      titleClassName={classes.regularText}
+      leading={
+        <>
+          <FileInputField
+            className={classes.fileInputField}
+            uploadFileError={uploadFileError}
+            textFieldHeight="44px"
+            inputId="replace-file-input"
+            text={originalLongUrl}
+            setFile={(newFile) => {
+              shortLinkDispatch?.replaceFile(newFile, setUploadFileError)
+            }}
+            setUploadFileError={setUploadFileError}
+          />
+          <CollapsibleMessage
+            type={CollapsibleMessageType.Error}
+            visible={!!uploadFileError}
+            position={CollapsibleMessagePosition.Absolute}
+          >
+            {uploadFileError}
+          </CollapsibleMessage>
+        </>
+      }
+      trailing={
+        <label htmlFor="replace-file-input">
+          <TrailingButton
+            onClick={() => {}}
+            disabled={isUploading}
+            variant={isMobileView ? 'contained' : 'outlined'}
+            fullWidth={isMobileView}
+            component="span"
+          >
+            {isUploading ? (
+              <CircularProgress color="primary" size={20} />
+            ) : (
+              'Replace file'
+            )}
+          </TrailingButton>
+        </label>
+      }
+      wrapTrailing={isMobileView}
+      trailingPosition={TrailingPosition.end}
+    />
+  )
+}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
@@ -1,0 +1,102 @@
+import React, { FunctionComponent, useState } from 'react'
+import {
+  Tooltip,
+  createStyles,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+
+import PrefixableTextField from '../../../../widgets/PrefixableTextField'
+import TrailingButton from './TrailingButton'
+import ConfigOption, {
+  TrailingPosition,
+} from '../../../../widgets/ConfigOption'
+import helpIcon from '../../../../../app/assets/help-icon.svg'
+import { useDrawerState } from '../../index'
+import useShortLink from '../util/shortlink'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    drawerTooltip: {
+      // margin: theme.spacing(1.5, 1, 1.5, 1),
+      whiteSpace: 'nowrap',
+      maxWidth: 'unset',
+      [theme.breakpoints.up('md')]: {
+        marginTop: '-12px',
+        padding: '16px',
+      },
+    },
+    ownershipHelpIcon: {
+      width: '14px',
+      verticalAlign: 'middle',
+    },
+    regularText: {
+      fontWeight: 400,
+    },
+  }),
+)
+
+type LinkOwnershipFieldProps = {
+  closeModal: () => void
+}
+
+const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({ closeModal }) =>  {
+  const classes = useStyles()
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+  const drawerStates = useDrawerState()
+  const { shortLinkDispatch } = useShortLink(drawerStates.relevantShortLink!)
+  const [pendingOwner, setPendingOwner] = useState<string>('')
+
+  const linkOwnershipHelp = (
+    <>
+      Link owner{' '}
+      <Tooltip
+        title="Links can only be transferred to an existing Go.gov.sg user"
+        arrow
+        placement="top"
+        classes={{ tooltip: classes.drawerTooltip }}
+      >
+        <img
+          className={classes.ownershipHelpIcon}
+          src={helpIcon}
+          alt="Ownership help"
+          draggable={false}
+        />
+      </Tooltip>
+    </>
+  )
+
+  return (
+    <ConfigOption
+      title={linkOwnershipHelp}
+      titleVariant="body2"
+      titleClassName={classes.regularText}
+      leading={
+        <PrefixableTextField
+          value={pendingOwner}
+          onChange={(event) => setPendingOwner(event.target.value)}
+          placeholder="Email of link recipient"
+          helperText={' '}
+        />
+      }
+      trailing={
+        <TrailingButton
+          onClick={() => {
+            shortLinkDispatch?.applyNewOwner(pendingOwner, closeModal)
+          }}
+          disabled={!pendingOwner}
+          variant={isMobileView ? 'contained' : 'outlined'}
+          fullWidth={isMobileView}
+        >
+          Transfer
+        </TrailingButton>
+      }
+      wrapTrailing={isMobileView}
+      trailingPosition={TrailingPosition.end}
+    />
+  )
+}
+
+export default LinkOwnershipField

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
@@ -1,7 +1,5 @@
 import React, { FunctionComponent, useState } from 'react'
 import {
-  createStyles,
-  makeStyles,
   useMediaQuery,
   useTheme,
 } from '@material-ui/core'
@@ -15,14 +13,6 @@ import DrawerTooltip from './DrawerTooltip'
 import PrefixableTextField from '../../../../widgets/PrefixableTextField'
 import TrailingButton from './TrailingButton'
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    regularText: {
-      fontWeight: 400,
-    },
-  }),
-)
-
 type LinkOwnershipFieldProps = {
   closeModal: () => void
 }
@@ -30,7 +20,6 @@ type LinkOwnershipFieldProps = {
 const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({
   closeModal,
 }) => {
-  const classes = useStyles()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const drawerStates = useDrawerState()
@@ -50,8 +39,6 @@ const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({
   return (
     <ConfigOption
       title={linkOwnershipHelp}
-      titleVariant="body2"
-      titleClassName={classes.regularText}
       leading={
         <PrefixableTextField
           value={pendingOwner}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkOwnershipField.tsx
@@ -1,36 +1,22 @@
 import React, { FunctionComponent, useState } from 'react'
 import {
-  Tooltip,
   createStyles,
   makeStyles,
   useMediaQuery,
   useTheme,
 } from '@material-ui/core'
 
-import PrefixableTextField from '../../../../widgets/PrefixableTextField'
-import TrailingButton from './TrailingButton'
 import ConfigOption, {
   TrailingPosition,
 } from '../../../../widgets/ConfigOption'
-import helpIcon from '../../../../../app/assets/help-icon.svg'
 import { useDrawerState } from '../../index'
 import useShortLink from '../util/shortlink'
+import DrawerTooltip from './DrawerTooltip'
+import PrefixableTextField from '../../../../widgets/PrefixableTextField'
+import TrailingButton from './TrailingButton'
 
-const useStyles = makeStyles((theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
-    drawerTooltip: {
-      // margin: theme.spacing(1.5, 1, 1.5, 1),
-      whiteSpace: 'nowrap',
-      maxWidth: 'unset',
-      [theme.breakpoints.up('md')]: {
-        marginTop: '-12px',
-        padding: '16px',
-      },
-    },
-    ownershipHelpIcon: {
-      width: '14px',
-      verticalAlign: 'middle',
-    },
     regularText: {
       fontWeight: 400,
     },
@@ -41,7 +27,9 @@ type LinkOwnershipFieldProps = {
   closeModal: () => void
 }
 
-const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({ closeModal }) =>  {
+const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({
+  closeModal,
+}) => {
   const classes = useStyles()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
@@ -52,19 +40,10 @@ const LinkOwnershipField: FunctionComponent<LinkOwnershipFieldProps> = ({ closeM
   const linkOwnershipHelp = (
     <>
       Link owner{' '}
-      <Tooltip
+      <DrawerTooltip
         title="Links can only be transferred to an existing Go.gov.sg user"
-        arrow
-        placement="top"
-        classes={{ tooltip: classes.drawerTooltip }}
-      >
-        <img
-          className={classes.ownershipHelpIcon}
-          src={helpIcon}
-          alt="Ownership help"
-          draggable={false}
-        />
-      </Tooltip>
+        imageAltText="Ownership help"
+      />
     </>
   )
 

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import {
+  createStyles,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+
+import { useDrawerState } from '../../index'
+import useShortLink from '../util/shortlink'
+import GoSwitch from '../../../../widgets/GoSwitch'
+import ConfigOption, {
+  TrailingPosition,
+} from '../../../../widgets/ConfigOption'
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    activeText: {
+      color: '#6d9067',
+    },
+    inactiveText: {
+      color: '#c85151',
+    },
+    regularText: {
+      fontWeight: 400,
+    },
+    stateSwitch: {
+      marginBottom: theme.spacing(2),
+    },
+  }),
+)
+
+export default function LinkStateText() {
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+  const classes = useStyles()
+  const drawerStates = useDrawerState()
+
+  // Fetch short link state and dispatches from redux store through our helper hook.
+  const { shortLinkState, shortLinkDispatch } = useShortLink(
+    drawerStates.relevantShortLink!,
+  )
+
+  const stateTitleActive = (
+    <>
+      Your link is <span className={classes.activeText}>active</span> and
+      publicly accessible
+    </>
+  )
+
+  const stateTitleInactive = (
+    <>
+      Your link is <span className={classes.inactiveText}>inactive</span> and
+      not publicly accessible
+    </>
+  )
+
+  return (
+    <ConfigOption
+      title={
+        shortLinkState?.state === 'ACTIVE'
+          ? stateTitleActive
+          : stateTitleInactive
+      }
+      titleVariant="h6"
+      titleClassName={isMobileView ? classes.regularText : ''}
+      trailing={
+        <GoSwitch
+          color="primary"
+          checked={shortLinkState?.state === 'ACTIVE'}
+          onChange={shortLinkDispatch?.toggleStatus}
+          className={classes.stateSwitch}
+        />
+      }
+      trailingPosition={TrailingPosition.center}
+    />
+  )
+}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import {
   createStyles,
   makeStyles,
-  useMediaQuery,
-  useTheme,
 } from '@material-ui/core'
 
 import { useDrawerState } from '../../index'
@@ -21,9 +19,6 @@ const useStyles = makeStyles((theme) =>
     inactiveText: {
       color: '#c85151',
     },
-    regularText: {
-      fontWeight: 400,
-    },
     stateSwitch: {
       marginBottom: theme.spacing(2),
     },
@@ -31,8 +26,6 @@ const useStyles = makeStyles((theme) =>
 )
 
 export default function LinkStateText() {
-  const theme = useTheme()
-  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const classes = useStyles()
   const drawerStates = useDrawerState()
 
@@ -62,8 +55,7 @@ export default function LinkStateText() {
           ? stateTitleActive
           : stateTitleInactive
       }
-      titleVariant="h6"
-      titleClassName={isMobileView ? classes.regularText : ''}
+      isTitleMobileResponsive
       trailing={
         <GoSwitch
           color="primary"

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkStateText.tsx
@@ -55,7 +55,7 @@ export default function LinkStateText() {
           ? stateTitleActive
           : stateTitleInactive
       }
-      isTitleMobileResponsive
+      mobile
       trailing={
         <GoSwitch
           color="primary"

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import {
+  createStyles,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+
+import useShortLink from '../util/shortlink'
+import { removeHttpsProtocol } from '../../../../../app/util/url'
+import { useDrawerState } from '../../index'
+import { isValidLongUrl } from '../../../../../../shared/util/validation'
+import ConfigOption, {
+  TrailingPosition,
+} from '../../../../widgets/ConfigOption'
+import PrefixableTextField from '../../../../widgets/PrefixableTextField'
+import TrailingButton from './TrailingButton'
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    regularText: {
+      fontWeight: 400,
+    },
+  }),
+)
+
+export default function LongUrlEditor() {
+  const classes = useStyles()
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+  const drawerStates = useDrawerState()
+  const { shortLinkState, shortLinkDispatch } = useShortLink(
+    drawerStates.relevantShortLink!,
+  )
+  const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
+  const editedLongUrl = shortLinkState?.editedLongUrl || ''
+
+  return (
+    <ConfigOption
+      title="Original link"
+      titleVariant="body2"
+      titleClassName={classes.regularText}
+      leading={
+        <PrefixableTextField
+          value={editedLongUrl}
+          onChange={(event) =>
+            shortLinkDispatch?.setEditLongUrl(event.target.value)
+          }
+          placeholder="Original link"
+          prefix="https://"
+          error={!isValidLongUrl(editedLongUrl, true)}
+          helperText={
+            isValidLongUrl(editedLongUrl, true)
+              ? ' '
+              : "This doesn't look like a valid url."
+          }
+        />
+      }
+      trailing={
+        <TrailingButton
+          disabled={
+            !isValidLongUrl(editedLongUrl, false) ||
+            editedLongUrl === originalLongUrl
+          }
+          onClick={() => shortLinkDispatch?.applyEditLongUrl(editedLongUrl)}
+          fullWidth={isMobileView}
+          variant={isMobileView ? 'contained' : 'outlined'}
+        >
+          Save
+        </TrailingButton>
+      }
+      wrapTrailing={isMobileView}
+      trailingPosition={TrailingPosition.end}
+    />
+  )
+}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 import {
-  createStyles,
-  makeStyles,
   useMediaQuery,
   useTheme,
 } from '@material-ui/core'
@@ -16,16 +14,7 @@ import ConfigOption, {
 import PrefixableTextField from '../../../../widgets/PrefixableTextField'
 import TrailingButton from './TrailingButton'
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    regularText: {
-      fontWeight: 400,
-    },
-  }),
-)
-
 export default function LongUrlEditor() {
-  const classes = useStyles()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const drawerStates = useDrawerState()
@@ -38,8 +27,6 @@ export default function LongUrlEditor() {
   return (
     <ConfigOption
       title="Original link"
-      titleVariant="body2"
-      titleClassName={classes.regularText}
       leading={
         <PrefixableTextField
           value={editedLongUrl}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   createStyles,
   makeStyles,
@@ -33,7 +33,7 @@ export default function LongUrlEditor() {
     drawerStates.relevantShortLink!,
   )
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
-  const editedLongUrl = shortLinkState?.editedLongUrl || ''
+  const [editedLongUrl, setEditedLongUrl] = useState<string>(originalLongUrl)
 
   return (
     <ConfigOption
@@ -43,9 +43,7 @@ export default function LongUrlEditor() {
       leading={
         <PrefixableTextField
           value={editedLongUrl}
-          onChange={(event) =>
-            shortLinkDispatch?.setEditLongUrl(event.target.value)
-          }
+          onChange={(event) => setEditedLongUrl(event.target.value)}
           placeholder="Original link"
           prefix="https://"
           error={!isValidLongUrl(editedLongUrl, true)}

--- a/src/client/user/widgets/ConfigOption.tsx
+++ b/src/client/user/widgets/ConfigOption.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) =>
 
 type ConfigOptionProps = {
   title: string | React.ReactNode
-  isTitleMobileResponsive?: boolean
+  mobile?: boolean
   subtitle?: string
   leading?: React.ReactNode
   trailing: React.ReactNode
@@ -68,7 +68,7 @@ type ConfigOptionProps = {
 // Represents an edit option on the ControlPanel.
 export default function ConfigOption({
   title,
-  isTitleMobileResponsive = false,
+  mobile = false,
   subtitle,
   leading,
   trailing,
@@ -81,9 +81,9 @@ export default function ConfigOption({
   })
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
-  const titleVariant = isTitleMobileResponsive ? 'h6' : 'body2'
+  const titleVariant = mobile ? 'h6' : 'body2'
   let titleClass = classes.regularText
-  if (isTitleMobileResponsive && !isMobileView) titleClass = ''
+  if (mobile && !isMobileView) titleClass = ''
   return (
     <main className={classes.mainContainer}>
       <section className={classes.leadingContainer}>

--- a/src/client/user/widgets/ConfigOption.tsx
+++ b/src/client/user/widgets/ConfigOption.tsx
@@ -1,6 +1,18 @@
 import * as React from 'react'
-import { Typography, createStyles, makeStyles } from '@material-ui/core'
-import { Variant } from '@material-ui/core/styles/createTypography'
+import {
+  Typography,
+  createStyles,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+
+export enum TrailingPosition {
+  start,
+  center,
+  end,
+  none,
+}
 
 type StylesProps = {
   trailingPosition: TrailingPosition
@@ -32,55 +44,60 @@ const useStyles = makeStyles((theme) =>
     },
     trailingContainer: {
       marginTop: (props: StylesProps) =>
-        props.trailingPosition == TrailingPosition.end ? 'auto' : 'unset',
+        props.trailingPosition === TrailingPosition.end ? 'auto' : 'unset',
       marginBottom: (props: StylesProps) =>
-        props.trailingPosition == TrailingPosition.start ? 'auto' : 'unset',
+        props.trailingPosition === TrailingPosition.start ? 'auto' : 'unset',
       width: (props: StylesProps) => (props.wrapTrailing ? '100%' : 'unset'),
+    },
+    regularText: {
+      fontWeight: 400,
     },
   }),
 )
 
-export enum TrailingPosition {
-  start,
-  center,
-  end,
-  none,
-}
-
 type ConfigOptionProps = {
   title: string | React.ReactNode
+  isTitleMobileResponsive?: boolean
   subtitle?: string
   leading?: React.ReactNode
   trailing: React.ReactNode
   trailingPosition: TrailingPosition
-  titleVariant: Variant
-  titleClassName?: string
   wrapTrailing?: boolean
 }
 
 // Represents an edit option on the ControlPanel.
-export default function ConfigOption(props: ConfigOptionProps) {
+export default function ConfigOption({
+  title,
+  isTitleMobileResponsive = false,
+  subtitle,
+  leading,
+  trailing,
+  trailingPosition,
+  wrapTrailing,
+}: ConfigOptionProps) {
   const classes = useStyles({
-    trailingPosition: props.trailingPosition,
-    wrapTrailing: props.wrapTrailing,
+    trailingPosition,
+    wrapTrailing,
   })
+  const theme = useTheme()
+  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
+  const titleVariant = isTitleMobileResponsive ? 'h6' : 'body2'
+  let titleClass = classes.regularText
+  if (isTitleMobileResponsive && !isMobileView) titleClass = ''
   return (
     <main className={classes.mainContainer}>
       <section className={classes.leadingContainer}>
-        <Typography
-          variant={props.titleVariant}
-          className={props.titleClassName}
-        >
-          {props.title}
+        <Typography variant={titleVariant} className={titleClass}>
+          {title}
         </Typography>
-        {props.subtitle && (
+        {subtitle && (
           <Typography variant="body1" color="textSecondary">
-            {props.subtitle}
+            {subtitle}
           </Typography>
         )}
-        {props.leading}
+        {leading}
       </section>
-      <section className={classes.trailingContainer}>{props.trailing}</section>
+      <section className={classes.trailingContainer}>{trailing}</section>
     </main>
   )
 }

--- a/src/client/user/widgets/ConfigOption.tsx
+++ b/src/client/user/widgets/ConfigOption.tsx
@@ -82,8 +82,7 @@ export default function ConfigOption({
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const titleVariant = mobile ? 'h6' : 'body2'
-  let titleClass = classes.regularText
-  if (mobile && !isMobileView) titleClass = ''
+  const titleClass = mobile && !isMobileView ? '' : classes.regularText
   return (
     <main className={classes.mainContainer}>
       <section className={classes.leadingContainer}>

--- a/src/client/user/widgets/LinkInfoEditor.tsx
+++ b/src/client/user/widgets/LinkInfoEditor.tsx
@@ -160,8 +160,6 @@ export default function LinkInfoEditor({
       </Typography>
       <ConfigOption
         title={contactEmailHelp}
-        titleVariant="body2"
-        titleClassName={classes.regularText}
         leading={
           <PrefixableTextField
             value={contactEmail}
@@ -183,8 +181,6 @@ export default function LinkInfoEditor({
       />
       <ConfigOption
         title={linkDescriptionHelp}
-        titleVariant="body2"
-        titleClassName={classes.regularText}
         leading={
           <>
             <PrefixableTextField


### PR DESCRIPTION
## Problem

Drawer domain was implemented and migrated in a way that unnecessarily exposed a lot of implementation. There was a lot of code reimplementation that could have been abstracted for reuse.

Partially fixes #970

## Solution

**Improvements**:

- Extract LinkStateText, LinkOwnershipField, LongUrlEditor, FileEditor into their own components.

- Move ConfigOption into DownloadButton's implementation

- Enable reuse of regularText CSS by moving it into ConfigOption

- Move state management into the smallest component subset, which fixed bug #970 


