### PR TITLE
refactor(user): use interface for controller ctor arg again

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,10 +186,10 @@
   },
   "lint-staged": {
     "**/*.(js|jsx)": [
-      "eslint --ext .js,.jsx --no-eslintrc -c .eslintrc.json --fix"
+      "eslint --ext .js,.jsx --no-eslintrc -c .eslintrc.js.json --fix"
     ],
-    "**/*.ts": [
-      "eslint --ext .ts --no-eslintrc -c .eslintrc.ts.json --fix"
+    "**/*.(ts|tsx)": [
+      "eslint --ext .ts,.tsx --no-eslintrc -c .eslintrc.json --fix"
     ]
   },
   "config": {

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -3,7 +3,6 @@ import { inject, injectable } from 'inversify'
 
 import { OwnershipTransferRequest, UrlCreationRequest, UrlEditRequest } from '.'
 import jsonMessage from '../../util/json'
-import { UrlManagementService } from './services'
 import { DependencyIds } from '../../constants'
 import {
   AlreadyExistsError,
@@ -14,8 +13,9 @@ import { MessageType } from '../../../shared/util/messages'
 import { StorableUrlState } from '../../repositories/enums'
 
 import { logger } from '../../config'
+import { UrlManagementService } from './interfaces/UrlManagementService'
 
-interface AnnouncementResponse {
+type AnnouncementResponse = {
   message?: string
   title?: string
   subtitle?: string

--- a/src/server/modules/user/__tests__/UserController.test.ts
+++ b/src/server/modules/user/__tests__/UserController.test.ts
@@ -22,7 +22,6 @@ const userAnnouncement = {
 
 describe('UserController', () => {
   const controller = new UserController(
-    // @ts-ignore - no need for private properties in UrlManagementService
     urlManagementService,
     userMessage,
     userAnnouncement,

--- a/src/server/modules/user/interfaces/UrlManagementService.ts
+++ b/src/server/modules/user/interfaces/UrlManagementService.ts
@@ -1,0 +1,30 @@
+import {
+  StorableUrl,
+  UrlsPaginated,
+  UserUrlsQueryConditions,
+} from '../../../repositories/types'
+import { GoUploadedFile, UpdateUrlOptions } from '..'
+
+export interface UrlManagementService {
+  createUrl: (
+    userId: number,
+    shortUrl: string,
+    longUrl?: string,
+    file?: GoUploadedFile,
+  ) => Promise<StorableUrl>
+  updateUrl: (
+    userId: number,
+    shortUrl: string,
+    options: UpdateUrlOptions,
+  ) => Promise<StorableUrl>
+  changeOwnership: (
+    userId: number,
+    shortUrl: string,
+    newUserEmail: string,
+  ) => Promise<StorableUrl>
+  getUrlsWithConditions: (
+    conditions: UserUrlsQueryConditions,
+  ) => Promise<UrlsPaginated>
+}
+
+export default UrlManagementService

--- a/src/server/modules/user/interfaces/index.ts
+++ b/src/server/modules/user/interfaces/index.ts
@@ -1,0 +1,3 @@
+export { UrlManagementService } from './UrlManagementService'
+
+export default {}

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -15,9 +15,10 @@ import { UrlRepositoryInterface } from '../../../repositories/interfaces/UrlRepo
 import { addFileExtension, getFileExtension } from '../../../util/fileFormat'
 import { GoUploadedFile, UpdateUrlOptions } from '..'
 import { DependencyIds } from '../../../constants'
+import * as interfaces from '../interfaces'
 
 @injectable()
-export class UrlManagementService {
+export class UrlManagementService implements interfaces.UrlManagementService {
   private userRepository: UserRepositoryInterface
 
   private urlRepository: UrlRepositoryInterface


### PR DESCRIPTION
## Problem

Ongoing work for #869 

## Solution
Use an interface for the ctor argument that usually receives
the UrlManagementService. This allows us to helpfully locate
impls for the argument type using the IDE.

- Create a new interfaces dir with UrlManagementService in it
- Take care with naming to minimise confusion while still keeping
  names consistent and clear, despite using identical names for
  both interface and impl

Take the trouble also to correct the linting config for the pre-commit hook