### PR TITLE
Mirror URL table's click column

### DIFF
--- a/src/server/db_migrations/20201207_synchronise_url_clicks.sql
+++ b/src/server/db_migrations/20201207_synchronise_url_clicks.sql
@@ -1,0 +1,38 @@
+-- This SQL file is used to populate the url_clicks table with data from the
+-- url_table, and also add the necessary hooks such that they will always be
+-- in sync. These include 1) when a url_table row's click is changed, and
+-- 2) when a new url_table row is created.
+BEGIN TRANSACTION;
+
+INSERT INTO "url_clicks" ("shortUrl", "clicks", "createdAt", "updatedAt")
+SELECT "shortUrl", "clicks", "createdAt", "updatedAt" from urls;
+
+CREATE OR REPLACE FUNCTION update_clicks()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE url_clicks
+    SET "clicks" = NEW."clicks"
+    WHERE url_clicks."shortUrl" = NEW."shortUrl";
+    RETURN NEW;
+END; $$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER url_table_click_incremented
+    AFTER UPDATE of "clicks" on urls
+    FOR EACH ROW
+    WHEN (OLD."clicks" <> NEW."clicks")
+    EXECUTE PROCEDURE update_clicks();
+
+CREATE OR REPLACE FUNCTION create_clicks()
+    RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO url_clicks ("shortUrl", "clicks", "createdAt", "updatedAt")
+    VALUES (NEW."shortUrl", NEW."clicks", NEW."createdAt", NEW."updatedAt");
+    RETURN NEW;
+END; $$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER url_created
+    AFTER INSERT on urls
+    FOR EACH ROW
+    EXECUTE PROCEDURE create_clicks();
+
+COMMIT;

--- a/src/server/db_migrations/20201207_synchronise_url_clicks.sql
+++ b/src/server/db_migrations/20201207_synchronise_url_clicks.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION update_clicks()
 RETURNS TRIGGER AS $$
 BEGIN
     UPDATE url_clicks
-    SET "clicks" = NEW."clicks"
+    SET "clicks" = NEW."clicks", "updatedAt" = current_timestamp
     WHERE url_clicks."shortUrl" = NEW."shortUrl";
     RETURN NEW;
 END; $$ LANGUAGE PLPGSQL;

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -1,7 +1,7 @@
 import { sequelize } from '../util/sequelize'
 import { Url, UrlHistory } from './url'
 import { User } from './user'
-import { Clicks } from './statistics/daily'
+import { DailyClicks } from './statistics/daily'
 import { WeekdayClicks } from './statistics/weekday'
 import { Devices } from './statistics/devices'
 import { syncFunctions } from './functions'
@@ -15,10 +15,10 @@ User.hasMany(UrlHistory, { foreignKey: { allowNull: false } })
 UrlHistory.belongsTo(User, { foreignKey: { allowNull: false } })
 
 // A Url record can have various rows of relevant statistics.
-Url.hasMany(Clicks, { foreignKey: 'shortUrl', as: 'DailyClicks' })
+Url.hasMany(DailyClicks, { foreignKey: 'shortUrl', as: 'DailyClicks' })
 Url.hasMany(WeekdayClicks, { foreignKey: 'shortUrl', as: 'WeekdayClicks' })
 Url.hasOne(Devices, { foreignKey: 'shortUrl', as: 'DeviceClicks' })
-Clicks.belongsTo(Url, { foreignKey: 'shortUrl' })
+DailyClicks.belongsTo(Url, { foreignKey: 'shortUrl' })
 WeekdayClicks.belongsTo(Url, { foreignKey: 'shortUrl' })
 Devices.belongsTo(Url, { foreignKey: 'shortUrl' })
 

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -4,6 +4,7 @@ import { User } from './user'
 import { DailyClicks } from './statistics/daily'
 import { WeekdayClicks } from './statistics/weekday'
 import { Devices } from './statistics/devices'
+import { UrlClicks } from './statistics/clicks'
 import { syncFunctions } from './functions'
 
 // One user can create many urls but each url can only be mapped to one user.
@@ -18,9 +19,11 @@ UrlHistory.belongsTo(User, { foreignKey: { allowNull: false } })
 Url.hasMany(DailyClicks, { foreignKey: 'shortUrl', as: 'DailyClicks' })
 Url.hasMany(WeekdayClicks, { foreignKey: 'shortUrl', as: 'WeekdayClicks' })
 Url.hasOne(Devices, { foreignKey: 'shortUrl', as: 'DeviceClicks' })
+Url.hasOne(UrlClicks, { foreignKey: 'shortUrl', as: 'UrlClicks' })
 DailyClicks.belongsTo(Url, { foreignKey: 'shortUrl' })
 WeekdayClicks.belongsTo(Url, { foreignKey: 'shortUrl' })
 Devices.belongsTo(Url, { foreignKey: 'shortUrl' })
+UrlClicks.belongsTo(Url, { foreignKey: 'shortUrl' })
 
 /**
  * Initialise the database table.

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -25,5 +25,6 @@ export const UrlClicks = <UrlClicksTypeStatic>sequelize.define('url_clicks', {
   clicks: {
     type: Sequelize.INTEGER,
     defaultValue: 0,
+    allowNull: false,
   },
 })

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -1,0 +1,29 @@
+import Sequelize from 'sequelize'
+
+import { sequelize } from '../../util/sequelize'
+import { IdType } from '../../../types/server/models'
+
+export interface UrlClicksType extends IdType, Sequelize.Model {
+  readonly shortUrl: string
+  readonly clicks: number
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+type UrlClicksTypeStatic = typeof Sequelize.Model & {
+  new (values?: object, options?: Sequelize.BuildOptions): UrlClicksType
+}
+
+export const UrlClicks = <UrlClicksTypeStatic>sequelize.define('url_clicks', {
+  shortUrl: {
+    type: Sequelize.STRING,
+    primaryKey: true,
+    validate: {
+      is: /^[a-z0-9-]+$/,
+    },
+  },
+  clicks: {
+    type: Sequelize.INTEGER,
+    defaultValue: 0,
+  },
+})

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize'
 
 import { sequelize } from '../../util/sequelize'
 import { IdType } from '../../../types/server/models'
+import { SHORT_URL_REGEX } from '../../../shared/util/validation'
 
 export interface UrlClicksType extends IdType, Sequelize.Model {
   readonly shortUrl: string
@@ -19,7 +20,7 @@ export const UrlClicks = <UrlClicksTypeStatic>sequelize.define('url_clicks', {
     type: Sequelize.STRING,
     primaryKey: true,
     validate: {
-      is: /^[a-z0-9-]+$/,
+      is: SHORT_URL_REGEX,
     },
   },
   clicks: {

--- a/src/server/models/statistics/daily.ts
+++ b/src/server/models/statistics/daily.ts
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize'
 
 import { sequelize } from '../../util/sequelize'
 import { IdType } from '../../../types/server/models'
+import { SHORT_URL_REGEX } from '../../../shared/util/validation'
 
 export interface DailyClicksType extends IdType, Sequelize.Model {
   readonly shortUrl: string
@@ -22,7 +23,7 @@ export const DailyClicks = <DailyClicksTypeStatic>sequelize.define(
       type: Sequelize.STRING,
       primaryKey: true,
       validate: {
-        is: /^[a-z0-9-]+$/,
+        is: SHORT_URL_REGEX,
       },
     },
     date: {

--- a/src/server/models/statistics/daily.ts
+++ b/src/server/models/statistics/daily.ts
@@ -3,7 +3,7 @@ import Sequelize from 'sequelize'
 import { sequelize } from '../../util/sequelize'
 import { IdType } from '../../../types/server/models'
 
-export interface ClicksType extends IdType, Sequelize.Model {
+export interface DailyClicksType extends IdType, Sequelize.Model {
   readonly shortUrl: string
   readonly date: string
   readonly clicks: number
@@ -11,24 +11,27 @@ export interface ClicksType extends IdType, Sequelize.Model {
   readonly updatedAt: string
 }
 
-type ClicksTypeStatic = typeof Sequelize.Model & {
-  new (values?: object, options?: Sequelize.BuildOptions): ClicksType
+type DailyClicksTypeStatic = typeof Sequelize.Model & {
+  new (values?: object, options?: Sequelize.BuildOptions): DailyClicksType
 }
 
-export const Clicks = <ClicksTypeStatic>sequelize.define('daily_stats', {
-  shortUrl: {
-    type: Sequelize.STRING,
-    primaryKey: true,
-    validate: {
-      is: /^[a-z0-9-]+$/,
+export const DailyClicks = <DailyClicksTypeStatic>sequelize.define(
+  'daily_stats',
+  {
+    shortUrl: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+      validate: {
+        is: /^[a-z0-9-]+$/,
+      },
+    },
+    date: {
+      type: Sequelize.DATEONLY,
+      primaryKey: true,
+    },
+    clicks: {
+      type: Sequelize.INTEGER,
+      defaultValue: 0,
     },
   },
-  date: {
-    type: Sequelize.DATEONLY,
-    primaryKey: true,
-  },
-  clicks: {
-    type: Sequelize.INTEGER,
-    defaultValue: 0,
-  },
-})
+)

--- a/src/server/models/statistics/devices.ts
+++ b/src/server/models/statistics/devices.ts
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize'
 
 import { sequelize } from '../../util/sequelize'
 import { IdType } from '../../../types/server/models'
+import { SHORT_URL_REGEX } from '../../../shared/util/validation'
 
 export interface DevicesType extends IdType, Sequelize.Model {
   readonly shortUrl: string
@@ -22,7 +23,7 @@ export const Devices = <DevicesTypeStatic>sequelize.define('devices_stats', {
     type: Sequelize.STRING,
     primaryKey: true,
     validate: {
-      is: /^[a-z0-9-]+$/,
+      is: SHORT_URL_REGEX,
     },
   },
   mobile: {

--- a/src/server/models/statistics/weekday.ts
+++ b/src/server/models/statistics/weekday.ts
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize'
 
 import { sequelize } from '../../util/sequelize'
 import { IdType } from '../../../types/server/models'
+import { SHORT_URL_REGEX } from '../../../shared/util/validation'
 
 export interface WeekdayClicksType extends IdType, Sequelize.Model {
   readonly shortUrl: string
@@ -23,7 +24,7 @@ export const WeekdayClicks = <WeekdayClicksTypeStatic>sequelize.define(
       type: Sequelize.STRING,
       primaryKey: true,
       validate: {
-        is: /^[a-z0-9-]+$/,
+        is: SHORT_URL_REGEX,
       },
     },
     weekday: {

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -1,6 +1,7 @@
 import Sequelize from 'sequelize'
 import { ACTIVE, INACTIVE } from './types'
 import {
+  SHORT_URL_REGEX,
   isBlacklisted,
   isCircularRedirects,
   isHttps,
@@ -114,7 +115,7 @@ export const Url = <UrlTypeStatic>sequelize.define(
       type: Sequelize.STRING,
       primaryKey: true,
       validate: {
-        is: /^[a-z0-9-]+$/,
+        is: SHORT_URL_REGEX,
       },
     },
     longUrl: {

--- a/src/server/repositories/LinkStatisticsRepository.ts
+++ b/src/server/repositories/LinkStatisticsRepository.ts
@@ -3,7 +3,7 @@ import { Op, QueryTypes } from 'sequelize'
 import _ from 'lodash'
 
 import { Url, UrlType } from '../models/url'
-import { Clicks, ClicksType } from '../models/statistics/daily'
+import { DailyClicks, DailyClicksType } from '../models/statistics/daily'
 import { Devices, DevicesType } from '../models/statistics/devices'
 import { WeekdayClicks, WeekdayClicksType } from '../models/statistics/weekday'
 import { LinkStatisticsInterface } from '../../shared/interfaces/link-statistics'
@@ -15,7 +15,7 @@ import { DeviceType } from '../services/interfaces/DeviceCheckServiceInterface'
 // Get the relevant table names from their models.
 const urlTable = Url.getTableName()
 const devicesTable = Devices.getTableName()
-const clicksTable = Clicks.getTableName()
+const clicksTable = DailyClicks.getTableName()
 const weekdayTable = WeekdayClicks.getTableName()
 const timeZone = 'Asia/Singapore'
 
@@ -66,7 +66,7 @@ END; $$ LANGUAGE plpgsql;
 export type UrlStats = UrlType & {
   Url: UrlType
   DeviceClicks?: DevicesType
-  DailyClicks: ClicksType[]
+  DailyClicks: DailyClicksType[]
   WeekdayClicks: WeekdayClicksType[]
 }
 
@@ -81,7 +81,7 @@ export class LinkStatisticsRepository
       include: [
         { model: Devices, as: 'DeviceClicks' },
         {
-          model: Clicks,
+          model: DailyClicks,
           as: 'DailyClicks',
           where: {
             date: {
@@ -98,7 +98,7 @@ export class LinkStatisticsRepository
         },
       ],
       order: [
-        [{ model: Clicks, as: 'DailyClicks' }, 'date', 'ASC'],
+        [{ model: DailyClicks, as: 'DailyClicks' }, 'date', 'ASC'],
         [{ model: WeekdayClicks, as: 'WeekdayClicks' }, 'weekday', 'ASC'],
         [{ model: WeekdayClicks, as: 'WeekdayClicks' }, 'hours', 'ASC'],
       ],

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -5,6 +5,8 @@ import blacklist from '../../server/resources/blacklist'
 
 export const WHITELIST = [new RegExp('^http://localhost:4566')]
 
+export const SHORT_URL_REGEX = /^[a-z0-9-]+$/
+
 export const URL_OPTS: validator.IsURLOptions = {
   protocols: ['https'],
   require_tld: true,
@@ -41,7 +43,7 @@ export function isValidUrl(url: string, useWhitelist = false): boolean {
 
 // Tests if a short link consists of alphanumeric and hyphen characters.
 export function isValidShortUrl(url: string, allowBlank = false): boolean {
-  return allowBlank ? /^[a-z0-9-]*$/.test(url) : /^[a-z0-9-]+$/.test(url)
+  return allowBlank ? /^[a-z0-9-]*$/.test(url) : SHORT_URL_REGEX.test(url)
 }
 
 // Tests the validity of a long url. Will return true if blank.

--- a/test/server/api/setup.ts
+++ b/test/server/api/setup.ts
@@ -87,7 +87,7 @@ jest.mock('../../../src/server/models/url', () => ({
 
 // Necessary mock for app to work
 jest.mock('../../../src/server/models/statistics/daily', () => ({
-  Clicks: clicksModelMock,
+  DailyClicks: clicksModelMock,
 }))
 
 // Necessary mock for app to work

--- a/test/server/repositories/LinkStatisticsRepository.test.ts
+++ b/test/server/repositories/LinkStatisticsRepository.test.ts
@@ -17,7 +17,7 @@ jest.mock('../../../src/server/models/statistics/devices', () => ({
   Devices: { getTableName: () => 'devices' },
 }))
 jest.mock('../../../src/server/models/statistics/daily', () => ({
-  Clicks: { getTableName: () => 'daily' },
+  DailyClicks: { getTableName: () => 'daily' },
 }))
 jest.mock('../../../src/server/models/statistics/weekday', () => ({
   WeekdayClicks: { getTableName: () => 'weekday' },


### PR DESCRIPTION
## Problem

As we are moving forward with features that require bulk database operations, we want to move click count (a frequently updated field) in the URL table.

This is because updating the click count atomically requires a row lock, and it is unlikely that bulk operations will be able to acquire the necessary locks to proceed if a link is being visited constantly.

Part 1 of #984 

## Solution

Visit our [wiki page](https://github.com/opengovsg/GoGovSG/wiki/URL-Click-Column-DB-Migration) for in-depth discussion of solution.

Proposed migration approach involves multiple phases.

1) Deploy this PR that will let sequelize create a new `url_clicks` table.

2) Run the migration script in this PR that will populate the `url_clicks` table, as well as create the necessary hooks to keep them always in sync.

3) Deploy a separate PR that changes application code to do read/writes to `url_clicks` table.

4) Run a migration script to remove hooks and `url` table's click column.

**Side effects of PR**:

- Original `Clicks` model renamed to `DailyClicks`.

## Deploy Notes

Deploy code first to let sequelize create the tables before running migration script.

**New scripts**:

- `20201207_synchronise_url_clicks.sql` : Copies click count into url_clicks table, and adds DB hooks to keep it in sync.
