### PR TITLE
refactor(route): allow all private route to redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,10 +186,10 @@
   },
   "lint-staged": {
     "**/*.(js|jsx)": [
-      "eslint --ext .js,.jsx --no-eslintrc -c .eslintrc.json --fix"
+      "eslint --ext .js,.jsx --no-eslintrc -c .eslintrc.js.json --fix"
     ],
-    "**/*.ts": [
-      "eslint --ext .ts --no-eslintrc -c .eslintrc.ts.json --fix"
+    "**/*.(ts|tsx)": [
+      "eslint --ext .ts,.tsx --no-eslintrc -c .eslintrc.json --fix"
     ]
   },
   "config": {

--- a/src/client/directory/index.tsx
+++ b/src/client/directory/index.tsx
@@ -15,6 +15,7 @@ import DirectoryHeader from './components/DirectoryHeader'
 import DirectoryResults from './components/DirectoryResults'
 import EmptyStateGraphic from './components/EmptySearchGraphic'
 import { defaultSortOption } from './constants'
+import { GAEvent, GAPageView } from '../app/util/ga'
 
 type GoSearchParams = {
   query: string
@@ -181,6 +182,11 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
       )
     }
   }
+  // Google Analytics
+  useEffect(() => {
+    GAEvent('directory page', 'main')
+    GAPageView('DIRECTORY PAGE')
+  }, [])
 
   // Changes when queryEmail changes
   useEffect(() => {

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -14,12 +14,7 @@ import { Redirect } from 'react-router-dom'
 import { GoGovReduxState } from '../app/reducers/types'
 import loginActions from './actions'
 import rootActions from '../app/components/pages/RootPage/actions'
-import {
-  DIRECTORY_PAGE,
-  USER_PAGE,
-  VariantType,
-  loginFormVariants,
-} from '../app/util/types'
+import { USER_PAGE, VariantType, loginFormVariants } from '../app/util/types'
 import GoLogo from '../app/assets/go-logo-graphics/go-main-logo.svg'
 import LoginGraphics from '../app/assets/login-page-graphics/login-page-graphics.svg'
 import { get } from '../app/util/requests'
@@ -113,7 +108,7 @@ const useStyles = makeStyles((theme) =>
 )
 
 const LoginPage: FunctionComponent<LoginPageProps> = ({
-  location,
+  location = undefined,
 }: LoginPageProps) => {
   const classes = useStyles()
   const dispatch = useDispatch()
@@ -135,9 +130,8 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   )
   // Google Analytics
   useEffect(() => {
-    // Filter out redirects from directory page
-    // TODO (#988): Can this be fixed to cater to all routes?
-    if (location?.state?.previous !== '/directory') {
+    // Filter out redirects from private routes
+    if (!location?.state?.previous) {
       GAPageView('EMAIL LOGIN PAGE')
       GAEvent('login page', 'email')
     }
@@ -280,22 +274,13 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
   }
 
   if (location) {
-    // ensure redirection back to directory and reset the state
-    if (location?.state?.previous === '/directory') {
-      // reason why we record directory here is because going into directory page will always go into login page first
-      // before going into directory page
-      GAEvent('directory page', 'main')
-      GAPageView('DIRECTORY PAGE')
-      return <Redirect to={{ pathname: DIRECTORY_PAGE, state: {} }} />
+    // ensure page re-directed back to intended private route and reset the state
+    if (location?.state?.previous) {
+      return <Redirect to={{ pathname: location.state.previous, state: {} }} />
     }
-
     return <Redirect to={{ pathname: USER_PAGE, state: { from: location } }} />
   }
   return <Redirect to={{ pathname: USER_PAGE }} />
-}
-
-LoginPage.defaultProps = {
-  location: undefined,
 }
 
 export default LoginPage


### PR DESCRIPTION
## Problem

Currently, all private page routes (user and directory) will be directed to login page before redirecting back to the private page, on refresh. Directory page's redirect is coded as an edge case which can be generalised to allow redirect from all private routes

Closes #988 

## Solution

- Remove directory previous location check and enable all private route 

### Refactors
- Move GA recording for directory to directory page
- Change login defaultprops to typescript default value

