### PR TITLE
fix: directory toggle ui

### DIFF
--- a/src/client/directory/components/DirectoryHeader/DirectoryInput/index.tsx
+++ b/src/client/directory/components/DirectoryHeader/DirectoryInput/index.tsx
@@ -114,7 +114,7 @@ const useStyles = makeStyles((theme) =>
     },
     buttonWrapper: {
       width: 'auto',
-      display: 'inline-block',
+      display: 'box',
       [theme.breakpoints.down('sm')]: {
         display: 'inline-flex',
       },


### PR DESCRIPTION
## Problem

The arrow in the directory page toggle have been shifted down

## Solution

Change the css from inline-block to box

## Before & After Screenshots

**BEFORE**:
![Screenshot 2020-12-10 at 10 45 19 AM](https://user-images.githubusercontent.com/29625514/101716569-7da14500-3ad8-11eb-8167-878759ebdabc.png)

**AFTER**:
![Screenshot 2020-12-10 at 11 01 08 AM](https://user-images.githubusercontent.com/29625514/101716574-809c3580-3ad8-11eb-87e6-02d0d7e41731.png)


