### PR TITLE
Record search result clicks for search evaluation metric

### DIFF
--- a/src/client/app/util/ga.ts
+++ b/src/client/app/util/ga.ts
@@ -19,11 +19,13 @@ const getGaId = async () => {
  * @param {string} category
  * @param {string} action
  * @param {string} [label='nothing']
+ * @param {number} value
  */
 export const GAEvent = async (
   category: string,
   action: string,
   label: string = 'nothing',
+  value: number = 0,
 ) => {
   if (!hasInit) {
     await getGaId()
@@ -32,7 +34,7 @@ export const GAEvent = async (
     category, // Required
     action, // Required
     label,
-    value: 10,
+    value,
     nonInteraction: false,
   })
 }

--- a/src/client/directory/actions/index.ts
+++ b/src/client/directory/actions/index.ts
@@ -96,7 +96,12 @@ const getDirectoryResults = (
     // Remove all words that have @ inside to prevent potential email address problem
     filteredQuery = query.replace('@', ' ')
   }
-  GAEvent('directory page', filteredQuery, 'successful')
+  GAEvent(
+    'directory page',
+    filteredQuery,
+    'successful',
+    parseInt(`${json.count}`, 10),
+  )
   dispatch(
     setDirectoryResults({
       count: json.count,

--- a/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import copy from 'copy-to-clipboard'
 import {
   Hidden,
@@ -18,11 +18,14 @@ import { SetSuccessMessageAction } from '../../../../../app/components/pages/Roo
 import rootActions from '../../../../../app/components/pages/RootPage/actions'
 import DirectoryFileIcon from '../../../../widgets/DirectoryFileIcon'
 import DirectoryUrlIcon from '../../../../widgets/DirectoryUrlIcon'
+import { GoGovReduxState } from '../../../../../app/reducers/types'
+import { GAEvent } from '../../../../../app/util/ga'
 
 type DirectoryTableRowProps = {
   url: UrlTypePublic
   setUrlInfo: (url: UrlTypePublic) => void
   setOpen: (urlInfo: boolean) => void
+  index: number
 }
 
 type DirectoryTableRowStyleProps = {
@@ -163,16 +166,26 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
   url,
   setUrlInfo,
   setOpen,
+  index,
 }: DirectoryTableRowProps) => {
   const appMargins = useAppMargins()
   const classes = useStyles({ appMargins })
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const dispatch = useDispatch()
+  const query = useSelector(
+    (state: GoGovReduxState) => state.directory.queryForResult,
+  )
 
   const onClickEvent = (
     e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
   ) => {
+    GAEvent(
+      'directory result',
+      `${query}`,
+      'open tab',
+      parseInt(`${index}`, 10),
+    )
     if (!isMobileView && url.state === 'ACTIVE') {
       e.stopPropagation()
       const redirect = `${window.location.origin}/${url.shortUrl}`
@@ -184,6 +197,12 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
   }
 
   const onClickEmail = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+    GAEvent(
+      'directory result',
+      `${query}`,
+      'copy email',
+      parseInt(`${index}`, 10),
+    )
     if (!isMobileView) {
       e.stopPropagation()
       copy(url.email)

--- a/src/client/directory/components/DirectoryResults/DirectoryTable/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/index.tsx
@@ -20,6 +20,7 @@ type DirectoryTableProps = {
   disablePagination: boolean
   setUrlInfo: (url: UrlTypePublic) => void
   setOpen: (urlInfo: boolean) => void
+  rankOffset: number
 }
 
 const useStyles = makeStyles((theme) =>
@@ -46,16 +47,18 @@ const DirectoryTable: FunctionComponent<DirectoryTableProps> = React.memo(
     changeRowsPerPageHandler,
     setUrlInfo,
     setOpen,
+    rankOffset,
   }: DirectoryTableProps) => {
     const classes = useStyles()
     return (
       <Table aria-label="search results table" className={classes.resultsTable}>
         <TableBody>
-          {searchResults.map((url: UrlTypePublic) => (
+          {searchResults.map((url: UrlTypePublic, index) => (
             <DirectoryTableRow
               url={url}
               setUrlInfo={setUrlInfo}
               setOpen={setOpen}
+              index={index + 1 + rankOffset}
             />
           ))}
           <DirectoryTablePagination

--- a/src/client/directory/components/DirectoryResults/index.tsx
+++ b/src/client/directory/components/DirectoryResults/index.tsx
@@ -27,6 +27,7 @@ type DirectoryResultsProps = {
   resultsCount: number
   query: string
   disablePagination: boolean
+  rankOffset: number
 }
 
 const useStyles = makeStyles((theme) =>
@@ -61,6 +62,7 @@ const DirectoryResults: FunctionComponent<DirectoryResultsProps> = ({
   changeRowsPerPageHandler,
   query,
   disablePagination,
+  rankOffset,
 }: DirectoryResultsProps) => {
   const appMargins = useAppMargins()
   const classes = useStyles({ appMargins })
@@ -95,6 +97,7 @@ const DirectoryResults: FunctionComponent<DirectoryResultsProps> = ({
           setUrlInfo={setUrlInfo}
           setOpen={setIsMobilePanelOpen}
           disablePagination={disablePagination}
+          rankOffset={rankOffset}
         />
       )}
 

--- a/src/client/directory/index.tsx
+++ b/src/client/directory/index.tsx
@@ -97,7 +97,7 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
   const { query, sortOrder, state, isFile, isEmail } = params
   const rowsPerPage = Number(params.rowsPerPage)
   const currentPage = Number(params.currentPage)
-
+  const rankOffset = rowsPerPage * currentPage
   // When the query changes
   const getResults = () =>
     dispatch(
@@ -280,6 +280,7 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
             resultsCount={resultsCount}
             query={queryToDisplay}
             disablePagination={disablePagination}
+            rankOffset={rankOffset}
           />
         ) : (
           <EmptyStateGraphic />


### PR DESCRIPTION
## Problem

Going forward, we need a way to evaluate GoDirectory's search quality.
One of the way is to track the ranking of the results that are clicked by the users and the total results returned by the search query.

Gathering this data will allow us to calculate a meaningful baseline score and set google analytics goals that can be use as benchmark for future improvements.

## Solution

- Enable google analytics event to record value
- Include result count when recording user's search query
- Record click ranking and its respective query
