### PR TITLE
Display longurl in directory page

### DIFF
--- a/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
@@ -47,6 +47,9 @@ const useStyles = makeStyles((theme) =>
         marginLeft: () => 0,
       },
     },
+    longLinkText: {
+      color: '#BBBBBB',
+    },
     tableRow: {
       display: 'flex',
       flexWrap: 'wrap',
@@ -59,6 +62,7 @@ const useStyles = makeStyles((theme) =>
       },
     },
     shortLinkText: {
+      display: 'box',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
@@ -109,7 +113,7 @@ const useStyles = makeStyles((theme) =>
       paddingLeft: (props: DirectoryTableRowStyleProps) => props.appMargins,
       paddingBottom: theme.spacing(4),
       [theme.breakpoints.up('md')]: {
-        paddingTop: theme.spacing(5.5),
+        paddingTop: theme.spacing(7.5),
         paddingBottom: theme.spacing(0.5),
         paddingLeft: () => 0,
         width: '25%',
@@ -146,7 +150,7 @@ const useStyles = makeStyles((theme) =>
     },
     stateCell: {
       [theme.breakpoints.up('md')]: {
-        paddingTop: theme.spacing(5.5),
+        paddingTop: theme.spacing(7.5),
         minWidth: '100px',
       },
       [theme.breakpoints.down('sm')]: {
@@ -213,15 +217,19 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
             )}
           </div>
           {url.state === 'ACTIVE' ? (
-            <>
+            <div>
               <span className={classes.domainTextActive}>/{url.shortUrl}</span>
-            </>
+              <br />
+              <p className={classes.longLinkText}>{url.longUrl}</p>
+            </div>
           ) : (
-            <>
+            <div>
               <span className={classes.domainTextInactive}>
                 /{url.shortUrl}
               </span>
-            </>
+              <br />
+              <p className={classes.longLinkText}>{url.longUrl}</p>
+            </div>
           )}
         </Typography>
       </TableCell>

--- a/src/client/directory/components/DirectoryResults/MobilePanel/index.tsx
+++ b/src/client/directory/components/DirectoryResults/MobilePanel/index.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) =>
       marginBottom: theme.spacing(3),
     },
     shortUrlRow: {
-      display: 'inline-block',
+      display: 'box',
       maxWidth: '200px',
       width: '100%',
       textOverflow: 'ellipsis',
@@ -60,6 +60,9 @@ const useStyles = makeStyles((theme) =>
       overflow: 'hidden',
     },
     shortUrlInActive: {
+      color: '#BBBBBB',
+    },
+    longLinkText: {
       color: '#BBBBBB',
     },
     stateIcon: {
@@ -100,7 +103,11 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
       return (
         <>
           <DirectoryFileIcon className={classes.stateIcon} />
-          <span>/{url?.shortUrl}</span>
+          <div>
+            <span>/{url?.shortUrl}</span>
+            <br />
+            <p className={classes.longLinkText}>{url?.longUrl}</p>
+          </div>
         </>
       )
     }
@@ -108,7 +115,11 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
       return (
         <>
           <DirectoryUrlIcon className={classes.stateIcon} />
-          <span>/{url?.shortUrl}</span>
+          <div>
+            <span>/{url?.shortUrl}</span>
+            <br />
+            <p className={classes.longLinkText}>{url?.longUrl}</p>
+          </div>
         </>
       )
     }
@@ -116,7 +127,11 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
       return (
         <>
           <DirectoryFileIcon className={classes.stateIcon} color="#BBBBBB" />
-          <span className={classes.shortUrlInActive}>/{url?.shortUrl}</span>
+          <div>
+            <span className={classes.shortUrlInActive}>/{url?.shortUrl}</span>
+            <br />
+            <p className={classes.longLinkText}>{url?.longUrl}</p>
+          </div>
         </>
       )
     }
@@ -124,7 +139,11 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
     return (
       <>
         <DirectoryUrlIcon className={classes.stateIcon} color="#BBBBBB" />
-        <span className={classes.shortUrlInActive}>/{url?.shortUrl}</span>
+        <div>
+          <span className={classes.shortUrlInActive}>/{url?.shortUrl}</span>
+          <br />
+          <p className={classes.longLinkText}>{url?.longUrl}</p>
+        </div>
       </>
     )
   }

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -190,7 +190,7 @@ export class UrlRepository implements UrlRepositoryInterface {
 
     // TODO: optimize the search query, possibly with reverse-email search
     const rawQuery = `
-      SELECT "users"."email", "urls"."shortUrl", "urls"."state", "urls"."isFile"
+      SELECT "users"."email", "urls"."shortUrl", "urls"."state", "urls"."isFile", "urls"."longUrl"
       FROM urls AS "urls"
       JOIN users
       ON "urls"."userId" = "users"."id"
@@ -231,7 +231,7 @@ export class UrlRepository implements UrlRepositoryInterface {
     const queryFile = this.getQueryFileText(isFile)
     const queryState = this.getQueryStateText(state)
     const rawQuery = `
-      SELECT "urls"."shortUrl", "users"."email", "urls"."state", "urls"."isFile"
+      SELECT "urls"."shortUrl", "users"."email", "urls"."state", "urls"."isFile", "urls"."longUrl"
       FROM urls AS "urls"
       JOIN users
       ON "urls"."userId" = "users"."id"

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -53,6 +53,7 @@ export type UrlDirectory = {
   email: string
   state: string
   isFile: boolean
+  longUrl: string
 }
 
 export type UrlDirectoryPaginated = {

--- a/test/server/controllers/DirectoryController.test.ts
+++ b/test/server/controllers/DirectoryController.test.ts
@@ -48,6 +48,7 @@ describe('DirectoryController unit test', () => {
     expect(okSpy).toHaveBeenCalledWith({
       urls: [
         {
+          longUrl: 'https://test-moh.com',
           shortUrl: 'test-moh',
           state: 'ACTIVE',
           isFile: false,

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -43,6 +43,7 @@ export class UrlRepositoryMock implements UrlRepositoryInterface {
     return Promise.resolve({
       urls: [
         {
+          longUrl: 'https://test-moh.com',
           shortUrl: 'test-moh',
           state: 'ACTIVE',
           isFile: false,

--- a/test/server/mocks/services/DirectorySearchService.ts
+++ b/test/server/mocks/services/DirectorySearchService.ts
@@ -14,6 +14,7 @@ export class DirectorySearchServiceMock
     return Promise.resolve({
       urls: [
         {
+          longUrl: 'https://test-moh.com',
           shortUrl: 'test-moh',
           state: 'ACTIVE',
           isFile: false,

--- a/test/server/services/DirectorySearchService.test.ts
+++ b/test/server/services/DirectorySearchService.test.ts
@@ -24,6 +24,7 @@ describe('DirectorySearchService tests', () => {
       await expect(service.plainTextSearch(conditions)).resolves.toStrictEqual({
         urls: [
           {
+            longUrl: 'https://test-moh.com',
             shortUrl: 'test-moh',
             state: 'ACTIVE',
             isFile: false,


### PR DESCRIPTION
## Problem

If we were to allow searching by long link, we should also show the user the long link in the search results.

Closes #1059 

## Solution

- Include longUrl in the result from endpoint
- Include longUrl in the result found on directory page
- Update directory related tests 

## Before & After Screenshots

**AFTER**:
Web dashboard
![Screenshot 2020-12-15 at 2 21 15 PM](https://user-images.githubusercontent.com/29625514/102297566-72dc2980-3f8a-11eb-9c4f-0cbe375ae244.png)

Mobile dashboard
![Screenshot 2020-12-16 at 10 09 51 AM](https://user-images.githubusercontent.com/29625514/102297579-77a0dd80-3f8a-11eb-84b8-239108e0a7cb.png)

Mobile drawer
![Screenshot 2020-12-16 at 10 09 32 AM](https://user-images.githubusercontent.com/29625514/102297593-7e2f5500-3f8a-11eb-8ecd-87ffd77e2ae2.png)
