### PR TITLE
Move reading and writing of url table's clicks column to sharded table

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -196,9 +196,3 @@ export const accessEndpoint =
 export const dbPoolSize = Number(process.env.DB_POOL_SIZE) || 40
 
 export const sentryDns: string | undefined = process.env.SENTRY_DNS
-
-// Search variables
-export const searchShortUrlWeight =
-  Number(process.env.SEARCH_SHORT_URL_WEIGHT) || 1.0
-export const searchDescriptionWeight =
-  Number(process.env.SEARCH_DESCRIPTION_WEIGHT) || 0.4

--- a/src/server/db_migrations/20201221_remove_url_clicks_column.sql
+++ b/src/server/db_migrations/20201221_remove_url_clicks_column.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION;
+
+DROP TRIGGER IF EXISTS url_table_click_incremented ON urls;
+DROP TRIGGER IF EXISTS url_created ON urls;
+
+DROP FUNCTION IF EXISTS update_clicks;
+DROP FUNCTION IF EXISTS create_clicks;
+
+ALTER TABLE urls DROP COLUMN clicks;
+
+COMMIT;

--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -11,11 +11,14 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
     if (!urlType) {
       return null
     }
+    const { UrlClicks: urlClicks } = urlType
+    if (!urlClicks || !Number.isInteger(urlClicks.clicks))
+      throw new Error('UrlClicks object not populated.')
     return {
       shortUrl: urlType.shortUrl,
       longUrl: urlType.longUrl,
       state: urlType.state,
-      clicks: urlType.clicks,
+      clicks: urlClicks.clicks,
       isFile: urlType.isFile,
       createdAt: urlType.createdAt,
       updatedAt: urlType.updatedAt,

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -179,6 +179,7 @@ export const Url = <UrlTypeStatic>sequelize.define(
           },
         )
 
+        // TODO: change to create after DB triggers are removed.
         await UrlClicks.upsert(
           {
             shortUrl: url.shortUrl,

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -1,5 +1,5 @@
 import Sequelize from 'sequelize'
-import { UrlClicks } from './statistics/clicks'
+import { UrlClicks, UrlClicksType } from './statistics/clicks'
 import { ACTIVE, INACTIVE } from './types'
 import {
   SHORT_URL_REGEX,
@@ -24,7 +24,7 @@ interface UrlBaseType extends IdType {
 }
 
 export interface UrlType extends IdType, UrlBaseType, Sequelize.Model {
-  readonly clicks: number
+  readonly UrlClicks?: UrlClicksType
   readonly createdAt: string
   readonly updatedAt: string
   readonly email: string
@@ -144,11 +144,6 @@ export const Url = <UrlTypeStatic>sequelize.define(
       values: [ACTIVE, INACTIVE],
       defaultValue: ACTIVE,
     },
-    clicks: {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 0,
-    },
     isFile: {
       type: Sequelize.BOOLEAN,
       allowNull: false,
@@ -231,6 +226,16 @@ export const Url = <UrlTypeStatic>sequelize.define(
         fields: [Sequelize.literal(`(${urlSearchVector})`)],
       },
     ],
+    scopes: {
+      getClicks: {
+        include: [
+          {
+            model: UrlClicks,
+            as: 'UrlClicks',
+          },
+        ],
+      },
+    },
   },
 )
 

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -1,4 +1,5 @@
 import Sequelize from 'sequelize'
+import { UrlClicks } from './statistics/clicks'
 import { ACTIVE, INACTIVE } from './types'
 import {
   SHORT_URL_REGEX,
@@ -178,6 +179,15 @@ export const Url = <UrlTypeStatic>sequelize.define(
         // eslint-disable-next-line no-use-before-define
         await writeToUrlHistory(
           url,
+          options as Sequelize.CreateOptions & {
+            transaction: Sequelize.Transaction
+          },
+        )
+
+        await UrlClicks.upsert(
+          {
+            shortUrl: url.shortUrl,
+          },
           options as Sequelize.CreateOptions & {
             transaction: Sequelize.Transaction
           },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -91,7 +91,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url,
+              model: Url.scope('getClicks'),
               as: 'Urls',
               where: whereUrlConditions,
               // use left outer join instead of default inner join
@@ -115,7 +115,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url,
+              model: Url.scope('getClicks'),
               as: 'Urls',
               where: { shortUrl },
             },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize'
 import { sequelize } from '../util/sequelize'
 import { IdType, Settable } from '../../types/server/models'
 import { Url, UrlType } from './url'
+import { UrlClicks } from './statistics/clicks'
 import { emailValidator } from '../config'
 
 // Users
@@ -99,7 +100,17 @@ export const User = <UserTypeStatic>sequelize.define(
               right: false,
             },
           ],
-          order: [[{ model: Url, as: 'Urls' }, orderBy, sortDirection]],
+          order:
+            orderBy === 'clicks'
+              ? [
+                  [
+                    { model: Url, as: 'Urls' },
+                    { model: UrlClicks, as: 'UrlClicks' },
+                    orderBy,
+                    sortDirection,
+                  ],
+                ]
+              : [[{ model: Url, as: 'Urls' }, orderBy, sortDirection]],
           where: {
             id: userId,
           },

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -3,6 +3,7 @@
 import { injectable } from 'inversify'
 import { User } from '../../../models/user'
 import { Url } from '../../../models/url'
+import { UrlClicks } from '../../../models/statistics/clicks'
 import { statClient } from '../../../redis'
 import { logger, statisticsExpiry } from '../../../config'
 import * as interfaces from '../interfaces'
@@ -32,7 +33,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
 
     if (clickCount == null) {
       // Replace Nan with 0 if there is no data
-      clickCount = (await Url.sum('clicks')) || 0
+      clickCount = (await UrlClicks.sum('clicks')) || 0
       this.trySetCache(CLICK_COUNT_KEY, clickCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
+++ b/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
@@ -32,6 +32,8 @@ export const userModelMock = {
     ]),
 }
 
+export const urlClicksModelMock = {}
+
 const redisMockClient = redisMock.createClient()
 
 jest.mock('../../../../redis', () => ({
@@ -44,6 +46,10 @@ jest.mock('../../../../models/user', () => ({
 
 jest.mock('../../../../models/url', () => ({
   Url: urlModelMock,
+}))
+
+jest.mock('../../../../models/statistics/clicks', () => ({
+  UrlClicks: urlClicksModelMock,
 }))
 
 const setSpy = jest.spyOn(redisMockClient, 'set')
@@ -69,7 +75,7 @@ describe('StatisticsRepository', () => {
   afterEach(async () => {
     delete (userModelMock as any).count
     delete (urlModelMock as any).count
-    delete (urlModelMock as any).sum
+    delete (urlClicksModelMock as any).sum
   })
 
   it('returns values from Redis if present', async () => {
@@ -99,8 +105,10 @@ describe('StatisticsRepository', () => {
     mgetSpy.mockImplementation(raiseError)
     Object.assign(userModelMock, { count: () => userCount })
     Object.assign(urlModelMock, {
-      sum: () => clickCount,
       count: () => linkCount,
+    })
+    Object.assign(urlClicksModelMock, {
+      sum: () => clickCount,
     })
 
     await expect(repository.getGlobalStatistics()).resolves.toStrictEqual({
@@ -125,8 +133,10 @@ describe('StatisticsRepository', () => {
 
     Object.assign(userModelMock, { count: () => userCount })
     Object.assign(urlModelMock, {
-      sum: () => clickCount,
       count: () => linkCount,
+    })
+    Object.assign(urlClicksModelMock, {
+      sum: () => clickCount,
     })
 
     // @ts-ignore

--- a/src/server/repositories/LinkStatisticsRepository.ts
+++ b/src/server/repositories/LinkStatisticsRepository.ts
@@ -76,7 +76,7 @@ export class LinkStatisticsRepository
   public findByShortUrl: (
     shortUrl: string,
   ) => Promise<LinkStatisticsInterface | null> = async (shortUrl) => {
-    const url = await Url.findOne({
+    const url = await Url.scope('getClicks').findOne({
       where: { shortUrl },
       include: [
         { model: Devices, as: 'DeviceClicks' },
@@ -106,7 +106,7 @@ export class LinkStatisticsRepository
     if (url) {
       const urlStats = url as UrlStats
 
-      const totalClicks = url.clicks
+      const totalClicks = url.UrlClicks?.clicks
 
       const deviceClicks = urlStats.DeviceClicks
         ? _.pick(urlStats.DeviceClicks.toJSON(), [

--- a/src/server/repositories/LinkStatisticsRepository.ts
+++ b/src/server/repositories/LinkStatisticsRepository.ts
@@ -3,6 +3,7 @@ import { Op, QueryTypes } from 'sequelize'
 import _ from 'lodash'
 
 import { Url, UrlType } from '../models/url'
+import { UrlClicks } from '../models/statistics/clicks'
 import { DailyClicks, DailyClicksType } from '../models/statistics/daily'
 import { Devices, DevicesType } from '../models/statistics/devices'
 import { WeekdayClicks, WeekdayClicksType } from '../models/statistics/weekday'
@@ -13,7 +14,7 @@ import { sequelize } from '../util/sequelize'
 import { DeviceType } from '../services/interfaces/DeviceCheckServiceInterface'
 
 // Get the relevant table names from their models.
-const urlTable = Url.getTableName()
+const urlClicksTable = UrlClicks.getTableName()
 const devicesTable = Devices.getTableName()
 const clicksTable = DailyClicks.getTableName()
 const weekdayTable = WeekdayClicks.getTableName()
@@ -26,7 +27,7 @@ export const updateLinkStatistics = `CREATE OR REPLACE FUNCTION update_link_stat
 RETURNS void AS $$
 BEGIN
 -- Update total clicks.
-UPDATE "${urlTable}" SET "clicks" = "${urlTable}"."clicks" + 1
+UPDATE "${urlClicksTable}" SET "clicks" = "${urlClicksTable}"."clicks" + 1
 WHERE "shortUrl" = inputShortUrl;
 -- Update devices clicks.
 IF device='mobile' THEN

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -5,12 +5,7 @@ import { QueryTypes } from 'sequelize'
 import { Url, UrlType } from '../models/url'
 import { NotFoundError } from '../util/error'
 import { redirectClient } from '../redis'
-import {
-  logger,
-  redirectExpiry,
-  searchDescriptionWeight,
-  searchShortUrlWeight,
-} from '../config'
+import { logger, redirectExpiry } from '../config'
 import { sequelize } from '../util/sequelize'
 import { DependencyIds } from '../constants'
 import { FileVisibility, S3Interface } from '../services/aws'
@@ -403,16 +398,6 @@ export class UrlRepository implements UrlRepositoryInterface {
   ): string {
     let rankingAlgorithm
     switch (order) {
-      case SearchResultsSortOrder.Relevance:
-        {
-          // The 3rd argument passed into ts_rank_cd represents
-          // the normalization option that specifies whether and how
-          // a document's length should impact its rank. It works as a bit mask.
-          // 1 divides the rank by 1 + the logarithm of the document length
-          const textRanking = `ts_rank_cd('{0, 0, ${searchDescriptionWeight}, ${searchShortUrlWeight}}',${urlSearchVector}, query, 1)`
-          rankingAlgorithm = `${textRanking} * log(${tableName}.clicks + 1)`
-        }
-        break
       case SearchResultsSortOrder.Recency:
         rankingAlgorithm = `${tableName}."createdAt"`
         break

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -1,4 +1,5 @@
 import { UrlType } from '../models/url'
+import { UrlClicksType } from '../models/statistics/clicks'
 
 /**
  * A type that represents Urls stored in the data store.
@@ -8,13 +9,13 @@ export type StorableUrl = Pick<
   | 'shortUrl'
   | 'longUrl'
   | 'state'
-  | 'clicks'
   | 'isFile'
   | 'createdAt'
   | 'updatedAt'
   | 'description'
   | 'contactEmail'
->
+> &
+  Pick<UrlClicksType, 'clicks'>
 
 /**
  * A type that represents a file that can be stored in the data store.

--- a/src/shared/search.ts
+++ b/src/shared/search.ts
@@ -1,5 +1,4 @@
 export enum SearchResultsSortOrder {
-  Relevance = 'relevance',
   Popularity = 'popularity',
   Recency = 'recency',
 }

--- a/test/server/api/setup.ts
+++ b/test/server/api/setup.ts
@@ -10,6 +10,7 @@ import {
   mockQuery,
   mockTransaction,
   redisMockClient,
+  urlClicksModelMock,
   urlModelMock,
   userModelMock,
 } from './util'
@@ -83,6 +84,10 @@ jest.mock('../../../src/server/util/sequelize', () => ({
 
 jest.mock('../../../src/server/models/url', () => ({
   Url: urlModelMock,
+}))
+
+jest.mock('../../../src/server/models/statistics/clicks', () => ({
+  UrlClicks: urlClicksModelMock,
 }))
 
 // Necessary mock for app to work

--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -99,7 +99,9 @@ export const urlModelMock = sequelizeMock.define(
     shortUrl: 'a',
     longUrl: 'aa',
     state: ACTIVE,
-    clicks: 8,
+    UrlClicks: {
+      clicks: 3,
+    },
   },
   {
     instanceMethods: {
@@ -108,6 +110,11 @@ export const urlModelMock = sequelizeMock.define(
     },
   },
 )
+
+export const urlClicksModelMock = sequelizeMock.define('url_clicks', {
+  shortUrl: 'a',
+  clicks: 3,
+})
 
 export const clicksModelMock = sequelizeMock.define(
   'daily_stats',

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -7,6 +7,7 @@ import {
   mockTransaction,
   redisMockClient,
   sanitiseMock,
+  urlClicksModelMock,
   urlModelMock,
 } from '../api/util'
 import { UrlRepository } from '../../../src/server/repositories/UrlRepository'
@@ -20,6 +21,10 @@ import { DirectoryQueryConditions } from '../../../src/server/services/interface
 jest.mock('../../../src/server/models/url', () => ({
   Url: urlModelMock,
   sanitise: sanitiseMock,
+}))
+
+jest.mock('../../../src/server/models/statistics/clicks', () => ({
+  UrlClicks: urlClicksModelMock,
 }))
 
 jest.mock('../../../src/server/models/statistics/daily', () => ({

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -13,16 +13,29 @@ const userRepo = new UserRepository(
   new UrlMapper(),
 )
 
-const url = {
+const baseUrlTemplate = {
   shortUrl: 'short-link',
   longUrl: 'https://www.agency.gov.sg',
   state: 'ACTIVE',
-  clicks: 23,
   isFile: false,
   createdAt: Date.now(),
   updatedAt: Date.now(),
   description: 'An agency of the Singapore Government',
   contactEmail: 'contact-us@agency.gov.sg',
+}
+
+const urlClicks = {
+  clicks: 23,
+}
+
+const url = {
+  ...baseUrlTemplate,
+  UrlClicks: urlClicks,
+}
+
+const expectedUrl = {
+  ...baseUrlTemplate,
+  ...urlClicks,
 }
 
 describe('UserRepository', () => {
@@ -56,7 +69,7 @@ describe('UserRepository', () => {
       await expect(userRepo.findById(2)).resolves.toStrictEqual({
         id: user.id,
         email: user.email,
-        urls: [url],
+        urls: [expectedUrl],
       })
     })
   })
@@ -96,7 +109,7 @@ describe('UserRepository', () => {
       ).resolves.toStrictEqual({
         id: user.id,
         email: user.email,
-        urls: [url],
+        urls: [expectedUrl],
       })
     })
   })
@@ -120,10 +133,10 @@ describe('UserRepository', () => {
     it('returns null for null user', async () => {
       findOne.mockResolvedValue(null)
       await expect(
-        userRepo.findOneUrlForUser(2, url.shortUrl),
+        userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toBeNull()
       expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', url.shortUrl],
+        method: ['includeShortUrl', expectedUrl.shortUrl],
       })
     })
 
@@ -134,10 +147,10 @@ describe('UserRepository', () => {
         }),
       })
       await expect(
-        userRepo.findOneUrlForUser(2, url.shortUrl),
-      ).resolves.toStrictEqual(url)
+        userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
+      ).resolves.toStrictEqual(expectedUrl)
       expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', url.shortUrl],
+        method: ['includeShortUrl', expectedUrl.shortUrl],
       })
     })
   })
@@ -159,11 +172,13 @@ describe('UserRepository', () => {
         Urls: [url],
       }
       findOne.mockResolvedValue(user)
-      await expect(userRepo.findUserByUrl(url.shortUrl)).resolves.toStrictEqual(
+      await expect(
+        userRepo.findUserByUrl(expectedUrl.shortUrl),
+      ).resolves.toStrictEqual(
         expect.objectContaining({ id: user.id, email: user.email }),
       )
       expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', url.shortUrl],
+        method: ['includeShortUrl', expectedUrl.shortUrl],
       })
     })
   })
@@ -227,7 +242,7 @@ describe('UserRepository', () => {
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
       await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
         {
-          urls: [url],
+          urls: [expectedUrl],
           count: 1,
         },
       )


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Part 2 of #984 

## Solution

_How did you solve the problem?_

**Features**:

- [x] Remove `clicks` column definition in Url model.
- [x] Add `getClicks` scope for Url model. In order to fetch the clicks object, repositories must use this scope.
- [x] Modify `UrlRepository` and `UserRepository` to use new `getClicks` scope when fetching urls.
- [x] Modify `UrlMapper`'s `persistenceToDto` method to throw an error when a url is supplied without an associated `UrlClicks` object. This allows it to guarantee a complete `StorableUrl` object to be returned for abstraction layers above the repository.
- [x] Tweak GoSearch queries to `JOIN ON "url_clicks"."shortUrl" = "url"."shortUrl"`
- [x] Tweak ranking algorithm's `Popularity` order to `ORDER BY url_clicks.clicks`  instead of `ORDER BY url.clicks`
- [x] Modify LinkStatisticsRepository to call the `sum` method of `UrlClicks` instead of `Url.clicks`
- [x] Fix the 20-30 tests that started breaking as a result of this change
- [x] Tweak `updateLinkStatistics` SQL function to write to `url_clicks` instead of `url` table

**Improvements**:

- [x] Remove `Relevance` filter option for url search. This was used for GoSearch, but not for GoDirectory.

## Deploy Notes

1) Deploy application code directly.

2) Once confident that no IO has been made on the Url.clicks column, run the migration script to delete it.

**New scripts**:

- `20201221_remove_url_clicks_column.sql` : The final step in this DB sharding task. Removes all triggers/functions and deletes the Url.clicks column

