### PR TITLE
Use enum for user redux actions instead of constant value strings

### DIFF
--- a/src/client/user/actions/index.ts
+++ b/src/client/user/actions/index.ts
@@ -6,32 +6,11 @@ import { Dispatch } from 'redux'
 import { ThunkAction, ThunkDispatch } from 'redux-thunk'
 import * as Sentry from '@sentry/browser'
 import {
-  CLOSE_CREATE_URL_MODAL,
   CloseCreateUrlModalAction,
-  GET_URLS_FOR_USER_SUCCESS,
   GetUrlsForUserSuccessAction,
-  IS_FETCHING_URLS,
   IsFetchingUrlsAction,
-  OPEN_CREATE_URL_MODAL,
   OpenCreateUrlModalAction,
-  RESET_USER_STATE,
   ResetUserStateAction,
-  SET_CREATE_SHORT_LINK_ERROR,
-  SET_EDITED_CONTACT_EMAIL,
-  SET_EDITED_DESCRIPTION,
-  SET_EDITED_LONG_URL,
-  SET_FILE_UPLOAD_STATE,
-  SET_IS_UPLOADING,
-  SET_LAST_CREATED_LINK,
-  SET_LONG_URL,
-  SET_RANDOM_SHORT_URL,
-  SET_SHORT_URL,
-  SET_UPLOAD_FILE_ERROR,
-  SET_URL_FILTER,
-  SET_URL_TABLE_CONFIG,
-  SET_URL_UPLOAD_STATE,
-  SET_USER_ANNOUNCEMENT,
-  SET_USER_MESSAGE,
   SetCreateShortLinkErrorAction,
   SetEditedContactEmailAction,
   SetEditedDescriptionAction,
@@ -48,12 +27,10 @@ import {
   SetUrlUploadStateAction,
   SetUserAnnouncementAction,
   SetUserMessageAction,
-  TOGGLE_URL_STATE_SUCCESS,
   ToggleUrlStateSuccessAction,
-  UPDATE_URL_COUNT,
   UpdateUrlCountAction,
+  UserAction,
   UserActionType,
-  WIPE_USER_STATE,
   WipeUserStateAction,
 } from './types'
 import {
@@ -86,35 +63,35 @@ import { GAEvent } from '../../app/util/ga'
 const setUrlUploadState: (payload: boolean) => SetUrlUploadStateAction = (
   payload,
 ) => ({
-  type: SET_URL_UPLOAD_STATE,
+  type: UserAction.SET_URL_UPLOAD_STATE,
   payload,
 })
 
 const setFileUploadState: (payload: boolean) => SetFileUploadStateAction = (
   payload,
 ) => ({
-  type: SET_FILE_UPLOAD_STATE,
+  type: UserAction.SET_FILE_UPLOAD_STATE,
   payload,
 })
 
 const isFetchingUrls: (payload: boolean) => IsFetchingUrlsAction = (
   payload,
 ) => ({
-  type: IS_FETCHING_URLS,
+  type: UserAction.IS_FETCHING_URLS,
   payload,
 })
 
 const setLastCreatedLink: (payload: string) => SetLastCreatedLinkAction = (
   payload,
 ) => ({
-  type: SET_LAST_CREATED_LINK,
+  type: UserAction.SET_LAST_CREATED_LINK,
   payload,
 })
 
 const setIsUploading: (payload: boolean) => SetIsUploadingAction = (
   payload,
 ) => ({
-  type: SET_IS_UPLOADING,
+  type: UserAction.SET_IS_UPLOADING,
   payload,
 })
 
@@ -122,7 +99,7 @@ const setEditedContactEmail: (
   shortUrl: string,
   editedContactEmail: string,
 ) => SetEditedContactEmailAction = (shortUrl, editedContactEmail) => ({
-  type: SET_EDITED_CONTACT_EMAIL,
+  type: UserAction.SET_EDITED_CONTACT_EMAIL,
   payload: {
     shortUrl,
     editedContactEmail,
@@ -133,7 +110,7 @@ const setEditedDescription: (
   shortUrl: string,
   editedDescription: string,
 ) => SetEditedDescriptionAction = (shortUrl, editedDescription) => ({
-  type: SET_EDITED_DESCRIPTION,
+  type: UserAction.SET_EDITED_DESCRIPTION,
   payload: {
     shortUrl,
     editedDescription,
@@ -143,21 +120,21 @@ const setEditedDescription: (
 const setCreateShortLinkError: (
   payload: string,
 ) => SetCreateShortLinkErrorAction = (payload) => ({
-  type: SET_CREATE_SHORT_LINK_ERROR,
+  type: UserAction.SET_CREATE_SHORT_LINK_ERROR,
   payload,
 })
 
 const setUploadFileError: (payload: string) => SetUploadFileErrorAction = (
   payload,
 ) => ({
-  type: SET_UPLOAD_FILE_ERROR,
+  type: UserAction.SET_UPLOAD_FILE_ERROR,
   payload,
 })
 
 const isGetUrlsForUserSuccess: (
   urls: Array<UrlType>,
 ) => GetUrlsForUserSuccessAction = (urls) => ({
-  type: GET_URLS_FOR_USER_SUCCESS,
+  type: UserAction.GET_URLS_FOR_USER_SUCCESS,
   payload: urls,
 })
 
@@ -170,27 +147,27 @@ const isGetUrlsForUserSuccess: (
 const setUrlTableConfig: (
   payload: UrlTableConfig,
 ) => SetUrlTableConfigAction = (payload) => ({
-  type: SET_URL_TABLE_CONFIG,
+  type: UserAction.SET_URL_TABLE_CONFIG,
   payload,
 })
 
 const setUrlFilter: (payload: UrlTableFilterConfig) => SetUrlFilterAction = (
   payload,
 ) => ({
-  type: SET_URL_FILTER,
+  type: UserAction.SET_URL_FILTER,
   payload,
 })
 
 const updateUrlCount: (urlCount: number) => UpdateUrlCountAction = (
   urlCount,
 ) => ({
-  type: UPDATE_URL_COUNT,
+  type: UserAction.UPDATE_URL_COUNT,
   payload: urlCount,
 })
 
 const setUserMessage: (payload: string) => SetUserMessageAction = (
   payload,
-) => ({ type: SET_USER_MESSAGE, payload })
+) => ({ type: UserAction.SET_USER_MESSAGE, payload })
 
 const setUserAnnouncement: (payload: {
   message: string
@@ -199,7 +176,7 @@ const setUserAnnouncement: (payload: {
   url: string
   image: string
 }) => SetUserAnnouncementAction = (payload) => ({
-  type: SET_USER_ANNOUNCEMENT,
+  type: UserAction.SET_USER_ANNOUNCEMENT,
   payload,
 })
 
@@ -336,11 +313,11 @@ const getUrlsForUser = (): ThunkAction<
 }
 
 const resetUserState: () => ResetUserStateAction = () => ({
-  type: RESET_USER_STATE,
+  type: UserAction.RESET_USER_STATE,
 })
 
 const wipeUserState: () => WipeUserStateAction = () => ({
-  type: WIPE_USER_STATE,
+  type: UserAction.WIPE_USER_STATE,
 })
 
 // API call to update long URL
@@ -452,13 +429,13 @@ const replaceFile = (
 
 // For setting short link value in the input box
 const setShortUrl: (shortUrl: string) => SetShortUrlAction = (shortUrl) => ({
-  type: SET_SHORT_URL,
+  type: UserAction.SET_SHORT_URL,
   payload: shortUrl,
 })
 
 // For setting URL value in the input box
 const setLongUrl: (longUrl: string) => SetLongUrlAction = (longUrl) => ({
-  type: SET_LONG_URL,
+  type: UserAction.SET_LONG_URL,
   payload: removeHttpsProtocol(longUrl),
 })
 
@@ -466,7 +443,7 @@ const setEditedLongUrl: (
   shortUrl: string,
   editedLongUrl: string,
 ) => SetEditedLongUrlAction = (shortUrl, editedLongUrl) => ({
-  type: SET_EDITED_LONG_URL,
+  type: UserAction.SET_EDITED_LONG_URL,
   payload: { shortUrl, editedLongUrl },
 })
 
@@ -474,7 +451,7 @@ const setEditedLongUrl: (
 const setRandomShortUrl = () => (dispatch: Dispatch<SetRandomShortUrlAction>) =>
   generateShortUrl().then((randomUrl) => {
     dispatch<SetRandomShortUrlAction>({
-      type: SET_RANDOM_SHORT_URL,
+      type: UserAction.SET_RANDOM_SHORT_URL,
       payload: randomUrl,
     })
   })
@@ -483,7 +460,7 @@ const isToggleUrlStateSuccess: (payload: {
   shortUrl: string
   toState: UrlState
 }) => ToggleUrlStateSuccessAction = (payload) => ({
-  type: TOGGLE_URL_STATE_SUCCESS,
+  type: UserAction.TOGGLE_URL_STATE_SUCCESS,
   payload,
 })
 
@@ -510,11 +487,11 @@ const toggleUrlState = (shortUrl: string, state: UrlState) => (
 }
 
 const openCreateUrlModal: () => OpenCreateUrlModalAction = () => ({
-  type: OPEN_CREATE_URL_MODAL,
+  type: UserAction.OPEN_CREATE_URL_MODAL,
 })
 
 const closeCreateUrlModal: () => CloseCreateUrlModalAction = () => ({
-  type: CLOSE_CREATE_URL_MODAL,
+  type: UserAction.CLOSE_CREATE_URL_MODAL,
 })
 
 const urlCreated = (

--- a/src/client/user/actions/types.ts
+++ b/src/client/user/actions/types.ts
@@ -6,49 +6,52 @@ import {
 } from '../reducers/types'
 
 /* User actions */
-export const CREATE_URL_SUCCESS = 'CREATE_URL_SUCCESS'
-export const GET_URLS_FOR_USER_SUCCESS = 'GET_URLS_FOR_USER_SUCCESS'
-export const OPEN_CREATE_URL_MODAL = 'OPEN_CREATE_URL_MODAL'
-export const CLOSE_CREATE_URL_MODAL = 'CLOSE_CREATE_URL_MODAL'
-export const SET_SHORT_URL = 'SET_SHORT_URL'
-export const SET_LONG_URL = 'SET_LONG_URL'
-export const SET_EDITED_LONG_URL = 'SET_EDITED_LONG_URL'
-export const SET_RANDOM_SHORT_URL = 'SET_RANDOM_SHORT_URL'
-export const RESET_USER_STATE = 'RESET_USER_STATE'
-export const TOGGLE_URL_STATE_SUCCESS = 'TOGGLE_URL_STATE_SUCCESS'
-export const SET_URL_TABLE_CONFIG = 'SET_URL_TABLE_CONFIG'
-export const SET_URL_FILTER = 'SET_URL_FILTER'
-export const UPDATE_URL_COUNT = 'UPDATE_URL_COUNT'
-export const IS_FETCHING_URLS = 'IS_FETCHING_URLS'
-export const WIPE_USER_STATE = 'WIPE_USER_STATE'
-export const SET_IS_UPLOADING = 'SET_IS_UPLOADING'
-export const SET_UPLOAD_FILE_ERROR = 'SET_UPLOAD_FILE_ERROR'
-export const SET_CREATE_SHORT_LINK_ERROR = 'SET_CREATE_SHORT_LINK_ERROR'
-export const SET_LAST_CREATED_LINK = 'SET_LAST_CREATED_LINK'
-export const SET_EDITED_CONTACT_EMAIL = 'SET_EDITED_CONTACT_EMAIL'
-export const SET_EDITED_DESCRIPTION = 'SET_EDITED_DESCRIPTION'
-export const SET_USER_MESSAGE = 'SET_USER_MESSAGE'
-export const SET_USER_ANNOUNCEMENT = 'SET_USER_ANNOUNCEMENT'
-export const SET_URL_UPLOAD_STATE = 'SET_URL_UPLOAD_STATE'
-export const SET_FILE_UPLOAD_STATE = 'SET_FILE_UPLOAD_STATE'
+
+export enum UserAction {
+  CREATE_URL_SUCCESS = 'CREATE_URL_SUCCESS',
+  GET_URLS_FOR_USER_SUCCESS = 'GET_URLS_FOR_USER_SUCCESS',
+  OPEN_CREATE_URL_MODAL = 'OPEN_CREATE_URL_MODAL',
+  CLOSE_CREATE_URL_MODAL = 'CLOSE_CREATE_URL_MODAL',
+  SET_SHORT_URL = 'SET_SHORT_URL',
+  SET_LONG_URL = 'SET_LONG_URL',
+  SET_EDITED_LONG_URL = 'SET_EDITED_LONG_URL',
+  SET_RANDOM_SHORT_URL = 'SET_RANDOM_SHORT_URL',
+  RESET_USER_STATE = 'RESET_USER_STATE',
+  TOGGLE_URL_STATE_SUCCESS = 'TOGGLE_URL_STATE_SUCCESS',
+  SET_URL_TABLE_CONFIG = 'SET_URL_TABLE_CONFIG',
+  SET_URL_FILTER = 'SET_URL_FILTER',
+  UPDATE_URL_COUNT = 'UPDATE_URL_COUNT',
+  IS_FETCHING_URLS = 'IS_FETCHING_URLS',
+  WIPE_USER_STATE = 'WIPE_USER_STATE',
+  SET_IS_UPLOADING = 'SET_IS_UPLOADING',
+  SET_UPLOAD_FILE_ERROR = 'SET_UPLOAD_FILE_ERROR',
+  SET_CREATE_SHORT_LINK_ERROR = 'SET_CREATE_SHORT_LINK_ERROR',
+  SET_LAST_CREATED_LINK = 'SET_LAST_CREATED_LINK',
+  SET_EDITED_CONTACT_EMAIL = 'SET_EDITED_CONTACT_EMAIL',
+  SET_EDITED_DESCRIPTION = 'SET_EDITED_DESCRIPTION',
+  SET_USER_MESSAGE = 'SET_USER_MESSAGE',
+  SET_USER_ANNOUNCEMENT = 'SET_USER_ANNOUNCEMENT',
+  SET_URL_UPLOAD_STATE = 'SET_URL_UPLOAD_STATE',
+  SET_FILE_UPLOAD_STATE = 'SET_FILE_UPLOAD_STATE',
+}
 
 export type SetUrlUploadStateAction = {
-  type: typeof SET_URL_UPLOAD_STATE
+  type: typeof UserAction.SET_URL_UPLOAD_STATE
   payload: boolean
 }
 
 export type SetFileUploadStateAction = {
-  type: typeof SET_FILE_UPLOAD_STATE
+  type: typeof UserAction.SET_FILE_UPLOAD_STATE
   payload: boolean
 }
 
 export type SetUserMessageAction = {
-  type: typeof SET_USER_MESSAGE
+  type: typeof UserAction.SET_USER_MESSAGE
   payload: string
 }
 
 export type SetUserAnnouncementAction = {
-  type: typeof SET_USER_ANNOUNCEMENT
+  type: typeof UserAction.SET_USER_ANNOUNCEMENT
   payload: {
     message: string | undefined
     title: string | undefined
@@ -59,7 +62,7 @@ export type SetUserAnnouncementAction = {
 }
 
 export type SetEditedContactEmailAction = {
-  type: typeof SET_EDITED_CONTACT_EMAIL
+  type: typeof UserAction.SET_EDITED_CONTACT_EMAIL
   payload: {
     shortUrl: string
     editedContactEmail: string
@@ -67,7 +70,7 @@ export type SetEditedContactEmailAction = {
 }
 
 export type SetEditedDescriptionAction = {
-  type: typeof SET_EDITED_DESCRIPTION
+  type: typeof UserAction.SET_EDITED_DESCRIPTION
   payload: {
     shortUrl: string
     editedDescription: string
@@ -75,48 +78,48 @@ export type SetEditedDescriptionAction = {
 }
 
 export type SetLastCreatedLinkAction = {
-  type: typeof SET_LAST_CREATED_LINK
+  type: typeof UserAction.SET_LAST_CREATED_LINK
   payload: string
 }
 
 export type WipeUserStateAction = {
-  type: typeof WIPE_USER_STATE
+  type: typeof UserAction.WIPE_USER_STATE
 }
 
 export type IsFetchingUrlsAction = {
-  type: typeof IS_FETCHING_URLS
+  type: typeof UserAction.IS_FETCHING_URLS
   payload: boolean
 }
 
 export type CreateUrlSuccessAction = {
-  type: typeof CREATE_URL_SUCCESS
+  type: typeof UserAction.CREATE_URL_SUCCESS
 }
 
 export type GetUrlsForUserSuccessAction = {
-  type: typeof GET_URLS_FOR_USER_SUCCESS
+  type: typeof UserAction.GET_URLS_FOR_USER_SUCCESS
   payload: Array<UrlType>
 }
 
 export type OpenCreateUrlModalAction = {
-  type: typeof OPEN_CREATE_URL_MODAL
+  type: typeof UserAction.OPEN_CREATE_URL_MODAL
 }
 
 export type CloseCreateUrlModalAction = {
-  type: typeof CLOSE_CREATE_URL_MODAL
+  type: typeof UserAction.CLOSE_CREATE_URL_MODAL
 }
 
 export type SetShortUrlAction = {
-  type: typeof SET_SHORT_URL
+  type: typeof UserAction.SET_SHORT_URL
   payload: string
 }
 
 export type SetLongUrlAction = {
-  type: typeof SET_LONG_URL
+  type: typeof UserAction.SET_LONG_URL
   payload: string
 }
 
 export type SetEditedLongUrlAction = {
-  type: typeof SET_EDITED_LONG_URL
+  type: typeof UserAction.SET_EDITED_LONG_URL
   payload: {
     shortUrl: string
     editedLongUrl: string
@@ -124,16 +127,16 @@ export type SetEditedLongUrlAction = {
 }
 
 export type SetRandomShortUrlAction = {
-  type: typeof SET_RANDOM_SHORT_URL
+  type: typeof UserAction.SET_RANDOM_SHORT_URL
   payload: string
 }
 
 export type ResetUserStateAction = {
-  type: typeof RESET_USER_STATE
+  type: typeof UserAction.RESET_USER_STATE
 }
 
 export type ToggleUrlStateSuccessAction = {
-  type: typeof TOGGLE_URL_STATE_SUCCESS
+  type: typeof UserAction.TOGGLE_URL_STATE_SUCCESS
   payload: {
     shortUrl: string
     toState: UrlState
@@ -141,32 +144,32 @@ export type ToggleUrlStateSuccessAction = {
 }
 
 export type SetUrlTableConfigAction = {
-  type: typeof SET_URL_TABLE_CONFIG
+  type: typeof UserAction.SET_URL_TABLE_CONFIG
   payload: UrlTableConfig
 }
 
 export type UpdateUrlCountAction = {
-  type: typeof UPDATE_URL_COUNT
+  type: typeof UserAction.UPDATE_URL_COUNT
   payload: number
 }
 
 export type SetIsUploadingAction = {
-  type: typeof SET_IS_UPLOADING
+  type: typeof UserAction.SET_IS_UPLOADING
   payload: boolean
 }
 
 export type SetUploadFileErrorAction = {
-  type: typeof SET_UPLOAD_FILE_ERROR
+  type: typeof UserAction.SET_UPLOAD_FILE_ERROR
   payload: string
 }
 
 export type SetCreateShortLinkErrorAction = {
-  type: typeof SET_CREATE_SHORT_LINK_ERROR
+  type: typeof UserAction.SET_CREATE_SHORT_LINK_ERROR
   payload: string
 }
 
 export type SetUrlFilterAction = {
-  type: typeof SET_URL_FILTER
+  type: typeof UserAction.SET_URL_FILTER
   payload: UrlTableFilterConfig
 }
 

--- a/src/client/user/actions/types.ts
+++ b/src/client/user/actions/types.ts
@@ -36,22 +36,22 @@ export enum UserAction {
 }
 
 export type SetUrlUploadStateAction = {
-  type: typeof UserAction.SET_URL_UPLOAD_STATE
+  type: UserAction.SET_URL_UPLOAD_STATE
   payload: boolean
 }
 
 export type SetFileUploadStateAction = {
-  type: typeof UserAction.SET_FILE_UPLOAD_STATE
+  type: UserAction.SET_FILE_UPLOAD_STATE
   payload: boolean
 }
 
 export type SetUserMessageAction = {
-  type: typeof UserAction.SET_USER_MESSAGE
+  type: UserAction.SET_USER_MESSAGE
   payload: string
 }
 
 export type SetUserAnnouncementAction = {
-  type: typeof UserAction.SET_USER_ANNOUNCEMENT
+  type: UserAction.SET_USER_ANNOUNCEMENT
   payload: {
     message: string | undefined
     title: string | undefined
@@ -62,7 +62,7 @@ export type SetUserAnnouncementAction = {
 }
 
 export type SetEditedContactEmailAction = {
-  type: typeof UserAction.SET_EDITED_CONTACT_EMAIL
+  type: UserAction.SET_EDITED_CONTACT_EMAIL
   payload: {
     shortUrl: string
     editedContactEmail: string
@@ -70,7 +70,7 @@ export type SetEditedContactEmailAction = {
 }
 
 export type SetEditedDescriptionAction = {
-  type: typeof UserAction.SET_EDITED_DESCRIPTION
+  type: UserAction.SET_EDITED_DESCRIPTION
   payload: {
     shortUrl: string
     editedDescription: string
@@ -78,48 +78,48 @@ export type SetEditedDescriptionAction = {
 }
 
 export type SetLastCreatedLinkAction = {
-  type: typeof UserAction.SET_LAST_CREATED_LINK
+  type: UserAction.SET_LAST_CREATED_LINK
   payload: string
 }
 
 export type WipeUserStateAction = {
-  type: typeof UserAction.WIPE_USER_STATE
+  type: UserAction.WIPE_USER_STATE
 }
 
 export type IsFetchingUrlsAction = {
-  type: typeof UserAction.IS_FETCHING_URLS
+  type: UserAction.IS_FETCHING_URLS
   payload: boolean
 }
 
 export type CreateUrlSuccessAction = {
-  type: typeof UserAction.CREATE_URL_SUCCESS
+  type: UserAction.CREATE_URL_SUCCESS
 }
 
 export type GetUrlsForUserSuccessAction = {
-  type: typeof UserAction.GET_URLS_FOR_USER_SUCCESS
+  type: UserAction.GET_URLS_FOR_USER_SUCCESS
   payload: Array<UrlType>
 }
 
 export type OpenCreateUrlModalAction = {
-  type: typeof UserAction.OPEN_CREATE_URL_MODAL
+  type: UserAction.OPEN_CREATE_URL_MODAL
 }
 
 export type CloseCreateUrlModalAction = {
-  type: typeof UserAction.CLOSE_CREATE_URL_MODAL
+  type: UserAction.CLOSE_CREATE_URL_MODAL
 }
 
 export type SetShortUrlAction = {
-  type: typeof UserAction.SET_SHORT_URL
+  type: UserAction.SET_SHORT_URL
   payload: string
 }
 
 export type SetLongUrlAction = {
-  type: typeof UserAction.SET_LONG_URL
+  type: UserAction.SET_LONG_URL
   payload: string
 }
 
 export type SetEditedLongUrlAction = {
-  type: typeof UserAction.SET_EDITED_LONG_URL
+  type: UserAction.SET_EDITED_LONG_URL
   payload: {
     shortUrl: string
     editedLongUrl: string
@@ -127,16 +127,16 @@ export type SetEditedLongUrlAction = {
 }
 
 export type SetRandomShortUrlAction = {
-  type: typeof UserAction.SET_RANDOM_SHORT_URL
+  type: UserAction.SET_RANDOM_SHORT_URL
   payload: string
 }
 
 export type ResetUserStateAction = {
-  type: typeof UserAction.RESET_USER_STATE
+  type: UserAction.RESET_USER_STATE
 }
 
 export type ToggleUrlStateSuccessAction = {
-  type: typeof UserAction.TOGGLE_URL_STATE_SUCCESS
+  type: UserAction.TOGGLE_URL_STATE_SUCCESS
   payload: {
     shortUrl: string
     toState: UrlState
@@ -144,32 +144,32 @@ export type ToggleUrlStateSuccessAction = {
 }
 
 export type SetUrlTableConfigAction = {
-  type: typeof UserAction.SET_URL_TABLE_CONFIG
+  type: UserAction.SET_URL_TABLE_CONFIG
   payload: UrlTableConfig
 }
 
 export type UpdateUrlCountAction = {
-  type: typeof UserAction.UPDATE_URL_COUNT
+  type: UserAction.UPDATE_URL_COUNT
   payload: number
 }
 
 export type SetIsUploadingAction = {
-  type: typeof UserAction.SET_IS_UPLOADING
+  type: UserAction.SET_IS_UPLOADING
   payload: boolean
 }
 
 export type SetUploadFileErrorAction = {
-  type: typeof UserAction.SET_UPLOAD_FILE_ERROR
+  type: UserAction.SET_UPLOAD_FILE_ERROR
   payload: string
 }
 
 export type SetCreateShortLinkErrorAction = {
-  type: typeof UserAction.SET_CREATE_SHORT_LINK_ERROR
+  type: UserAction.SET_CREATE_SHORT_LINK_ERROR
   payload: string
 }
 
 export type SetUrlFilterAction = {
-  type: typeof UserAction.SET_URL_FILTER
+  type: UserAction.SET_URL_FILTER
   payload: UrlTableFilterConfig
 }
 

--- a/src/client/user/reducers/index.ts
+++ b/src/client/user/reducers/index.ts
@@ -1,30 +1,4 @@
-import {
-  CLOSE_CREATE_URL_MODAL,
-  GET_URLS_FOR_USER_SUCCESS,
-  IS_FETCHING_URLS,
-  OPEN_CREATE_URL_MODAL,
-  RESET_USER_STATE,
-  SET_CREATE_SHORT_LINK_ERROR,
-  SET_EDITED_CONTACT_EMAIL,
-  SET_EDITED_DESCRIPTION,
-  SET_EDITED_LONG_URL,
-  SET_FILE_UPLOAD_STATE,
-  SET_IS_UPLOADING,
-  SET_LAST_CREATED_LINK,
-  SET_LONG_URL,
-  SET_RANDOM_SHORT_URL,
-  SET_SHORT_URL,
-  SET_UPLOAD_FILE_ERROR,
-  SET_URL_FILTER,
-  SET_URL_TABLE_CONFIG,
-  SET_URL_UPLOAD_STATE,
-  SET_USER_ANNOUNCEMENT,
-  SET_USER_MESSAGE,
-  TOGGLE_URL_STATE_SUCCESS,
-  UPDATE_URL_COUNT,
-  UserActionType,
-  WIPE_USER_STATE,
-} from '../actions/types'
+import { UserAction, UserActionType } from '../actions/types'
 import { UserState } from './types'
 import { initialSortConfig } from '../constants'
 
@@ -61,58 +35,58 @@ const user: (state: UserState, action: UserActionType) => UserState = (
   let nextState: Partial<UserState> = {}
 
   switch (action.type) {
-    case SET_USER_MESSAGE:
+    case UserAction.SET_USER_MESSAGE:
       nextState = {
         message: action.payload,
       }
       break
-    case SET_USER_ANNOUNCEMENT:
+    case UserAction.SET_USER_ANNOUNCEMENT:
       nextState = {
         announcement: action.payload,
       }
       break
-    case SET_LAST_CREATED_LINK:
+    case UserAction.SET_LAST_CREATED_LINK:
       nextState = {
         lastCreatedLink: action.payload,
       }
       break
-    case SET_CREATE_SHORT_LINK_ERROR:
+    case UserAction.SET_CREATE_SHORT_LINK_ERROR:
       nextState = {
         createShortLinkError: action.payload,
       }
       break
-    case SET_UPLOAD_FILE_ERROR:
+    case UserAction.SET_UPLOAD_FILE_ERROR:
       nextState = {
         uploadFileError: action.payload,
       }
       break
-    case SET_IS_UPLOADING:
+    case UserAction.SET_IS_UPLOADING:
       nextState = {
         isUploading: action.payload,
       }
       break
-    case IS_FETCHING_URLS:
+    case UserAction.IS_FETCHING_URLS:
       nextState = {
         isFetchingUrls: action.payload,
       }
       break
-    case GET_URLS_FOR_USER_SUCCESS:
+    case UserAction.GET_URLS_FOR_USER_SUCCESS:
       nextState = {
         initialised: true,
         urls: action.payload,
       }
       break
-    case SET_SHORT_URL:
+    case UserAction.SET_SHORT_URL:
       nextState = {
         shortUrl: action.payload,
       }
       break
-    case SET_LONG_URL:
+    case UserAction.SET_LONG_URL:
       nextState = {
         longUrl: action.payload,
       }
       break
-    case SET_EDITED_LONG_URL: {
+    case UserAction.SET_EDITED_LONG_URL: {
       const { editedLongUrl, shortUrl } = action.payload
       nextState = {
         urls: state.urls.map((url) => {
@@ -127,7 +101,7 @@ const user: (state: UserState, action: UserActionType) => UserState = (
       }
       break
     }
-    case SET_EDITED_CONTACT_EMAIL: {
+    case UserAction.SET_EDITED_CONTACT_EMAIL: {
       const { editedContactEmail, shortUrl } = action.payload
       nextState = {
         urls: state.urls.map((url) => {
@@ -142,7 +116,7 @@ const user: (state: UserState, action: UserActionType) => UserState = (
       }
       break
     }
-    case SET_EDITED_DESCRIPTION: {
+    case UserAction.SET_EDITED_DESCRIPTION: {
       const { editedDescription, shortUrl } = action.payload
       nextState = {
         urls: state.urls.map((url) => {
@@ -157,23 +131,23 @@ const user: (state: UserState, action: UserActionType) => UserState = (
       }
       break
     }
-    case SET_RANDOM_SHORT_URL:
+    case UserAction.SET_RANDOM_SHORT_URL:
       nextState = {
         shortUrl: action.payload,
       }
       break
-    case RESET_USER_STATE:
+    case UserAction.RESET_USER_STATE:
       nextState = {
         shortUrl: '',
         longUrl: '',
       }
       break
-    case WIPE_USER_STATE:
+    case UserAction.WIPE_USER_STATE:
       nextState = {
         ...initialState,
       }
       break
-    case TOGGLE_URL_STATE_SUCCESS: {
+    case UserAction.TOGGLE_URL_STATE_SUCCESS: {
       const { shortUrl, toState } = action.payload
 
       nextState = {
@@ -189,17 +163,17 @@ const user: (state: UserState, action: UserActionType) => UserState = (
       }
       break
     }
-    case OPEN_CREATE_URL_MODAL:
+    case UserAction.OPEN_CREATE_URL_MODAL:
       nextState = {
         createUrlModal: true,
       }
       break
-    case CLOSE_CREATE_URL_MODAL:
+    case UserAction.CLOSE_CREATE_URL_MODAL:
       nextState = {
         createUrlModal: false,
       }
       break
-    case SET_URL_TABLE_CONFIG:
+    case UserAction.SET_URL_TABLE_CONFIG:
       nextState = {
         tableConfig: {
           ...state.tableConfig,
@@ -207,7 +181,7 @@ const user: (state: UserState, action: UserActionType) => UserState = (
         },
       }
       break
-    case SET_URL_FILTER:
+    case UserAction.SET_URL_FILTER:
       nextState = {
         tableConfig: {
           ...state.tableConfig,
@@ -216,12 +190,12 @@ const user: (state: UserState, action: UserActionType) => UserState = (
         },
       }
       break
-    case UPDATE_URL_COUNT:
+    case UserAction.UPDATE_URL_COUNT:
       nextState = {
         urlCount: action.payload,
       }
       break
-    case SET_URL_UPLOAD_STATE:
+    case UserAction.SET_URL_UPLOAD_STATE:
       nextState = {
         uploadState: {
           ...state.uploadState,
@@ -229,7 +203,7 @@ const user: (state: UserState, action: UserActionType) => UserState = (
         },
       }
       break
-    case SET_FILE_UPLOAD_STATE:
+    case UserAction.SET_FILE_UPLOAD_STATE:
       nextState = {
         uploadState: {
           ...state.uploadState,


### PR DESCRIPTION
## Problem

Import bloat in `src/client/user/actions/index.ts` due to actions being stored as constant value strings in `src/client/user/actions/types.ts`

Closes #937

## Solution

Replace constant value strings with `UserAction` [String Enum](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) as suggested in issue.

## Tests

`npm run build` compiled successfully.

First time contributing to this repo, kindly let me if there are areas I can improve in.