### PR TITLE
chore(robots): disallow NLB crawler from parsing beyond the application bundle

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,7 @@
-User-agent: *
-Disallow: /bundle.js
+User-agent: NLB_archive_bot
+
+Allow: /
+Allow: /bundle.js
+Allow: /css*
+Allow: /assets/*
+Disallow: *

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /bundle.js

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,8 @@ User-agent: NLB_archive_bot
 
 Allow: /
 Allow: /bundle.js
-Allow: /css*
+Allow: /css2
 Allow: /assets/*
+Allow: /s/*.woff2$
+Allow: /favicon.ico
 Disallow: *


### PR DESCRIPTION
Keep crawlers away from bundle.js as there are no real links in here