### PR TITLE
fix(gitpod): specify user for DB_URI

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -15,7 +15,7 @@ USER gitpod
 
 ENV NODE_ENV=development
 ENV PORT=8080
-ENV DB_URI=postgres://0.0.0.0:5432/postgres
+ENV DB_URI=postgres://gitpod@0.0.0.0:5432/postgres
 ENV REDIS_OTP_URI=redis://0.0.0.0:6379/0
 ENV REDIS_SESSION_URI=redis://0.0.0.0:6379/1
 ENV REDIS_REDIRECT_URI=redis://0.0.0.0:6379/2


### PR DESCRIPTION
## Problem

Gitpod broke with a recent update to pg, which required specifying the user in the database url

## Solution

Specify the default user for gitpod postgres in `DB_URI`