### PR TITLE
fix(qr): change postbuild cmd to incorporate assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "npm run lint-js && npm run lint-ts",
     "lint:fix": "npm run lint-js:fix && npm run lint-ts:fix",
     "build": "tsc && webpack --mode production",
-    "postbuild": "copyfiles -u 1 src/server/views/**/* build && copyfiles -u 4 src/server/services/QrCodeService/assets/**/* build/server/services/QrCodeService",
+    "postbuild": "copyfiles -u 1 src/server/views/**/* build && copyfiles -u 4 src/server/modules/qr/assets/**/* build/server/modules/qr",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "start": "node build/server/index.js",
     "client-dev": "webpack serve --mode development --host 0.0.0.0 --devtool inline-source-map --hot",


### PR DESCRIPTION
## Problem

A recent PR broke the package.json postbuild script, which relied on a hardcoded path

## Solution

Fix the path