### PR TITLE
Url click table migration cleanup

### DIFF
--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -184,9 +184,7 @@ export const Url = <UrlTypeStatic>sequelize.define(
             shortUrl: url.shortUrl,
             clicks: 0,
           },
-          options as Sequelize.CreateOptions & {
-            transaction: Sequelize.Transaction
-          },
+          options,
         )
         return Promise.resolve()
       },

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -179,10 +179,10 @@ export const Url = <UrlTypeStatic>sequelize.define(
           },
         )
 
-        // TODO: change to create after DB triggers are removed.
-        await UrlClicks.upsert(
+        await UrlClicks.create(
           {
             shortUrl: url.shortUrl,
+            clicks: 0,
           },
           options as Sequelize.CreateOptions & {
             transaction: Sequelize.Transaction

--- a/src/server/modules/qr/QrCodeController.ts
+++ b/src/server/modules/qr/QrCodeController.ts
@@ -28,7 +28,7 @@ export class QrCodeController {
   private shortUrlExists: (shortUrl: string) => Promise<boolean> = async (
     shortUrl,
   ) => {
-    return !!(await this.urlRepository.findByShortUrl(shortUrl))
+    return !!(await this.urlRepository.findByShortUrlWithTotalClicks(shortUrl))
   }
 
   createGoQrCode: (req: Request, res: Response) => Promise<void> = async (

--- a/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
+++ b/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
@@ -18,7 +18,7 @@ describe('UrlManagementService', () => {
   const urlRepository = {
     update: jest.fn(),
     create: jest.fn(),
-    findByShortUrl: jest.fn(),
+    findByShortUrlWithTotalClicks: jest.fn(),
     getLongUrl: jest.fn(),
     plainTextSearch: jest.fn(),
     rawDirectorySearch: jest.fn(),
@@ -34,7 +34,7 @@ describe('UrlManagementService', () => {
     beforeEach(() => {
       userRepository.findById.mockReset()
       userRepository.findUserByUrl.mockReset()
-      urlRepository.findByShortUrl.mockReset()
+      urlRepository.findByShortUrlWithTotalClicks.mockReset()
       urlRepository.create.mockReset()
     })
 
@@ -65,7 +65,7 @@ describe('UrlManagementService', () => {
 
     it('processes new non-file url', async () => {
       userRepository.findById.mockResolvedValue({ id: userId })
-      urlRepository.findByShortUrl.mockResolvedValue(null)
+      urlRepository.findByShortUrlWithTotalClicks.mockResolvedValue(null)
       urlRepository.create.mockResolvedValue({ userId, longUrl, shortUrl })
       await expect(
         service.createUrl(userId, shortUrl, longUrl),
@@ -85,7 +85,7 @@ describe('UrlManagementService', () => {
         mimetype: 'application/json',
       }
       userRepository.findById.mockResolvedValue({ id: userId })
-      urlRepository.findByShortUrl.mockResolvedValue(null)
+      urlRepository.findByShortUrlWithTotalClicks.mockResolvedValue(null)
       urlRepository.create.mockResolvedValue({ userId, longUrl, shortUrl })
       await expect(
         service.createUrl(userId, shortUrl, longUrl, file),

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -44,7 +44,7 @@ export class UrlRepository implements UrlRepositoryInterface {
     this.urlMapper = urlMapper
   }
 
-  public findByShortUrl: (
+  public findByShortUrlWithTotalClicks: (
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (shortUrl) => {
     const url = await Url.scope('getClicks').findOne({

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -5,7 +5,7 @@ import { DirectoryQueryConditions } from '../../modules/directory'
  * A url repository that handles access to the data store of Urls.
  */
 export interface UrlRepositoryInterface {
-  findByShortUrl(shortUrl: string): Promise<StorableUrl | null>
+  findByShortUrlWithTotalClicks(shortUrl: string): Promise<StorableUrl | null>
 
   /**
    * Updates the input url with the input changes and file (if any) in the data store.

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -14,7 +14,7 @@ import { DirectoryQueryConditions } from '../../../../src/server/modules/directo
 
 @injectable()
 export class UrlRepositoryMock implements UrlRepositoryInterface {
-  findByShortUrl: (shortUrl: string) => Promise<StorableUrl | null> = () => {
+  findByShortUrlWithTotalClicks: (shortUrl: string) => Promise<StorableUrl | null> = () => {
     throw new Error('Not implemented')
   }
 

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -14,7 +14,9 @@ import { DirectoryQueryConditions } from '../../../../src/server/modules/directo
 
 @injectable()
 export class UrlRepositoryMock implements UrlRepositoryInterface {
-  findByShortUrlWithTotalClicks: (shortUrl: string) => Promise<StorableUrl | null> = () => {
+  findByShortUrlWithTotalClicks: (
+    shortUrl: string,
+  ) => Promise<StorableUrl | null> = () => {
     throw new Error('Not implemented')
   }
 

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -93,7 +93,7 @@ describe('UrlRepository', () => {
     try {
       const shortUrl = 'abcdef'
       findOne.mockResolvedValue(null)
-      await expect(repository.findByShortUrl(shortUrl)).resolves.toBeNull()
+      await expect(repository.findByShortUrlWithTotalClicks(shortUrl)).resolves.toBeNull()
       expect(findOne).toHaveBeenCalledWith({ where: { shortUrl } })
     } finally {
       // Deliberately not call findOne.mockRestore(), as it seems

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -93,7 +93,9 @@ describe('UrlRepository', () => {
     try {
       const shortUrl = 'abcdef'
       findOne.mockResolvedValue(null)
-      await expect(repository.findByShortUrlWithTotalClicks(shortUrl)).resolves.toBeNull()
+      await expect(
+        repository.findByShortUrlWithTotalClicks(shortUrl),
+      ).resolves.toBeNull()
       expect(findOne).toHaveBeenCalledWith({ where: { shortUrl } })
     } finally {
       // Deliberately not call findOne.mockRestore(), as it seems


### PR DESCRIPTION
## Problem

There are a few outstanding issues surrounding the url click table migration that needs to be cleaned up.

Closes #1097 

## Solution

- Change `upsert` to `create` in url's onCreate hook
- Remove unnecessary typecast of the transition object in `create`
- Rename `findByUrl` to `findByUrlWithTotalClicks` for better clarity


