### PR TITLE
fix(ci): use existing eb package for edu, if exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,5 +272,6 @@ jobs:
           version_label: ${{ steps.get_label.outputs.label }}
           region: ap-southeast-1
           deployment_package: deploy.zip
+          use_existing_version_if_available: true
           wait_for_deployment: false
           wait_for_environment_recovery: false


### PR DESCRIPTION
## Problem 

the EB deployment for edu fails because it tries to create an application deployment package that already exists

## Solution

re-use where possible