### PR TITLE
chore(gitpod): use last working version of LocalStack

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,7 +9,8 @@ RUN sudo apt-get update \
 RUN sudo mkdir -p /docker-entrypoint-initaws.d
 RUN sudo chown gitpod /docker-entrypoint-initaws.d
 
-RUN pip install "localstack[full]"
+# Use last known working version of LocalStack
+RUN pip install "localstack[full]==0.11.3"
 
 USER gitpod
 


### PR DESCRIPTION
## Problem

LocalStack 0.12.x is currently not working with GitPod

## Solution

Fallback to version that is specified in docker-compose.yml