### PR TITLE
chore(gitpod): roll even further back to localstack 0.11.2

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -10,7 +10,7 @@ RUN sudo mkdir -p /docker-entrypoint-initaws.d
 RUN sudo chown gitpod /docker-entrypoint-initaws.d
 
 # Use last known working version of LocalStack
-RUN pip install "localstack[full]==0.11.3"
+RUN pip install "localstack[full]==0.11.2"
 
 USER gitpod
 


### PR DESCRIPTION
## Problem

localstack continues to pose problems for gitpod

## Solution

roll even further back to localstack 0.11.2