### PR TITLE
fix(LongUrlEditor): strip protocol from long URL

### DIFF
--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -27,7 +27,9 @@ export default function LongUrlEditor() {
       leading={
         <PrefixableTextField
           value={editedLongUrl}
-          onChange={(event) => setEditedLongUrl(event.target.value)}
+          onChange={(event) =>
+            setEditedLongUrl(removeHttpsProtocol(event.target.value))
+          }
           placeholder="Original link"
           prefix="https://"
           error={!isValidLongUrl(editedLongUrl, true)}


### PR DESCRIPTION
## Problem

When editing the long URL in `LongUrlEditor`, the protocol is not automatically stripped. This behaviour does not match that of the link creation modal.

Closes #1092

## Solution

**Bug Fixes**:

- Strip the protocol from the long URL before updating the state of the `LongUrlEditor`.

## Tests

**Protocol should be stripped when editing the long URL in `LongUrlEditor`**:
1. Deploy the change
2. Change the long URL of an existing link to one prefixed with `http://` or `https://`
3. The prefix should be automatically stripped