### PR TITLE
refactor(pages): drop govtech-sgds via jsdelivr

### DIFF
--- a/public/assets/not-found-page/styles/not-found-page.css
+++ b/public/assets/not-found-page/styles/not-found-page.css
@@ -40,6 +40,36 @@ img {
   padding: 6px 30px;
 }
 
+.sgds-masthead {
+  position: relative;
+  background-color: #f0f0f0;
+  height: auto;
+  font-size: 14px
+}
+
+.sgds-masthead .sgds-icon {
+  font-size: 20px
+}
+
+.sgds-masthead a {
+  color: #484848;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.sgds-masthead .is-text {
+  margin-left: 4px;
+}
+
+.sgds-masthead a:hover {
+  color: #151515
+}
+
+#main-message p {
+  line-height: 2rem;
+}
+
 #main-container {
   margin-top: 10vh;
   margin-bottom: 10vh;

--- a/public/assets/transition-page/styles/transition-page.css
+++ b/public/assets/transition-page/styles/transition-page.css
@@ -15,6 +15,36 @@ body {
   padding: 6px 30px;
 }
 
+.sgds-masthead {
+  position: relative;
+  background-color: #f0f0f0;
+  height: auto;
+  font-size: 14px
+}
+
+.sgds-masthead .sgds-icon {
+  font-size: 20px
+}
+
+.sgds-masthead a {
+  color: #484848;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.sgds-masthead .is-text {
+  margin-left: 4px;
+}
+
+.sgds-masthead a:hover {
+  color: #151515
+}
+
+#main-message p {
+  line-height: 2rem;
+}
+
 .top-half {
   background: #384a51;
   height: 50vh;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -92,13 +92,8 @@ app.use(
           "'self'",
           "'unsafe-inline'",
           'https://fonts.googleapis.com/',
-          'https://cdn.jsdelivr.net/',
         ],
-        fontSrc: [
-          "'self'",
-          'https://fonts.gstatic.com/',
-          'https://cdn.jsdelivr.net/',
-        ],
+        fontSrc: ["'self'", 'https://fonts.gstatic.com/'],
         imgSrc: [
           "'self'",
           'data:',

--- a/src/server/views/404.error.ejs
+++ b/src/server/views/404.error.ejs
@@ -9,7 +9,6 @@
     <title>Go.gov.sg: Page not found</title>
     <base href="~/" />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.13/css/sgds.css">
     <link href="/assets/not-found-page/styles/not-found-page.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 </head>
@@ -17,7 +16,7 @@
 <body>
     <div class="sgds-masthead masthead-root">
         <a href="https://www.gov.sg" target="_blank" rel=”noreferrer noopener”>
-            <span class="sgds-icon sgds-icon-sg-crest"></span>
+            <img src="/assets/lion-head-symbol.svg" />
             <span class="is-text">A Singapore Government Agency Website</span>
         </a>
     </div>

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -8,7 +8,6 @@
     <meta charset="UTF-8">
     <title>Go.gov.sg</title>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.13/css/sgds.css">
     <link href="/assets/transition-page/styles/transition-page.css" rel="stylesheet">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -17,7 +16,7 @@
 <body>
     <div class="sgds-masthead masthead-root">
         <a href="https://www.gov.sg" target="_blank" rel=”noreferrer noopener”>
-            <span class="sgds-icon sgds-icon-sg-crest"></span>
+            <img src="/assets/lion-head-symbol.svg" />
             <span class="is-text">A Singapore Government Agency Website</span>
         </a>
     </div>


### PR DESCRIPTION
## Problem

The transition and 404 pages currently have a dependency on
govtech-sgds, delivered via cdn.jsdelivr.com. While convenient, this
needs an entry on our CSP to allow jsdelivr, which malicious actors
might take advantage of.

## Solution

- Replace govtech-sgds with CSS specific to the masthead, and the
  Lion Head Symbol introduced earlier
- Remove jsdelivr entries in CSP
