### PR TITLE
fix(masthead): add default asset variant for masthead

### DIFF
--- a/src/client/app/components/BaseLayout/index.tsx
+++ b/src/client/app/components/BaseLayout/index.tsx
@@ -19,7 +19,8 @@ import { USER_PAGE } from '../../util/types'
 import Banner from './widgets/Banner'
 import { GoGovReduxState } from '../../reducers/types'
 
-const displayMasthead = process.env.ASSET_VARIANT === 'gov'
+const assetVariant = process.env.ASSET_VARIANT === 'edu' ? 'edu' : 'gov'
+const displayMasthead = assetVariant === 'gov'
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/src/client/app/components/BaseLayout/index.tsx
+++ b/src/client/app/components/BaseLayout/index.tsx
@@ -19,7 +19,7 @@ import { USER_PAGE } from '../../util/types'
 import Banner from './widgets/Banner'
 import { GoGovReduxState } from '../../reducers/types'
 
-const assetVariant = process.env.ASSET_VARIANT === 'edu' ? 'edu' : 'gov'
+const assetVariant = process.env.ASSET_VARIANT || 'gov'
 const displayMasthead = assetVariant === 'gov'
 
 const useStyles = makeStyles(() =>


### PR DESCRIPTION
## Problem

Masthead does not show up if `ASSET_VARIANT` env var is not set

## Solution

Added defaults to use 'gov' as default value for `ASSET_VARIANT`
