### PR TITLE
fix(qr-fonts): implement ibm plex sans for qrcode url

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,6 +9,10 @@ RUN sudo apt-get update \
 RUN sudo mkdir -p /docker-entrypoint-initaws.d
 RUN sudo chown gitpod /docker-entrypoint-initaws.d
 
+# Installs IBMPlexSans-Regular.ttf for QRCodeService.
+RUN sudo wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/truetype/IBMPlexSans-Regular.ttf
+RUN sudo fc-cache -f
+
 USER gitpod
 
 ENV NODE_ENV=development
@@ -37,10 +41,6 @@ ENV AWS_SECRET_ACCESS_KEY=foobar
 ENV PORT_WEB_UI=8055
 
 ENV BUCKET_ENDPOINT=http://localhost:4566
-
-# Installs IBMPlexSans-Regular.ttf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/truetype/IBMPlexSans-Regular.ttf
-RUN fc-cache -f
 
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
 RUN chmod 755 /tmp/wait-for-it.sh

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -38,5 +38,9 @@ ENV PORT_WEB_UI=8055
 
 ENV BUCKET_ENDPOINT=http://localhost:4566
 
+# Installs IBMPlexSans-Regular.ttf for QRCodeService.
+RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/TTF/IBMPlexSans-Regular.ttf
+RUN fc-cache -f
+
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
 RUN chmod 755 /tmp/wait-for-it.sh

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -39,7 +39,7 @@ ENV PORT_WEB_UI=8055
 ENV BUCKET_ENDPOINT=http://localhost:4566
 
 # Installs IBMPlexSans-Regular.ttf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/TTF/IBMPlexSans-Regular.ttf
+RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/truetype/IBMPlexSans-Regular.ttf
 RUN fc-cache -f
 
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ EXPOSE 3000
 
 RUN apk update && apk add ttf-freefont && rm -rf /var/cache/apk/*
 
+# Installs IBMPlexSans-Regular.ttf for QRCodeService.
+RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/TTF/IBMPlexSans-Regular.ttf
+RUN fc-cache -f
+
 # Install libraries
 COPY package.json package-lock.json ./
 

--- a/src/server/modules/qr/services/QrCodeService.ts
+++ b/src/server/modules/qr/services/QrCodeService.ts
@@ -63,6 +63,18 @@ export class QrCodeService implements interfaces.QrCodeService {
       .attr('height', `${imageHeight}`)
       .attr('xmlns', 'http://www.w3.org/2000/svg')
 
+    // Sources IBM Plex Sans font from Google Fonts and defines the text style.
+    // This only affects QRCodes that are exported to SVGs.
+    // Note that sharp sources the font file from the Docker container that the
+    // instance is run on. Refer to Dockerfile for the installation.
+    svg.append(
+      `<defs>
+        <style type="text/css">
+          @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&amp;display=swap");
+        </style>
+      </defs>`,
+    )
+
     // Provides the entire graphic with a white background.
     svg.append('<rect></rect>')
     dom('rect')
@@ -114,7 +126,7 @@ export class QrCodeService implements interfaces.QrCodeService {
         .attr('x', `${textLocationX}`)
         .attr('y', `${textLocationY + i * FONT_SIZE * LINE_HEIGHT}`)
         .attr('text-anchor', 'middle')
-        .attr('font-family', 'sans-serif')
+        .attr('font-family', 'IBM Plex Sans, sans-serif')
         .attr('font-weight', '400')
         .attr('font-size', `${FONT_SIZE}px`)
         .text(line)


### PR DESCRIPTION
## Problem

Currently, the font used in qr-code generation does not sufficiently distinguish between (capital i) `I`,`1` and (lowercase L) `l`.

Closes #433

## Solution

Implement IBM Plex Sans as the font for qr code generation instead of the default sans-serif font.

- added appropriate styles to qr generation in `QRCodeService` to render IBM Plex Sans Regular
- added wget command in Dockerfile to install IBM Plex Sans Regular in the container instance to give
sharp access to the font

## Screenshots

### Before
![https __go gov sg_il1il1i1l1i1i1i1i1111ll1l111-1](https://user-images.githubusercontent.com/21305518/111440281-264aea80-8741-11eb-8018-5e80ed96ee1d.png)

### After
![https __go gov sg_il1il1i1l1i1i1i1i1111ll1l111](https://user-images.githubusercontent.com/21305518/111439248-226a9880-8740-11eb-8445-c20ef47228cf.png)

## Deploy Notes

Note that IBM Plex Sans is sourced from Google Fonts when exporting to SVG, while sharp uses a container-installed instance of the same font from IBM's Plex typeface repository ([link](https://github.com/IBM/plex)).

As such, modifications have been made to the appropriate Dockerfiles to get the container instance to download the appropriate font and subsequently install via `fc-cache -f`, which force rebuilds the font configurations on Alpine Linux.