### PR TITLE
build(webpack): remove spurious . from assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = () => {
       path: path.join(__dirname, outputDirectory),
       filename: 'bundle.js',
       publicPath: '/',
-      assetModuleFilename: 'assets/[name].[ext]',
+      assetModuleFilename: 'assets/[name][ext]',
     },
     resolve: {
       extensions: ['.jsx', '.js', '.tsx', '.ts', '.json', '.png', '.svg'],


### PR DESCRIPTION
## Problem and Solution

webpack 5 prepends `[ext]` with a `.` in file naming, so remove the 
one we explicitly put in, since we are no longer in webpack 4