### PR TITLE
refactor(redux-actions): refactor redux types to use generics

### DIFF
--- a/src/client/app/actions/types.ts
+++ b/src/client/app/actions/types.ts
@@ -23,4 +23,7 @@ export interface HasPayload<P> {
   payload: P
 }
 
+export type ReduxPayloadAction<T extends string, P> = ReduxAction<T> &
+  HasPayload<P>
+
 export type AllThunkDispatch = ThunkDispatch<GoGovReduxState, void, AllActions>

--- a/src/client/app/actions/types.ts
+++ b/src/client/app/actions/types.ts
@@ -15,4 +15,12 @@ export type AllActions =
   | HomeActionType
   | DirectoryActionType
 
+export interface ReduxAction<T extends string> {
+  type: T
+}
+
+export interface HasPayload<P> {
+  payload: P
+}
+
 export type AllThunkDispatch = ThunkDispatch<GoGovReduxState, void, AllActions>

--- a/src/client/directory/actions/types.ts
+++ b/src/client/directory/actions/types.ts
@@ -1,21 +1,20 @@
 import { UrlTypePublic } from '../reducers/types'
+import { HasPayload, ReduxAction } from '../../app/actions/types'
 
 export const SET_DIRECTORY_RESULTS = 'SET_DIRECTORY_RESULTS'
 export const SET_DIRECTORY_TABLE_CONFIG = 'SET_DIRECTORY_TABLE_CONFIG'
 export const SET_INITIAL_STATE = 'SET_INITIAL_STATE'
 
-export type SetDirectoryResultsAction = {
-  type: typeof SET_DIRECTORY_RESULTS
-  payload: {
+export type SetDirectoryResultsAction = ReduxAction<
+  typeof SET_DIRECTORY_RESULTS
+> &
+  HasPayload<{
     urls: Array<UrlTypePublic>
     count: number
     query: string
-  }
-}
+  }>
 
-export type ResetDirectoryResultsAction = {
-  type: typeof SET_INITIAL_STATE
-}
+export type ResetDirectoryResultsAction = ReduxAction<typeof SET_INITIAL_STATE>
 
 export type DirectoryActionType =
   | SetDirectoryResultsAction

--- a/src/client/directory/actions/types.ts
+++ b/src/client/directory/actions/types.ts
@@ -1,18 +1,18 @@
 import { UrlTypePublic } from '../reducers/types'
-import { HasPayload, ReduxAction } from '../../app/actions/types'
+import { ReduxAction, ReduxPayloadAction } from '../../app/actions/types'
 
 export const SET_DIRECTORY_RESULTS = 'SET_DIRECTORY_RESULTS'
 export const SET_DIRECTORY_TABLE_CONFIG = 'SET_DIRECTORY_TABLE_CONFIG'
 export const SET_INITIAL_STATE = 'SET_INITIAL_STATE'
 
-export type SetDirectoryResultsAction = ReduxAction<
-  typeof SET_DIRECTORY_RESULTS
-> &
-  HasPayload<{
+export type SetDirectoryResultsAction = ReduxPayloadAction<
+  typeof SET_DIRECTORY_RESULTS,
+  {
     urls: Array<UrlTypePublic>
     count: number
     query: string
-  }>
+  }
+>
 
 export type ResetDirectoryResultsAction = ReduxAction<typeof SET_INITIAL_STATE>
 

--- a/src/client/home/actions/types.ts
+++ b/src/client/home/actions/types.ts
@@ -1,16 +1,13 @@
 import { HomeStatistics, LinksToRotate } from '../reducers/types'
+import { HasPayload, ReduxAction } from '../../app/actions/types'
 
 export const LOAD_STATS = 'LOAD_STATS'
 export const SET_LINKS_TO_ROTATE = 'SET_LINKS_TO_ROTATE'
 
-export type LoadStatsAction = {
-  type: typeof LOAD_STATS
-  payload: HomeStatistics
-}
+export type LoadStatsAction = ReduxAction<typeof LOAD_STATS> &
+  HasPayload<HomeStatistics>
 
-export type SetLinksToRotateAction = {
-  type: typeof SET_LINKS_TO_ROTATE
-  payload: LinksToRotate
-}
+export type SetLinksToRotateAction = ReduxAction<typeof SET_LINKS_TO_ROTATE> &
+  HasPayload<LinksToRotate>
 
 export type HomeActionType = SetLinksToRotateAction | LoadStatsAction

--- a/src/client/home/actions/types.ts
+++ b/src/client/home/actions/types.ts
@@ -1,13 +1,17 @@
 import { HomeStatistics, LinksToRotate } from '../reducers/types'
-import { HasPayload, ReduxAction } from '../../app/actions/types'
+import { ReduxPayloadAction } from '../../app/actions/types'
 
 export const LOAD_STATS = 'LOAD_STATS'
 export const SET_LINKS_TO_ROTATE = 'SET_LINKS_TO_ROTATE'
 
-export type LoadStatsAction = ReduxAction<typeof LOAD_STATS> &
-  HasPayload<HomeStatistics>
+export type LoadStatsAction = ReduxPayloadAction<
+  typeof LOAD_STATS,
+  HomeStatistics
+>
 
-export type SetLinksToRotateAction = ReduxAction<typeof SET_LINKS_TO_ROTATE> &
-  HasPayload<LinksToRotate>
+export type SetLinksToRotateAction = ReduxPayloadAction<
+  typeof SET_LINKS_TO_ROTATE,
+  LinksToRotate
+>
 
 export type HomeActionType = SetLinksToRotateAction | LoadStatsAction

--- a/src/client/login/actions/types.ts
+++ b/src/client/login/actions/types.ts
@@ -1,3 +1,5 @@
+import { HasPayload, ReduxAction } from '../../app/actions/types'
+
 export const GET_OTP_EMAIL_SUCCESS = 'GET_OTP_EMAIL_SUCCESS'
 export const GET_OTP_EMAIL_PENDING = 'GET_OTP_EMAIL_PENDING'
 export const GET_OTP_EMAIL_ERROR = 'GET_OTP_EMAIL_ERROR'
@@ -9,49 +11,33 @@ export const SET_EMAIL_VALIDATOR = 'SET_EMAIL_VALIDATOR'
 export const IS_LOGGED_IN_SUCCESS = 'IS_LOGGED_IN_SUCCESS'
 export const IS_LOGGED_OUT = 'IS_LOGGED_OUT'
 
-export type GetOtpEmailSuccessAction = {
-  type: typeof GET_OTP_EMAIL_SUCCESS
-  payload: string
-}
+export type GetOtpEmailSuccessAction = ReduxAction<
+  typeof GET_OTP_EMAIL_SUCCESS
+> &
+  HasPayload<string>
 
-export type GetOtpEmailPendingAction = {
-  type: typeof GET_OTP_EMAIL_PENDING
-}
+export type GetOtpEmailPendingAction = ReduxAction<typeof GET_OTP_EMAIL_PENDING>
 
-export type GetOtpEmailErrorAction = {
-  type: typeof GET_OTP_EMAIL_ERROR
-}
+export type GetOtpEmailErrorAction = ReduxAction<typeof GET_OTP_EMAIL_ERROR> &
+  HasPayload<string | undefined>
 
-export type VerifyOtpErrorAction = {
-  type: typeof VERIFY_OTP_ERROR
-}
+export type VerifyOtpErrorAction = ReduxAction<typeof VERIFY_OTP_ERROR>
 
-export type VerifyOtpPendingAction = {
-  type: typeof VERIFY_OTP_PENDING
-}
-export type ResendOtpPendingAction = {
-  type: typeof RESEND_OTP_PENDING
-}
+export type VerifyOtpPendingAction = ReduxAction<typeof VERIFY_OTP_PENDING>
 
-export type ResendOtpDisabledAction = {
-  type: typeof RESEND_OTP_DISABLED
-}
+export type ResendOtpPendingAction = ReduxAction<typeof RESEND_OTP_PENDING>
+
+export type ResendOtpDisabledAction = ReduxAction<typeof RESEND_OTP_DISABLED>
 
 export type EmailValidatorType = (email: string) => boolean
 
-export type SetEmailValidatorAction = {
-  type: typeof SET_EMAIL_VALIDATOR
-  payload: EmailValidatorType
-}
+export type SetEmailValidatorAction = ReduxAction<typeof SET_EMAIL_VALIDATOR> &
+  HasPayload<EmailValidatorType>
 
-export type IsLoggedInSuccessAction = {
-  type: typeof IS_LOGGED_IN_SUCCESS
-  payload: { id: string }
-}
+export type IsLoggedInSuccessAction = ReduxAction<typeof IS_LOGGED_IN_SUCCESS> &
+  HasPayload<{ id: string }>
 
-export type IsLoggedOutAction = {
-  type: typeof IS_LOGGED_OUT
-}
+export type IsLoggedOutAction = ReduxAction<typeof IS_LOGGED_OUT>
 
 export type LoginActionType =
   | IsLoggedOutAction

--- a/src/client/login/actions/types.ts
+++ b/src/client/login/actions/types.ts
@@ -1,4 +1,4 @@
-import { HasPayload, ReduxAction } from '../../app/actions/types'
+import { ReduxAction, ReduxPayloadAction } from '../../app/actions/types'
 
 export const GET_OTP_EMAIL_SUCCESS = 'GET_OTP_EMAIL_SUCCESS'
 export const GET_OTP_EMAIL_PENDING = 'GET_OTP_EMAIL_PENDING'
@@ -11,15 +11,17 @@ export const SET_EMAIL_VALIDATOR = 'SET_EMAIL_VALIDATOR'
 export const IS_LOGGED_IN_SUCCESS = 'IS_LOGGED_IN_SUCCESS'
 export const IS_LOGGED_OUT = 'IS_LOGGED_OUT'
 
-export type GetOtpEmailSuccessAction = ReduxAction<
-  typeof GET_OTP_EMAIL_SUCCESS
-> &
-  HasPayload<string>
+export type GetOtpEmailSuccessAction = ReduxPayloadAction<
+  typeof GET_OTP_EMAIL_SUCCESS,
+  string
+>
 
 export type GetOtpEmailPendingAction = ReduxAction<typeof GET_OTP_EMAIL_PENDING>
 
-export type GetOtpEmailErrorAction = ReduxAction<typeof GET_OTP_EMAIL_ERROR> &
-  HasPayload<string | undefined>
+export type GetOtpEmailErrorAction = ReduxPayloadAction<
+  typeof GET_OTP_EMAIL_ERROR,
+  string | undefined
+>
 
 export type VerifyOtpErrorAction = ReduxAction<typeof VERIFY_OTP_ERROR>
 
@@ -31,11 +33,15 @@ export type ResendOtpDisabledAction = ReduxAction<typeof RESEND_OTP_DISABLED>
 
 export type EmailValidatorType = (email: string) => boolean
 
-export type SetEmailValidatorAction = ReduxAction<typeof SET_EMAIL_VALIDATOR> &
-  HasPayload<EmailValidatorType>
+export type SetEmailValidatorAction = ReduxPayloadAction<
+  typeof SET_EMAIL_VALIDATOR,
+  EmailValidatorType
+>
 
-export type IsLoggedInSuccessAction = ReduxAction<typeof IS_LOGGED_IN_SUCCESS> &
-  HasPayload<{ id: string }>
+export type IsLoggedInSuccessAction = ReduxPayloadAction<
+  typeof IS_LOGGED_IN_SUCCESS,
+  { id: string }
+>
 
 export type IsLoggedOutAction = ReduxAction<typeof IS_LOGGED_OUT>
 

--- a/src/client/user/actions/types.ts
+++ b/src/client/user/actions/types.ts
@@ -5,7 +5,7 @@ import {
   UrlType,
 } from '../reducers/types'
 
-import { HasPayload, ReduxAction } from '../../app/actions/types'
+import { ReduxAction, ReduxPayloadAction } from '../../app/actions/types'
 
 /* User actions */
 
@@ -37,68 +37,68 @@ export enum UserAction {
   SET_FILE_UPLOAD_STATE = 'SET_FILE_UPLOAD_STATE',
 }
 
-export type SetUrlUploadStateAction = ReduxAction<
-  typeof UserAction.SET_URL_UPLOAD_STATE
-> &
-  HasPayload<boolean>
+export type SetUrlUploadStateAction = ReduxPayloadAction<
+  typeof UserAction.SET_URL_UPLOAD_STATE,
+  boolean
+>
 
-export type SetFileUploadStateAction = ReduxAction<
-  typeof UserAction.SET_FILE_UPLOAD_STATE
-> &
-  HasPayload<boolean>
+export type SetFileUploadStateAction = ReduxPayloadAction<
+  typeof UserAction.SET_FILE_UPLOAD_STATE,
+  boolean
+>
 
-export type SetUserMessageAction = ReduxAction<
-  typeof UserAction.SET_USER_MESSAGE
-> &
-  HasPayload<string>
+export type SetUserMessageAction = ReduxPayloadAction<
+  typeof UserAction.SET_USER_MESSAGE,
+  string
+>
 
-export type SetUserAnnouncementAction = ReduxAction<
-  typeof UserAction.SET_USER_ANNOUNCEMENT
-> &
-  HasPayload<{
+export type SetUserAnnouncementAction = ReduxPayloadAction<
+  typeof UserAction.SET_USER_ANNOUNCEMENT,
+  {
     message: string | undefined
     title: string | undefined
     subtitle: string | undefined
     url: string | undefined
     image: string | undefined
-  }>
+  }
+>
 
-export type SetEditedContactEmailAction = ReduxAction<
-  typeof UserAction.SET_EDITED_CONTACT_EMAIL
-> &
-  HasPayload<{
+export type SetEditedContactEmailAction = ReduxPayloadAction<
+  typeof UserAction.SET_EDITED_CONTACT_EMAIL,
+  {
     shortUrl: string
     editedContactEmail: string
-  }>
+  }
+>
 
-export type SetEditedDescriptionAction = ReduxAction<
-  typeof UserAction.SET_EDITED_DESCRIPTION
-> &
-  HasPayload<{
+export type SetEditedDescriptionAction = ReduxPayloadAction<
+  typeof UserAction.SET_EDITED_DESCRIPTION,
+  {
     shortUrl: string
     editedDescription: string
-  }>
+  }
+>
 
-export type SetLastCreatedLinkAction = ReduxAction<
-  typeof UserAction.SET_LAST_CREATED_LINK
-> &
-  HasPayload<string>
+export type SetLastCreatedLinkAction = ReduxPayloadAction<
+  typeof UserAction.SET_LAST_CREATED_LINK,
+  string
+>
 
 export type WipeUserStateAction = ReduxAction<typeof UserAction.WIPE_USER_STATE>
 
-export type IsFetchingUrlsAction = ReduxAction<
-  typeof UserAction.IS_FETCHING_URLS
-> &
-  HasPayload<boolean>
+export type IsFetchingUrlsAction = ReduxPayloadAction<
+  typeof UserAction.IS_FETCHING_URLS,
+  boolean
+>
 
 export type CreateUrlSuccessAction = ReduxAction<
   typeof UserAction.CREATE_URL_SUCCESS
 >
 
-export type GetUrlsForUserSuccessAction = ReduxAction<
-  typeof UserAction.GET_URLS_FOR_USER_SUCCESS
-> &
-  HasPayload<Array<UrlType>>
+export type GetUrlsForUserSuccessAction = ReduxPayloadAction<
+  typeof UserAction.GET_URLS_FOR_USER_SUCCESS,
+  Array<UrlType>
+>
 
 export type OpenCreateUrlModalAction = ReduxAction<
   typeof UserAction.OPEN_CREATE_URL_MODAL
@@ -108,64 +108,70 @@ export type CloseCreateUrlModalAction = ReduxAction<
   typeof UserAction.CLOSE_CREATE_URL_MODAL
 >
 
-export type SetShortUrlAction = ReduxAction<typeof UserAction.SET_SHORT_URL> &
-  HasPayload<string>
+export type SetShortUrlAction = ReduxPayloadAction<
+  typeof UserAction.SET_SHORT_URL,
+  string
+>
 
-export type SetLongUrlAction = ReduxAction<typeof UserAction.SET_LONG_URL> &
-  HasPayload<string>
+export type SetLongUrlAction = ReduxPayloadAction<
+  typeof UserAction.SET_LONG_URL,
+  string
+>
 
-export type SetEditedLongUrlAction = ReduxAction<
-  typeof UserAction.SET_EDITED_LONG_URL
-> &
-  HasPayload<{
+export type SetEditedLongUrlAction = ReduxPayloadAction<
+  typeof UserAction.SET_EDITED_LONG_URL,
+  {
     shortUrl: string
     editedLongUrl: string
-  }>
+  }
+>
 
-export type SetRandomShortUrlAction = ReduxAction<
-  typeof UserAction.SET_RANDOM_SHORT_URL
-> &
-  HasPayload<string>
+export type SetRandomShortUrlAction = ReduxPayloadAction<
+  typeof UserAction.SET_RANDOM_SHORT_URL,
+  string
+>
 
 export type ResetUserStateAction = ReduxAction<
   typeof UserAction.RESET_USER_STATE
 >
 
-export type ToggleUrlStateSuccessAction = ReduxAction<
-  typeof UserAction.TOGGLE_URL_STATE_SUCCESS
-> &
-  HasPayload<{
+export type ToggleUrlStateSuccessAction = ReduxPayloadAction<
+  typeof UserAction.TOGGLE_URL_STATE_SUCCESS,
+  {
     shortUrl: string
     toState: UrlState
-  }>
+  }
+>
 
-export type SetUrlTableConfigAction = ReduxAction<
-  typeof UserAction.SET_URL_TABLE_CONFIG
-> &
-  HasPayload<UrlTableConfig>
+export type SetUrlTableConfigAction = ReduxPayloadAction<
+  typeof UserAction.SET_URL_TABLE_CONFIG,
+  UrlTableConfig
+>
 
-export type UpdateUrlCountAction = ReduxAction<
-  typeof UserAction.UPDATE_URL_COUNT
-> &
-  HasPayload<number>
+export type UpdateUrlCountAction = ReduxPayloadAction<
+  typeof UserAction.UPDATE_URL_COUNT,
+  number
+>
 
-export type SetIsUploadingAction = ReduxAction<
-  typeof UserAction.SET_IS_UPLOADING
-> &
-  HasPayload<boolean>
+export type SetIsUploadingAction = ReduxPayloadAction<
+  typeof UserAction.SET_IS_UPLOADING,
+  boolean
+>
 
-export type SetUploadFileErrorAction = ReduxAction<
-  typeof UserAction.SET_UPLOAD_FILE_ERROR
-> &
-  HasPayload<string>
+export type SetUploadFileErrorAction = ReduxPayloadAction<
+  typeof UserAction.SET_UPLOAD_FILE_ERROR,
+  string
+>
 
-export type SetCreateShortLinkErrorAction = ReduxAction<
-  typeof UserAction.SET_CREATE_SHORT_LINK_ERROR
-> &
-  HasPayload<string>
+export type SetCreateShortLinkErrorAction = ReduxPayloadAction<
+  typeof UserAction.SET_CREATE_SHORT_LINK_ERROR,
+  string
+>
 
-export type SetUrlFilterAction = ReduxAction<typeof UserAction.SET_URL_FILTER> &
-  HasPayload<UrlTableFilterConfig>
+export type SetUrlFilterAction = ReduxPayloadAction<
+  typeof UserAction.SET_URL_FILTER,
+  UrlTableFilterConfig
+>
 
 export type UserActionType =
   | UpdateUrlCountAction

--- a/src/client/user/actions/types.ts
+++ b/src/client/user/actions/types.ts
@@ -5,6 +5,8 @@ import {
   UrlType,
 } from '../reducers/types'
 
+import { HasPayload, ReduxAction } from '../../app/actions/types'
+
 /* User actions */
 
 export enum UserAction {
@@ -35,143 +37,135 @@ export enum UserAction {
   SET_FILE_UPLOAD_STATE = 'SET_FILE_UPLOAD_STATE',
 }
 
-export type SetUrlUploadStateAction = {
-  type: UserAction.SET_URL_UPLOAD_STATE
-  payload: boolean
-}
+export type SetUrlUploadStateAction = ReduxAction<
+  typeof UserAction.SET_URL_UPLOAD_STATE
+> &
+  HasPayload<boolean>
 
-export type SetFileUploadStateAction = {
-  type: UserAction.SET_FILE_UPLOAD_STATE
-  payload: boolean
-}
+export type SetFileUploadStateAction = ReduxAction<
+  typeof UserAction.SET_FILE_UPLOAD_STATE
+> &
+  HasPayload<boolean>
 
-export type SetUserMessageAction = {
-  type: UserAction.SET_USER_MESSAGE
-  payload: string
-}
+export type SetUserMessageAction = ReduxAction<
+  typeof UserAction.SET_USER_MESSAGE
+> &
+  HasPayload<string>
 
-export type SetUserAnnouncementAction = {
-  type: UserAction.SET_USER_ANNOUNCEMENT
-  payload: {
+export type SetUserAnnouncementAction = ReduxAction<
+  typeof UserAction.SET_USER_ANNOUNCEMENT
+> &
+  HasPayload<{
     message: string | undefined
     title: string | undefined
     subtitle: string | undefined
     url: string | undefined
     image: string | undefined
-  }
-}
+  }>
 
-export type SetEditedContactEmailAction = {
-  type: UserAction.SET_EDITED_CONTACT_EMAIL
-  payload: {
+export type SetEditedContactEmailAction = ReduxAction<
+  typeof UserAction.SET_EDITED_CONTACT_EMAIL
+> &
+  HasPayload<{
     shortUrl: string
     editedContactEmail: string
-  }
-}
+  }>
 
-export type SetEditedDescriptionAction = {
-  type: UserAction.SET_EDITED_DESCRIPTION
-  payload: {
+export type SetEditedDescriptionAction = ReduxAction<
+  typeof UserAction.SET_EDITED_DESCRIPTION
+> &
+  HasPayload<{
     shortUrl: string
     editedDescription: string
-  }
-}
+  }>
 
-export type SetLastCreatedLinkAction = {
-  type: UserAction.SET_LAST_CREATED_LINK
-  payload: string
-}
+export type SetLastCreatedLinkAction = ReduxAction<
+  typeof UserAction.SET_LAST_CREATED_LINK
+> &
+  HasPayload<string>
 
-export type WipeUserStateAction = {
-  type: UserAction.WIPE_USER_STATE
-}
+export type WipeUserStateAction = ReduxAction<typeof UserAction.WIPE_USER_STATE>
 
-export type IsFetchingUrlsAction = {
-  type: UserAction.IS_FETCHING_URLS
-  payload: boolean
-}
+export type IsFetchingUrlsAction = ReduxAction<
+  typeof UserAction.IS_FETCHING_URLS
+> &
+  HasPayload<boolean>
 
-export type CreateUrlSuccessAction = {
-  type: UserAction.CREATE_URL_SUCCESS
-}
+export type CreateUrlSuccessAction = ReduxAction<
+  typeof UserAction.CREATE_URL_SUCCESS
+>
 
-export type GetUrlsForUserSuccessAction = {
-  type: UserAction.GET_URLS_FOR_USER_SUCCESS
-  payload: Array<UrlType>
-}
+export type GetUrlsForUserSuccessAction = ReduxAction<
+  typeof UserAction.GET_URLS_FOR_USER_SUCCESS
+> &
+  HasPayload<Array<UrlType>>
 
-export type OpenCreateUrlModalAction = {
-  type: UserAction.OPEN_CREATE_URL_MODAL
-}
+export type OpenCreateUrlModalAction = ReduxAction<
+  typeof UserAction.OPEN_CREATE_URL_MODAL
+>
 
-export type CloseCreateUrlModalAction = {
-  type: UserAction.CLOSE_CREATE_URL_MODAL
-}
+export type CloseCreateUrlModalAction = ReduxAction<
+  typeof UserAction.CLOSE_CREATE_URL_MODAL
+>
 
-export type SetShortUrlAction = {
-  type: UserAction.SET_SHORT_URL
-  payload: string
-}
+export type SetShortUrlAction = ReduxAction<typeof UserAction.SET_SHORT_URL> &
+  HasPayload<string>
 
-export type SetLongUrlAction = {
-  type: UserAction.SET_LONG_URL
-  payload: string
-}
+export type SetLongUrlAction = ReduxAction<typeof UserAction.SET_LONG_URL> &
+  HasPayload<string>
 
-export type SetEditedLongUrlAction = {
-  type: UserAction.SET_EDITED_LONG_URL
-  payload: {
+export type SetEditedLongUrlAction = ReduxAction<
+  typeof UserAction.SET_EDITED_LONG_URL
+> &
+  HasPayload<{
     shortUrl: string
     editedLongUrl: string
-  }
-}
+  }>
 
-export type SetRandomShortUrlAction = {
-  type: UserAction.SET_RANDOM_SHORT_URL
-  payload: string
-}
+export type SetRandomShortUrlAction = ReduxAction<
+  typeof UserAction.SET_RANDOM_SHORT_URL
+> &
+  HasPayload<string>
 
-export type ResetUserStateAction = {
-  type: UserAction.RESET_USER_STATE
-}
+export type ResetUserStateAction = ReduxAction<
+  typeof UserAction.RESET_USER_STATE
+>
 
-export type ToggleUrlStateSuccessAction = {
-  type: UserAction.TOGGLE_URL_STATE_SUCCESS
-  payload: {
+export type ToggleUrlStateSuccessAction = ReduxAction<
+  typeof UserAction.TOGGLE_URL_STATE_SUCCESS
+> &
+  HasPayload<{
     shortUrl: string
     toState: UrlState
-  }
-}
+  }>
 
-export type SetUrlTableConfigAction = {
-  type: UserAction.SET_URL_TABLE_CONFIG
-  payload: UrlTableConfig
-}
+export type SetUrlTableConfigAction = ReduxAction<
+  typeof UserAction.SET_URL_TABLE_CONFIG
+> &
+  HasPayload<UrlTableConfig>
 
-export type UpdateUrlCountAction = {
-  type: UserAction.UPDATE_URL_COUNT
-  payload: number
-}
+export type UpdateUrlCountAction = ReduxAction<
+  typeof UserAction.UPDATE_URL_COUNT
+> &
+  HasPayload<number>
 
-export type SetIsUploadingAction = {
-  type: UserAction.SET_IS_UPLOADING
-  payload: boolean
-}
+export type SetIsUploadingAction = ReduxAction<
+  typeof UserAction.SET_IS_UPLOADING
+> &
+  HasPayload<boolean>
 
-export type SetUploadFileErrorAction = {
-  type: UserAction.SET_UPLOAD_FILE_ERROR
-  payload: string
-}
+export type SetUploadFileErrorAction = ReduxAction<
+  typeof UserAction.SET_UPLOAD_FILE_ERROR
+> &
+  HasPayload<string>
 
-export type SetCreateShortLinkErrorAction = {
-  type: UserAction.SET_CREATE_SHORT_LINK_ERROR
-  payload: string
-}
+export type SetCreateShortLinkErrorAction = ReduxAction<
+  typeof UserAction.SET_CREATE_SHORT_LINK_ERROR
+> &
+  HasPayload<string>
 
-export type SetUrlFilterAction = {
-  type: UserAction.SET_URL_FILTER
-  payload: UrlTableFilterConfig
-}
+export type SetUrlFilterAction = ReduxAction<typeof UserAction.SET_URL_FILTER> &
+  HasPayload<UrlTableFilterConfig>
 
 export type UserActionType =
   | UpdateUrlCountAction

--- a/src/client/user/actions/types.ts
+++ b/src/client/user/actions/types.ts
@@ -38,22 +38,22 @@ export enum UserAction {
 }
 
 export type SetUrlUploadStateAction = ReduxPayloadAction<
-  typeof UserAction.SET_URL_UPLOAD_STATE,
+  UserAction.SET_URL_UPLOAD_STATE,
   boolean
 >
 
 export type SetFileUploadStateAction = ReduxPayloadAction<
-  typeof UserAction.SET_FILE_UPLOAD_STATE,
+  UserAction.SET_FILE_UPLOAD_STATE,
   boolean
 >
 
 export type SetUserMessageAction = ReduxPayloadAction<
-  typeof UserAction.SET_USER_MESSAGE,
+  UserAction.SET_USER_MESSAGE,
   string
 >
 
 export type SetUserAnnouncementAction = ReduxPayloadAction<
-  typeof UserAction.SET_USER_ANNOUNCEMENT,
+  UserAction.SET_USER_ANNOUNCEMENT,
   {
     message: string | undefined
     title: string | undefined
@@ -64,7 +64,7 @@ export type SetUserAnnouncementAction = ReduxPayloadAction<
 >
 
 export type SetEditedContactEmailAction = ReduxPayloadAction<
-  typeof UserAction.SET_EDITED_CONTACT_EMAIL,
+  UserAction.SET_EDITED_CONTACT_EMAIL,
   {
     shortUrl: string
     editedContactEmail: string
@@ -72,7 +72,7 @@ export type SetEditedContactEmailAction = ReduxPayloadAction<
 >
 
 export type SetEditedDescriptionAction = ReduxPayloadAction<
-  typeof UserAction.SET_EDITED_DESCRIPTION,
+  UserAction.SET_EDITED_DESCRIPTION,
   {
     shortUrl: string
     editedDescription: string
@@ -80,46 +80,40 @@ export type SetEditedDescriptionAction = ReduxPayloadAction<
 >
 
 export type SetLastCreatedLinkAction = ReduxPayloadAction<
-  typeof UserAction.SET_LAST_CREATED_LINK,
+  UserAction.SET_LAST_CREATED_LINK,
   string
 >
 
-export type WipeUserStateAction = ReduxAction<typeof UserAction.WIPE_USER_STATE>
+export type WipeUserStateAction = ReduxAction<UserAction.WIPE_USER_STATE>
 
 export type IsFetchingUrlsAction = ReduxPayloadAction<
-  typeof UserAction.IS_FETCHING_URLS,
+  UserAction.IS_FETCHING_URLS,
   boolean
 >
 
-export type CreateUrlSuccessAction = ReduxAction<
-  typeof UserAction.CREATE_URL_SUCCESS
->
+export type CreateUrlSuccessAction = ReduxAction<UserAction.CREATE_URL_SUCCESS>
 
 export type GetUrlsForUserSuccessAction = ReduxPayloadAction<
-  typeof UserAction.GET_URLS_FOR_USER_SUCCESS,
+  UserAction.GET_URLS_FOR_USER_SUCCESS,
   Array<UrlType>
 >
 
-export type OpenCreateUrlModalAction = ReduxAction<
-  typeof UserAction.OPEN_CREATE_URL_MODAL
->
+export type OpenCreateUrlModalAction = ReduxAction<UserAction.OPEN_CREATE_URL_MODAL>
 
-export type CloseCreateUrlModalAction = ReduxAction<
-  typeof UserAction.CLOSE_CREATE_URL_MODAL
->
+export type CloseCreateUrlModalAction = ReduxAction<UserAction.CLOSE_CREATE_URL_MODAL>
 
 export type SetShortUrlAction = ReduxPayloadAction<
-  typeof UserAction.SET_SHORT_URL,
+  UserAction.SET_SHORT_URL,
   string
 >
 
 export type SetLongUrlAction = ReduxPayloadAction<
-  typeof UserAction.SET_LONG_URL,
+  UserAction.SET_LONG_URL,
   string
 >
 
 export type SetEditedLongUrlAction = ReduxPayloadAction<
-  typeof UserAction.SET_EDITED_LONG_URL,
+  UserAction.SET_EDITED_LONG_URL,
   {
     shortUrl: string
     editedLongUrl: string
@@ -127,16 +121,14 @@ export type SetEditedLongUrlAction = ReduxPayloadAction<
 >
 
 export type SetRandomShortUrlAction = ReduxPayloadAction<
-  typeof UserAction.SET_RANDOM_SHORT_URL,
+  UserAction.SET_RANDOM_SHORT_URL,
   string
 >
 
-export type ResetUserStateAction = ReduxAction<
-  typeof UserAction.RESET_USER_STATE
->
+export type ResetUserStateAction = ReduxAction<UserAction.RESET_USER_STATE>
 
 export type ToggleUrlStateSuccessAction = ReduxPayloadAction<
-  typeof UserAction.TOGGLE_URL_STATE_SUCCESS,
+  UserAction.TOGGLE_URL_STATE_SUCCESS,
   {
     shortUrl: string
     toState: UrlState
@@ -144,32 +136,32 @@ export type ToggleUrlStateSuccessAction = ReduxPayloadAction<
 >
 
 export type SetUrlTableConfigAction = ReduxPayloadAction<
-  typeof UserAction.SET_URL_TABLE_CONFIG,
+  UserAction.SET_URL_TABLE_CONFIG,
   UrlTableConfig
 >
 
 export type UpdateUrlCountAction = ReduxPayloadAction<
-  typeof UserAction.UPDATE_URL_COUNT,
+  UserAction.UPDATE_URL_COUNT,
   number
 >
 
 export type SetIsUploadingAction = ReduxPayloadAction<
-  typeof UserAction.SET_IS_UPLOADING,
+  UserAction.SET_IS_UPLOADING,
   boolean
 >
 
 export type SetUploadFileErrorAction = ReduxPayloadAction<
-  typeof UserAction.SET_UPLOAD_FILE_ERROR,
+  UserAction.SET_UPLOAD_FILE_ERROR,
   string
 >
 
 export type SetCreateShortLinkErrorAction = ReduxPayloadAction<
-  typeof UserAction.SET_CREATE_SHORT_LINK_ERROR,
+  UserAction.SET_CREATE_SHORT_LINK_ERROR,
   string
 >
 
 export type SetUrlFilterAction = ReduxPayloadAction<
-  typeof UserAction.SET_URL_FILTER,
+  UserAction.SET_URL_FILTER,
   UrlTableFilterConfig
 >
 


### PR DESCRIPTION
## Problem

Duplicate boilerplate code exists where Redux actions are present. By addressing this issue, not only will we adhere to the DRY principle, but it will also help ensure that all Redux actions are typed correctly throughout the codebase.

Closes #938

## Solution

- Implemented generic redux actions interfaces through intersection type extensions
- Refactored redux type definitions to use generic interfaces
