### PR TITLE
fix(webpack): fix webpack for IE 11 support

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,14 @@ const metaVariant = assetVariant === 'edu' ? eduMetaTags : govMetaTags
 
 module.exports = () => {
   const jsBundle = {
-    entry: ['babel-polyfill', path.join(srcDirectory, 'index.tsx')],
+    target: ['web', 'es5'],
+    entry: [
+      // explicitly specify transpilation order to prevent IE 11 from breaking
+      'babel-polyfill',
+      'react',
+      'react-dom',
+      path.join(srcDirectory, 'index.tsx'),
+    ],
     output: {
       path: path.join(__dirname, outputDirectory),
       filename: 'bundle.js',
@@ -54,6 +61,11 @@ module.exports = () => {
       },
       fallback: {
         path: require.resolve('path-browserify'),
+        zlib: false,
+        http: false,
+        https: false,
+        stream: false,
+        crypto: false,
       },
     },
     module: {


### PR DESCRIPTION
## Problem

Currently, webpack 5 builds to target es6 by default, which breaks IE 11 since it only supports up to es5. Additionally, webpack 5 drops quite a few polyfills, which triggers warnings to provide fallbacks even if unused. There is also a transpilation issue with react components where IE would break if the transpilation order was incorrect.

## Solution

- Changed webpack build target to es5
- Added fallbacks for unused polyfills that webpack 5 drops from webpack 4
- Specified transpilation order to fix an issue with IE, where it would break react components otherwise
