### PR TITLE
feat(maildev): log OTP in console through maildev in dev mode

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -42,5 +42,9 @@ ENV PORT_WEB_UI=8055
 
 ENV BUCKET_ENDPOINT=http://localhost:4566
 
+# maildev env vars
+ENV MAILDEV_HOST=0.0.0.0
+ENV MAILDEV_SMTP_PORT=1025
+
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
 RUN chmod 755 /tmp/wait-for-it.sh

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -43,8 +43,8 @@ ENV PORT_WEB_UI=8055
 ENV BUCKET_ENDPOINT=http://localhost:4566
 
 # maildev env vars
-ENV MAILDEV_HOST=0.0.0.0
-ENV MAILDEV_SMTP_PORT=1025
+ENV SES_HOST=localhost
+ENV SES_PORT=1025
 
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
 RUN chmod 755 /tmp/wait-for-it.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,8 +8,8 @@ tasks:
   - before: export ACCESS_ENDPOINT=`gp url 4566`
     init: npm install
     command: /tmp/wait-for-it.sh localhost:4566 -t 0 -- ./init-localstack.sh && echo "Run npm run docker-dev to begin"
-  - init: npm install maildev -g
-    command: maildev --verbose
+  - before: npm install maildev -g
+    command: echo "maildev.on('new', ({ html }) => console.log('The login OTP is ' + html.match(/\d{6}/)[0]))" >> $(which maildev) && maildev --verbose
 ports:
   # postgres
   - port: 5432

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,8 @@ tasks:
   - before: export ACCESS_ENDPOINT=`gp url 4566`
     init: npm install
     command: /tmp/wait-for-it.sh localhost:4566 -t 0 -- ./init-localstack.sh && echo "Run npm run docker-dev to begin"
+  - init: npm install maildev -g
+    command: maildev --verbose
 ports:
   # postgres
   - port: 5432
@@ -25,4 +27,7 @@ ports:
   # expressjs - not needed since we have
   # access via webpack dev server proxy
   - port: 8080
+    onOpen: ignore
+  # maildev
+  - port: 1025
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,11 +5,11 @@ tasks:
   - before: cp ./init-localstack.sh /docker-entrypoint-initaws.d/init-localstack.sh
     init: pip install --quiet localstack[full]
     command: /workspace/.pip-modules/bin/localstack start --host
+  - before: npm install maildev -g
+    command: echo "maildev.on('new', ({ html }) => console.log('The login OTP is ' + html.match(/\d{6}/)[0]))" >> $(which maildev) && maildev --verbose
   - before: export ACCESS_ENDPOINT=`gp url 4566`
     init: npm install
     command: /tmp/wait-for-it.sh localhost:4566 -t 0 -- ./init-localstack.sh && echo "Run npm run docker-dev to begin"
-  - before: npm install maildev -g
-    command: echo "maildev.on('new', ({ html }) => console.log('The login OTP is ' + html.match(/\d{6}/)[0]))" >> $(which maildev) && maildev --verbose
 ports:
   # postgres
   - port: 5432
@@ -30,4 +30,6 @@ ports:
     onOpen: ignore
   # maildev
   - port: 1025
+    onOpen: ignore
+  - port: 1080
     onOpen: ignore

--- a/Dockerfile.maildev-logging
+++ b/Dockerfile.maildev-logging
@@ -1,0 +1,3 @@
+FROM maildev/maildev:1.1.0
+WORKDIR /usr/src/app
+RUN echo "maildev.on('new', ({ html }) => console.log('Login OTP: ' + html.match(/\d{6}/)[0]))" >> bin/maildev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
       - SAFE_BROWSING_KEY=
       - CLOUDMERSIVE_KEY=
       - ASSET_VARIANT=
-      - MAILDEV_HOST=
-      - MAILDEV_SMTP_PORT=
+      - SES_HOST=maildev
+      - SES_PORT=25
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - SAFE_BROWSING_KEY=
       - CLOUDMERSIVE_KEY=
       - ASSET_VARIANT=
+      - MAILDEV_HOST=
+      - MAILDEV_SMTP_PORT=
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src
@@ -80,6 +82,9 @@ services:
       - '/var/run/docker.sock:/var/run/docker.sock'
   maildev:
     image: maildev/maildev
+    build:
+      context: .
+      dockerfile: Dockerfile.maildev-logging
     command: bin/maildev --web 80 --smtp 25 --verbose
     ports:
       - "1080:80"

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -84,6 +84,16 @@ let proxy: boolean = true
 let cookieConfig = null
 let otpLimit: number = 5
 
+// Configure transporer options for nodemailer
+// All session variables will now be casted to non-nullable strings
+transporterOpts = {
+  host: process.env.SES_HOST as string,
+  port: process.env.SES_PORT as string,
+  pool: true,
+  maxMessages: 100,
+  maxConnections: 20,
+}
+
 if (DEV_ENV) {
   // Only configure things particular to development here
   logger.warn('Deploying in development mode.')
@@ -94,15 +104,8 @@ if (DEV_ENV) {
   proxy = false
   otpLimit = 10
 
-  // Configures transporter for maildev
-  transporterOpts = {
-    host: process.env.MAILDEV_HOST || 'maildev',
-    port: process.env.MAILDEV_SMTP_PORT || '25',
-    pool: true,
-    maxMessages: 100,
-    maxConnections: 20,
-    ignoreTLS: true,
-  }
+  // Configure maildev specific options
+  transporterOpts.ignoreTLS = true
 } else {
   logger.info('Deploying in production mode.')
 
@@ -112,17 +115,11 @@ if (DEV_ENV) {
     maxAge: Number.isNaN(maxAge) ? 1800000 : maxAge,
   }
   exitIfAnyMissing(sesVars)
-  // All session variables will now be casted to non-nullable strings
-  transporterOpts = {
-    host: process.env.SES_HOST as string,
-    auth: {
-      user: process.env.SES_USER as string,
-      pass: process.env.SES_PASS as string,
-    },
-    port: process.env.SES_PORT as string,
-    pool: true,
-    maxMessages: 100,
-    maxConnections: 20,
+
+  // Confgiure SES specific options
+  transporterOpts.auth = {
+    user: process.env.SES_USER as string,
+    pass: process.env.SES_PASS as string,
   }
 }
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -96,8 +96,8 @@ if (DEV_ENV) {
 
   // Configures transporter for maildev
   transporterOpts = {
-    host: 'maildev',
-    port: '25',
+    host: process.env.MAILDEV_HOST || 'maildev',
+    port: process.env.MAILDEV_SMTP_PORT || '25',
     pool: true,
     maxMessages: 100,
     maxConnections: 20,


### PR DESCRIPTION
## Problem

Currently, the implementation for maildev does not include support for Gitpod, as maildev is run on another container instance and thus cannot be ported to Gitpod as is. Furthermore, the development workflow is slightly slowed down due to having to get the OTP manually from maildev's visual interface through `localhost:1080`.

## Solution

By logging the OTP in the console, developers should be able to retrieve the OTP there and log into the application without having to open `localhost:1080`. In addition, this pull request also implements maildev for Gitpod through running a maildev instance on the same container instance.

- logs the OTP in console for logins through maildev during development mode for convenience
- implements maildev support for gitpod
- refactored transport option configurations for server side config to reuse some SES variables for maildev

## Deploy Notes

### Environmental Variables
- Reused `SES_HOST` and `SES_PORT` for configuring maildev host and smtp ports.
    - `docker-compose.yml` sets `SES_HOST` and `SES_PORT` to `maildev` and `25` respectively
    - `gitpod.Dockerfile` sets `SES_HOST` and `SES_PORT` to `localhost` and `1025` respectively
