### PR TITLE
fix(featured-sliver): shift columns const within export function

### DIFF
--- a/src/client/home/components/FeatureListSliver.tsx
+++ b/src/client/home/components/FeatureListSliver.tsx
@@ -62,43 +62,43 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-const columns = [
-  {
-    id: 1,
-    data: [
-      {
-        icon: antiPhishingIcon,
-        title: 'Anti-phishing',
-        description: i18next.t('homePage.features.antiPhishing.description'),
-      },
-      {
-        icon: fileSharingIcon,
-        title: 'File sharing',
-        description: i18next.t('homePage.features.fileSharing.description'),
-      },
-    ],
-  },
-  {
-    id: 2,
-    data: [
-      {
-        icon: customisedIcon,
-        title: 'Customised',
-        description: i18next.t('homePage.features.customised.description'),
-      },
-      {
-        icon: analyticsIcon,
-        title: 'Analytics',
-        description: i18next.t('homePage.features.analytics.description'),
-      },
-    ],
-  },
-]
-
 const FeatureListSliver = () => {
   const classes = useStyles()
   const theme = useTheme()
   const isDesktopWidth = useMediaQuery(theme.breakpoints.up('lg'))
+  const columns = [
+    {
+      id: 1,
+      data: [
+        {
+          icon: antiPhishingIcon,
+          title: 'Anti-phishing',
+          description: i18next.t('homePage.features.antiPhishing.description'),
+        },
+        {
+          icon: fileSharingIcon,
+          title: 'File sharing',
+          description: i18next.t('homePage.features.fileSharing.description'),
+        },
+      ],
+    },
+    {
+      id: 2,
+      data: [
+        {
+          icon: customisedIcon,
+          title: 'Customised',
+          description: i18next.t('homePage.features.customised.description'),
+        },
+        {
+          icon: analyticsIcon,
+          title: 'Analytics',
+          description: i18next.t('homePage.features.analytics.description'),
+        },
+      ],
+    },
+  ]
+
   return (
     <>
       <Typography


### PR DESCRIPTION
## Problem

The constant defining data to be fed into the featured-by-sliver columns was outside of the export
function, which meant that the i18next.t() function within the const definition was not called
properly at function runtime

Closes #1354

## Solution

- Shifted the constant to be definted within the export function