### PR TITLE
fix(rotating-links): use non-empty array as fallback

### DIFF
--- a/src/client/home/components/RotatingLinksGraphic/index.tsx
+++ b/src/client/home/components/RotatingLinksGraphic/index.tsx
@@ -99,7 +99,7 @@ const RotatingLinksGraphic = () => {
       <div className={classes.rotatingLinks}>
         <RotatingLinks
           prefix={i18next.t('general.shortUrlPrefix')}
-          strings={linksToRotate || []}
+          strings={linksToRotate || ['whatsapp', 'passport']}
         />
       </div>
     </div>


### PR DESCRIPTION
## Problem

E2E tests have started getting flaky recently, mainly due to a javascript error occurring on the browser being caught by testcafe.

The error is non-deterministic and states `TypeError: Cannot read property 'substr' of undefined` on the landing page. 

After inspecting network calls made in the landing page and observing the state of the variables, I found `linksToRotate` being momentarily undefined for a few render cycles before being populated with the correct array of links.

Incidentally, there has always been a fallback mechanism in place when linksToRotate was undefined, and that was to supply an empty array. I discovered that whenever an empty array was supplied to the components, the error would appear.

## Solution

The solution would be to fix the broken fallback mechanism by supplying some hardcoded strings in the array at least so the array would never be empty.

