### PR TITLE
fix(home): render rotating links only if we have some

### DIFF
--- a/src/client/home/components/RotatingLinksGraphic/RotatingLinks.tsx
+++ b/src/client/home/components/RotatingLinksGraphic/RotatingLinks.tsx
@@ -15,13 +15,15 @@ const RotatingLinks: FunctionComponent<RotatingLinksType> = ({
   return (
     <main className={className}>
       {prefix}
-      <Typed
-        strings={strings}
-        typeSpeed={80}
-        backDelay={2500}
-        smartBackspace={false}
-        loop
-      />
+      {strings && strings.length > 0 ? (
+        <Typed
+          strings={strings}
+          typeSpeed={80}
+          backDelay={2500}
+          smartBackspace={false}
+          loop
+        />
+      ) : null}
     </main>
   )
 }


### PR DESCRIPTION
## Problem

As exposed by the flakiness in e2e tests, react-typed has undefined behaviour if it receives an empty array of strings. This causes the frontend to throw spurious errors.

Supersedes #1382 , which has further background

## Solution

Render the react-typed component only if we have an non-empty array of strings