### PR TITLE
fix(copy): fix statistics sliver copy

### DIFF
--- a/src/client/home/components/StatisticsSliver.tsx
+++ b/src/client/home/components/StatisticsSliver.tsx
@@ -81,7 +81,12 @@ const StatisticsSliver: FunctionComponent = () => {
   const { userCount, linkCount, clickCount } = statistics
   // ensure number will never be null
   const statisticsToShow = [
-    { label: 'PUBLIC OFFICERS ONBOARD', number: userCount },
+    {
+      label: `${i18next
+        .t('general.officerType')
+        .toUpperCase()} OFFICERS ONBOARD`,
+      number: userCount,
+    },
     { label: 'SHORT LINKS CREATED', number: linkCount },
     { label: 'CLICKS', number: clickCount },
   ]


### PR DESCRIPTION
## Problem

Fixes an error with the statistics sliver copy which would read "public officers onboard" when it should be "education officers onboard"

### Solution

- implement i18next translation to switch between public and education officers based on current translation.json