### PR TITLE
Use read replica for statistics retrieval operations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - PORT=8080
       # postgres://user:pass@hostname:port/database
       - DB_URI=postgres://postgres:postgres@postgres:5432/postgres
+      - REPLICA_URI=postgres://postgres:postgres@postgres:5432/postgres
       # redis://[CLUSTER-PUBLIC-IP]:[PORT]
       - REDIS_OTP_URI=redis://redis:6379/0
       - REDIS_SESSION_URI=redis://redis:6379/1

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "nanoid": "^2.1.11",
     "nodemailer": "^6.5.0",
     "pg": "^8.5.1",
+    "pg-connection-string": "^2.4.0",
     "pg-hstore": "^2.3.2",
     "prop-types": "^15.7.2",
     "qrcode": "^1.4.4",

--- a/src/client/home/components/RotatingLinksGraphic/index.tsx
+++ b/src/client/home/components/RotatingLinksGraphic/index.tsx
@@ -99,7 +99,7 @@ const RotatingLinksGraphic = () => {
       <div className={classes.rotatingLinks}>
         <RotatingLinks
           prefix={i18next.t('general.shortUrlPrefix')}
-          strings={linksToRotate || ['whatsapp', 'passport']}
+          strings={linksToRotate || []}
         />
       </div>
     </div>

--- a/src/client/home/components/RotatingLinksGraphic/index.tsx
+++ b/src/client/home/components/RotatingLinksGraphic/index.tsx
@@ -99,7 +99,7 @@ const RotatingLinksGraphic = () => {
       <div className={classes.rotatingLinks}>
         <RotatingLinks
           prefix={i18next.t('general.shortUrlPrefix')}
-          strings={linksToRotate || []}
+          strings={linksToRotate || ['whatsapp', 'passport']}
         />
       </div>
     </div>

--- a/src/server/models/functions.ts
+++ b/src/server/models/functions.ts
@@ -9,6 +9,7 @@ import { updateLinkStatistics } from '../modules/analytics/repositories/LinkStat
 export async function syncFunctions() {
   // Initialises the link statistics database function.
   await sequelize.query(updateLinkStatistics, {
+    useMaster: true,
     type: QueryTypes.RAW,
   })
 }

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -40,11 +40,7 @@ export const UrlClicks = <UrlClicksTypeStatic>sequelize.define(
        * Use the replica database for read queries. To be enabled
        * when realtime data is not needed.
        */
-      useReplica() {
-        return {
-          useMaster: false,
-        }
-      },
+      useReplica: {},
     },
   },
 )

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -37,12 +37,12 @@ export const UrlClicks = <UrlClicksTypeStatic>sequelize.define(
     },
     scopes: {
       /**
-       * Use the master database for read queries. To be enabled
-       * when realtime data is needed.
+       * Use the replica database for read queries. To be enabled
+       * when realtime data is not needed.
        */
-      useMasterDb() {
+      useReplica() {
         return {
-          useMaster: true,
+          useMaster: false,
         }
       },
     },

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -15,17 +15,36 @@ type UrlClicksTypeStatic = typeof Sequelize.Model & {
   new (values?: object, options?: Sequelize.BuildOptions): UrlClicksType
 }
 
-export const UrlClicks = <UrlClicksTypeStatic>sequelize.define('url_clicks', {
-  shortUrl: {
-    type: Sequelize.STRING,
-    primaryKey: true,
-    validate: {
-      is: SHORT_URL_REGEX,
+export const UrlClicks = <UrlClicksTypeStatic>sequelize.define(
+  'url_clicks',
+  {
+    shortUrl: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+      validate: {
+        is: SHORT_URL_REGEX,
+      },
+    },
+    clicks: {
+      type: Sequelize.INTEGER,
+      defaultValue: 0,
+      allowNull: false,
     },
   },
-  clicks: {
-    type: Sequelize.INTEGER,
-    defaultValue: 0,
-    allowNull: false,
+  {
+    defaultScope: {
+      useMaster: true,
+    },
+    scopes: {
+      /**
+       * Use the master database for read queries. To be enabled
+       * when realtime data is needed.
+       */
+      useMasterDb() {
+        return {
+          useMaster: true,
+        }
+      },
+    },
   },
-})
+)

--- a/src/server/models/statistics/clicks.ts
+++ b/src/server/models/statistics/clicks.ts
@@ -40,7 +40,9 @@ export const UrlClicks = <UrlClicksTypeStatic>sequelize.define(
        * Use the replica database for read queries. To be enabled
        * when realtime data is not needed.
        */
-      useReplica: {},
+      useReplica: {
+        useMaster: undefined,
+      },
     },
   },
 )

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -241,11 +241,7 @@ export const Url = <UrlTypeStatic>sequelize.define(
        * Use the replica database for read queries. To be enabled
        * when realtime data is not needed.
        */
-      useReplica() {
-        return {
-          useMaster: false,
-        }
-      },
+      useReplica: {},
     },
   },
 )

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -241,7 +241,9 @@ export const Url = <UrlTypeStatic>sequelize.define(
        * Use the replica database for read queries. To be enabled
        * when realtime data is not needed.
        */
-      useReplica: {},
+      useReplica: {
+        useMaster: undefined,
+      },
     },
   },
 )

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -225,6 +225,9 @@ export const Url = <UrlTypeStatic>sequelize.define(
         fields: [Sequelize.literal(`(${urlSearchVector})`)],
       },
     ],
+    defaultScope: {
+      useMaster: true,
+    },
     scopes: {
       getClicks: {
         include: [
@@ -233,6 +236,15 @@ export const Url = <UrlTypeStatic>sequelize.define(
             as: 'UrlClicks',
           },
         ],
+      },
+      /**
+       * Use the master database for read queries. To be enabled
+       * when realtime data is needed.
+       */
+      useMasterDb() {
+        return {
+          useMaster: true,
+        }
       },
     },
   },

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -238,12 +238,12 @@ export const Url = <UrlTypeStatic>sequelize.define(
         ],
       },
       /**
-       * Use the master database for read queries. To be enabled
-       * when realtime data is needed.
+       * Use the replica database for read queries. To be enabled
+       * when realtime data is not needed.
        */
-      useMasterDb() {
+      useReplica() {
         return {
-          useMaster: true,
+          useMaster: false,
         }
       },
     },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -139,7 +139,9 @@ export const User = <UserTypeStatic>sequelize.define(
       /**
        * Use the replica database for read queries.
        */
-      useReplica: {},
+      useReplica: {
+        useMaster: undefined,
+      },
     },
   },
 )

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -139,11 +139,7 @@ export const User = <UserTypeStatic>sequelize.define(
       /**
        * Use the replica database for read queries.
        */
-      useReplica() {
-        return {
-          useMaster: false,
-        }
-      },
+      useReplica: {},
     },
   },
 )

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -35,6 +35,9 @@ export const User = <UserTypeStatic>sequelize.define(
     },
   },
   {
+    defaultScope: {
+      useMaster: true,
+    },
     scopes: {
       /**
        * Fetches all Urls with the given settings.
@@ -131,6 +134,14 @@ export const User = <UserTypeStatic>sequelize.define(
               where: { shortUrl },
             },
           ],
+        }
+      },
+      /**
+       * Use the master database for read queries. ALWAYS ENABLE THIS.
+       */
+      useMasterDb() {
+        return {
+          useMaster: true,
         }
       },
     },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -95,7 +95,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url.scope(['useMasterDb', 'getClicks']),
+              model: Url.scope(['defaultScope', 'getClicks']),
               as: 'Urls',
               where: whereUrlConditions,
               // use left outer join instead of default inner join
@@ -129,7 +129,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url.scope(['useMasterDb', 'getClicks']),
+              model: Url.scope(['defaultScope', 'getClicks']),
               as: 'Urls',
               where: { shortUrl },
             },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -95,7 +95,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url.scope('getClicks'),
+              model: Url.scope(['useMasterDb', 'getClicks']),
               as: 'Urls',
               where: whereUrlConditions,
               // use left outer join instead of default inner join
@@ -129,7 +129,7 @@ export const User = <UserTypeStatic>sequelize.define(
         return {
           include: [
             {
-              model: Url.scope('getClicks'),
+              model: Url.scope(['useMasterDb', 'getClicks']),
               as: 'Urls',
               where: { shortUrl },
             },

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -137,11 +137,11 @@ export const User = <UserTypeStatic>sequelize.define(
         }
       },
       /**
-       * Use the master database for read queries. ALWAYS ENABLE THIS.
+       * Use the replica database for read queries.
        */
-      useMasterDb() {
+      useReplica() {
         return {
-          useMaster: true,
+          useMaster: false,
         }
       },
     },

--- a/src/server/modules/analytics/repositories/LinkStatisticsRepository.ts
+++ b/src/server/modules/analytics/repositories/LinkStatisticsRepository.ts
@@ -81,7 +81,7 @@ export class LinkStatisticsRepository
     shortUrl: string,
     offsetDays?: number,
   ) => Promise<LinkStatistics | null> = async (shortUrl, offsetDays = 6) => {
-    const url = await Url.scope('getClicks').findOne({
+    const url = await Url.scope(['useReplica', 'getClicks']).findOne({
       where: { shortUrl },
       include: [
         { model: Devices, as: 'DeviceClicks' },

--- a/src/server/modules/analytics/repositories/LinkStatisticsRepository.ts
+++ b/src/server/modules/analytics/repositories/LinkStatisticsRepository.ts
@@ -156,7 +156,10 @@ export class LinkStatisticsRepository
     const rawFunction = `
       SELECT update_link_statistics('${shortUrl}', '${device}')
     `
-    return sequelize.query(rawFunction, { type: QueryTypes.SELECT })
+    return sequelize.query(rawFunction, {
+      useMaster: true,
+      type: QueryTypes.SELECT,
+    })
   }
 }
 

--- a/src/server/modules/analytics/repositories/__tests__/LinkStatisticsRepository.test.ts
+++ b/src/server/modules/analytics/repositories/__tests__/LinkStatisticsRepository.test.ts
@@ -136,9 +136,11 @@ describe('LinkStatisticsRepository', () => {
 
     repository.updateLinkStatistics(shortUrl, device)
     expect(query).toHaveBeenCalledWith(expect.stringContaining(shortUrl), {
+      useMaster: true,
       type: QueryTypes.SELECT,
     })
     expect(query).toHaveBeenCalledWith(expect.stringContaining(device), {
+      useMaster: true,
       type: QueryTypes.SELECT,
     })
   })

--- a/src/server/modules/analytics/repositories/__tests__/LinkStatisticsRepository.test.ts
+++ b/src/server/modules/analytics/repositories/__tests__/LinkStatisticsRepository.test.ts
@@ -79,7 +79,7 @@ describe('LinkStatisticsRepository', () => {
     expect(findOne).toBeCalledWith(
       expect.objectContaining({ where: { shortUrl } }),
     )
-    expect(scope).toBeCalledWith('getClicks')
+    expect(scope).toBeCalledWith(['useReplica', 'getClicks'])
   })
 
   it('correctly queries daily click stats', async () => {
@@ -119,7 +119,7 @@ describe('LinkStatisticsRepository', () => {
         ]),
       }),
     )
-    expect(scope).toBeCalledWith('getClicks')
+    expect(scope).toBeCalledWith(['useReplica', 'getClicks'])
   })
 
   it('correctly interpolates table names into update_link_statistics', () => {

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -38,7 +38,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
     }
 
     if (linkCount == null) {
-      linkCount = await Url.count()
+      linkCount = await Url.scope('useMasterDb').count()
       this.trySetCache(LINK_COUNT_KEY, linkCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -27,7 +27,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
     )
 
     if (userCount == null) {
-      userCount = await User.count()
+      userCount = await User.scope('useMasterDb').count()
       this.trySetCache(USER_COUNT_KEY, userCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -28,7 +28,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
 
     if (userCount == null) {
       // Allow use of read replica
-      userCount = await User.unscoped().count()
+      userCount = await User.scope('useReplica').count()
       this.trySetCache(USER_COUNT_KEY, userCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -27,18 +27,21 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
     )
 
     if (userCount == null) {
-      userCount = await User.scope('useMasterDb').count()
+      // Allow use of read replica
+      userCount = await User.unscoped().count()
       this.trySetCache(USER_COUNT_KEY, userCount.toString())
     }
 
     if (clickCount == null) {
       // Replace Nan with 0 if there is no data
-      clickCount = (await UrlClicks.sum('clicks')) || 0
+      // Allow use of read replica
+      clickCount = (await UrlClicks.unscoped().sum('clicks')) || 0
       this.trySetCache(CLICK_COUNT_KEY, clickCount.toString())
     }
 
     if (linkCount == null) {
-      linkCount = await Url.scope('useMasterDb').count()
+      // Allow use of read replica
+      linkCount = await Url.unscoped().count()
       this.trySetCache(LINK_COUNT_KEY, linkCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -35,7 +35,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
     if (clickCount == null) {
       // Replace Nan with 0 if there is no data
       // Allow use of read replica
-      clickCount = (await UrlClicks.unscoped().sum('clicks')) || 0
+      clickCount = (await UrlClicks.scope('useReplica').sum('clicks')) || 0
       this.trySetCache(CLICK_COUNT_KEY, clickCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/StatisticsRepository.ts
+++ b/src/server/modules/statistics/repositories/StatisticsRepository.ts
@@ -41,7 +41,7 @@ export class StatisticsRepository implements interfaces.StatisticsRepository {
 
     if (linkCount == null) {
       // Allow use of read replica
-      linkCount = await Url.unscoped().count()
+      linkCount = await Url.scope('useReplica').count()
       this.trySetCache(LINK_COUNT_KEY, linkCount.toString())
     }
 

--- a/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
+++ b/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
@@ -63,6 +63,7 @@ describe('StatisticsRepository', () => {
   const userCount = 1
   const clickCount = 3
   const linkCount = 2
+  const { scope } = userModelMock
 
   beforeEach(async () => {
     await new Promise<void>((resolve) => {
@@ -70,10 +71,10 @@ describe('StatisticsRepository', () => {
     })
     setSpy.mockClear()
     mgetSpy.mockClear()
+    scope.mockReset()
   })
 
   afterEach(async () => {
-    delete (userModelMock as any).count
     delete (urlModelMock as any).count
     delete (urlClicksModelMock as any).sum
   })
@@ -103,7 +104,7 @@ describe('StatisticsRepository', () => {
 
     // @ts-ignore
     mgetSpy.mockImplementation(raiseError)
-    Object.assign(userModelMock, { count: () => userCount })
+    scope.mockReturnValue({ count: () => userCount })
     Object.assign(urlModelMock, {
       count: () => linkCount,
     })
@@ -118,6 +119,7 @@ describe('StatisticsRepository', () => {
     })
     expect(mgetSpy).toHaveBeenCalled()
     expect(setSpy).toHaveBeenCalledTimes(3)
+    expect(scope).toBeCalledWith('useMasterDb')
   })
 
   it('returns values from Sequelize even if Redis set fails', async () => {
@@ -131,7 +133,7 @@ describe('StatisticsRepository', () => {
       callback(new Error('error'))
     }
 
-    Object.assign(userModelMock, { count: () => userCount })
+    scope.mockReturnValue({ count: () => userCount })
     Object.assign(urlModelMock, {
       count: () => linkCount,
     })
@@ -149,5 +151,6 @@ describe('StatisticsRepository', () => {
     })
     expect(mgetSpy).toHaveBeenCalled()
     expect(setSpy).toHaveBeenCalledTimes(3)
+    expect(scope).toHaveBeenCalledWith('useMasterDb')
   })
 })

--- a/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
+++ b/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
@@ -63,6 +63,7 @@ describe('StatisticsRepository', () => {
   const userCount = 1
   const clickCount = 3
   const linkCount = 2
+  const scope = jest.spyOn(urlModelMock, 'scope')
 
   beforeEach(async () => {
     await new Promise<void>((resolve) => {
@@ -70,6 +71,7 @@ describe('StatisticsRepository', () => {
     })
     setSpy.mockClear()
     mgetSpy.mockClear()
+    scope.mockReset()
   })
 
   afterEach(async () => {
@@ -105,9 +107,7 @@ describe('StatisticsRepository', () => {
     Object.assign(userModelMock, {
       unscoped: () => ({ count: () => userCount }),
     })
-    Object.assign(urlModelMock, {
-      unscoped: () => ({ count: () => linkCount }),
-    })
+    scope.mockReturnValue({ count: () => linkCount })
     Object.assign(urlClicksModelMock, {
       unscoped: () => ({ sum: () => clickCount }),
     })
@@ -132,12 +132,10 @@ describe('StatisticsRepository', () => {
       callback(new Error('error'))
     }
 
-    Object.assign(urlModelMock, {
-      unscoped: () => ({ count: () => linkCount }),
+    Object.assign(userModelMock, {
+      unscoped: () => ({ count: () => userCount }),
     })
-    Object.assign(urlModelMock, {
-      count: () => linkCount,
-    })
+    scope.mockReturnValue({ count: () => linkCount })
     Object.assign(urlClicksModelMock, {
       sum: () => clickCount,
     })

--- a/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
+++ b/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
@@ -32,7 +32,9 @@ export const userModelMock = {
     ]),
 }
 
-export const urlClicksModelMock = {}
+export const urlClicksModelMock = {
+  scope: jest.fn(),
+}
 
 const redisMockClient = redisMock.createClient()
 
@@ -65,6 +67,7 @@ describe('StatisticsRepository', () => {
   const linkCount = 2
   const urlScope = jest.spyOn(urlModelMock, 'scope')
   const userScope = jest.spyOn(userModelMock, 'scope')
+  const urlClickScope = jest.spyOn(urlClicksModelMock, 'scope')
 
   beforeEach(async () => {
     await new Promise<void>((resolve) => {
@@ -73,6 +76,8 @@ describe('StatisticsRepository', () => {
     setSpy.mockClear()
     mgetSpy.mockClear()
     urlScope.mockReset()
+    userScope.mockReset()
+    urlClickScope.mockReset()
   })
 
   afterEach(async () => {
@@ -107,9 +112,7 @@ describe('StatisticsRepository', () => {
     mgetSpy.mockImplementation(raiseError)
     userScope.mockReturnValue({ count: () => userCount })
     urlScope.mockReturnValue({ count: () => linkCount })
-    Object.assign(urlClicksModelMock, {
-      unscoped: () => ({ sum: () => clickCount }),
-    })
+    urlClickScope.mockReturnValue({ sum: () => clickCount })
 
     await expect(repository.getGlobalStatistics()).resolves.toStrictEqual({
       userCount,
@@ -133,9 +136,7 @@ describe('StatisticsRepository', () => {
 
     userScope.mockReturnValue({ count: () => userCount })
     urlScope.mockReturnValue({ count: () => linkCount })
-    Object.assign(urlClicksModelMock, {
-      sum: () => clickCount,
-    })
+    urlClickScope.mockReturnValue({ sum: () => clickCount })
 
     // @ts-ignore
     setSpy.mockImplementation(raiseError)

--- a/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
+++ b/src/server/modules/statistics/repositories/__tests__/StatisticsRepository.test.ts
@@ -63,7 +63,8 @@ describe('StatisticsRepository', () => {
   const userCount = 1
   const clickCount = 3
   const linkCount = 2
-  const scope = jest.spyOn(urlModelMock, 'scope')
+  const urlScope = jest.spyOn(urlModelMock, 'scope')
+  const userScope = jest.spyOn(userModelMock, 'scope')
 
   beforeEach(async () => {
     await new Promise<void>((resolve) => {
@@ -71,7 +72,7 @@ describe('StatisticsRepository', () => {
     })
     setSpy.mockClear()
     mgetSpy.mockClear()
-    scope.mockReset()
+    urlScope.mockReset()
   })
 
   afterEach(async () => {
@@ -104,10 +105,8 @@ describe('StatisticsRepository', () => {
 
     // @ts-ignore
     mgetSpy.mockImplementation(raiseError)
-    Object.assign(userModelMock, {
-      unscoped: () => ({ count: () => userCount }),
-    })
-    scope.mockReturnValue({ count: () => linkCount })
+    userScope.mockReturnValue({ count: () => userCount })
+    urlScope.mockReturnValue({ count: () => linkCount })
     Object.assign(urlClicksModelMock, {
       unscoped: () => ({ sum: () => clickCount }),
     })
@@ -132,10 +131,8 @@ describe('StatisticsRepository', () => {
       callback(new Error('error'))
     }
 
-    Object.assign(userModelMock, {
-      unscoped: () => ({ count: () => userCount }),
-    })
-    scope.mockReturnValue({ count: () => linkCount })
+    userScope.mockReturnValue({ count: () => userCount })
+    urlScope.mockReturnValue({ count: () => linkCount })
     Object.assign(urlClicksModelMock, {
       sum: () => clickCount,
     })

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -47,7 +47,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   public findByShortUrlWithTotalClicks: (
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (shortUrl) => {
-    const url = await Url.scope(['useMasterDb', 'getClicks']).findOne({
+    const url = await Url.scope(['defaultScope', 'getClicks']).findOne({
       where: { shortUrl },
     })
     return this.urlMapper.persistenceToDto(url)
@@ -75,9 +75,12 @@ export class UrlRepository implements UrlRepositoryInterface {
       }
 
       // Do a fresh read which eagerly loads the associated UrlClicks field.
-      return Url.scope('getClicks').findByPk(properties.shortUrl, {
-        transaction: t,
-      })
+      return Url.scope(['defaultScope', 'getClicks']).findByPk(
+        properties.shortUrl,
+        {
+          transaction: t,
+        },
+      )
     })
 
     if (!newUrl) throw new Error('Newly-created url is null')
@@ -90,7 +93,7 @@ export class UrlRepository implements UrlRepositoryInterface {
     file?: StorableFile,
   ) => Promise<StorableUrl> = async (originalUrl, changes, file) => {
     const { shortUrl } = originalUrl
-    const url = await Url.scope(['useMasterDb', 'getClicks']).findOne({
+    const url = await Url.scope(['defaultScope', 'getClicks']).findOne({
       where: { shortUrl },
     })
     if (!url) {
@@ -386,7 +389,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   private getLongUrlFromDatabase: (
     shortUrl: string,
   ) => Promise<string> = async (shortUrl) => {
-    const url = await Url.scope('useMasterDb').findOne({
+    const url = await Url.findOne({
       where: { shortUrl, state: StorableUrlState.Active },
     })
     if (!url) {

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -47,7 +47,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   public findByShortUrlWithTotalClicks: (
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (shortUrl) => {
-    const url = await Url.scope('getClicks').findOne({
+    const url = await Url.scope(['useMasterDb', 'getClicks']).findOne({
       where: { shortUrl },
     })
     return this.urlMapper.persistenceToDto(url)
@@ -90,7 +90,9 @@ export class UrlRepository implements UrlRepositoryInterface {
     file?: StorableFile,
   ) => Promise<StorableUrl> = async (originalUrl, changes, file) => {
     const { shortUrl } = originalUrl
-    const url = await Url.scope('getClicks').findOne({ where: { shortUrl } })
+    const url = await Url.scope(['useMasterDb', 'getClicks']).findOne({
+      where: { shortUrl },
+    })
     if (!url) {
       throw new NotFoundError(
         `url not found in database:\tshortUrl=${shortUrl}`,
@@ -233,6 +235,7 @@ export class UrlRepository implements UrlRepositoryInterface {
       model: Url,
       raw: true,
       mapToModel: true,
+      useMaster: true,
     })) as Array<UrlDirectory>
 
     const count = urlsModel.length
@@ -289,6 +292,7 @@ export class UrlRepository implements UrlRepositoryInterface {
       type: QueryTypes.SELECT,
       model: Url,
       mapToModel: true,
+      useMaster: true,
     })) as Array<UrlDirectory>
 
     const count = urlsModel.length
@@ -382,7 +386,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   private getLongUrlFromDatabase: (
     shortUrl: string,
   ) => Promise<string> = async (shortUrl) => {
-    const url = await Url.findOne({
+    const url = await Url.scope('useMasterDb').findOne({
       where: { shortUrl, state: StorableUrlState.Active },
     })
     if (!url) {

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -35,25 +35,21 @@ export class UserRepository implements UserRepositoryInterface {
   public findById: (userId: number) => Promise<StorableUser | null> = async (
     userId,
   ) => {
-    return this.userMapper.persistenceToDto(
-      await User.scope('useMasterDb').findByPk(userId),
-    )
+    return this.userMapper.persistenceToDto(await User.findByPk(userId))
   }
 
   public findByEmail: (email: string) => Promise<StorableUser | null> = async (
     email,
   ) => {
     return this.userMapper.persistenceToDto(
-      await User.scope('useMasterDb').findOne({ where: { email } }),
+      await User.findOne({ where: { email } }),
     )
   }
 
   public findOrCreateWithEmail: (email: string) => Promise<StorableUser> = (
     email,
   ) => {
-    return User.scope('useMasterDb')
-      .findOrCreate({ where: { email } })
-      .then(([user, _]) => user)
+    return User.findOrCreate({ where: { email } }).then(([user, _]) => user)
   }
 
   public findOneUrlForUser: (
@@ -61,7 +57,7 @@ export class UserRepository implements UserRepositoryInterface {
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (userId, shortUrl) => {
     const user = await User.scope([
-      { method: ['useMasterDb'] },
+      { method: ['defaultScope'] },
       {
         method: ['includeShortUrl', shortUrl],
       },
@@ -82,7 +78,7 @@ export class UserRepository implements UserRepositoryInterface {
     shortUrl: string,
   ) => Promise<StorableUser | null> = async (shortUrl) => {
     const user = await User.scope([
-      { method: ['useMasterDb'] },
+      { method: ['defaultScope'] },
       {
         method: ['includeShortUrl', shortUrl],
       },
@@ -96,7 +92,7 @@ export class UserRepository implements UserRepositoryInterface {
   ) => Promise<UrlsPaginated> = async (conditions) => {
     const notFoundMessage = 'Urls not found'
     const userCountAndArray = await User.scope([
-      { method: ['useMasterDb'] },
+      { method: ['defaultScope'] },
       {
         method: ['urlsWithQueryConditions', conditions],
       },

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -57,7 +57,7 @@ export class UserRepository implements UserRepositoryInterface {
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (userId, shortUrl) => {
     const user = await User.scope([
-      { method: ['defaultScope'] },
+      'defaultScope',
       {
         method: ['includeShortUrl', shortUrl],
       },
@@ -78,7 +78,7 @@ export class UserRepository implements UserRepositoryInterface {
     shortUrl: string,
   ) => Promise<StorableUser | null> = async (shortUrl) => {
     const user = await User.scope([
-      { method: ['defaultScope'] },
+      'defaultScope',
       {
         method: ['includeShortUrl', shortUrl],
       },
@@ -92,7 +92,7 @@ export class UserRepository implements UserRepositoryInterface {
   ) => Promise<UrlsPaginated> = async (conditions) => {
     const notFoundMessage = 'Urls not found'
     const userCountAndArray = await User.scope([
-      { method: ['defaultScope'] },
+      'defaultScope',
       {
         method: ['urlsWithQueryConditions', conditions],
       },

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -53,7 +53,7 @@ export class UserRepository implements UserRepositoryInterface {
   ) => {
     return User.scope('useMasterDb')
       .findOrCreate({ where: { email } })
-      .then(([user, _]) => user.get())
+      .then(([user, _]) => user)
   }
 
   public findOneUrlForUser: (
@@ -73,9 +73,7 @@ export class UserRepository implements UserRepositoryInterface {
       return null
     }
 
-    const {
-      Urls: [url],
-    } = user.get() as UserType
+    const [url] = user.Urls
 
     return this.urlMapper.persistenceToDto(url)
   }
@@ -118,7 +116,7 @@ export class UserRepository implements UserRepositoryInterface {
       throw new NotFoundError(notFoundMessage)
     }
 
-    const urls = (userUrls.get() as UserType).Urls.map((urlType) =>
+    const urls = userUrls.Urls.map((urlType) =>
       this.urlMapper.persistenceToDto(urlType),
     )
 

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -35,32 +35,37 @@ export class UserRepository implements UserRepositoryInterface {
   public findById: (userId: number) => Promise<StorableUser | null> = async (
     userId,
   ) => {
-    return this.userMapper.persistenceToDto(await User.findByPk(userId))
+    return this.userMapper.persistenceToDto(
+      await User.scope('useMasterDb').findByPk(userId),
+    )
   }
 
   public findByEmail: (email: string) => Promise<StorableUser | null> = async (
     email,
   ) => {
     return this.userMapper.persistenceToDto(
-      await User.findOne({ where: { email } }),
+      await User.scope('useMasterDb').findOne({ where: { email } }),
     )
   }
 
   public findOrCreateWithEmail: (email: string) => Promise<StorableUser> = (
     email,
   ) => {
-    return User.findOrCreate({ where: { email } }).then(([user, _]) =>
-      user.get(),
-    )
+    return User.scope('useMasterDb')
+      .findOrCreate({ where: { email } })
+      .then(([user, _]) => user.get())
   }
 
   public findOneUrlForUser: (
     userId: number,
     shortUrl: string,
   ) => Promise<StorableUrl | null> = async (userId, shortUrl) => {
-    const user = await User.scope({
-      method: ['includeShortUrl', shortUrl],
-    }).findOne({
+    const user = await User.scope([
+      { method: ['useMasterDb'] },
+      {
+        method: ['includeShortUrl', shortUrl],
+      },
+    ]).findOne({
       where: { id: userId },
     })
 
@@ -78,9 +83,12 @@ export class UserRepository implements UserRepositoryInterface {
   public findUserByUrl: (
     shortUrl: string,
   ) => Promise<StorableUser | null> = async (shortUrl) => {
-    const user = await User.scope({
-      method: ['includeShortUrl', shortUrl],
-    }).findOne()
+    const user = await User.scope([
+      { method: ['useMasterDb'] },
+      {
+        method: ['includeShortUrl', shortUrl],
+      },
+    ]).findOne()
 
     return this.userMapper.persistenceToDto(user)
   }
@@ -89,9 +97,12 @@ export class UserRepository implements UserRepositoryInterface {
     conditions: UserUrlsQueryConditions,
   ) => Promise<UrlsPaginated> = async (conditions) => {
     const notFoundMessage = 'Urls not found'
-    const userCountAndArray = await User.scope({
-      method: ['urlsWithQueryConditions', conditions],
-    }).findAndCountAll({
+    const userCountAndArray = await User.scope([
+      { method: ['useMasterDb'] },
+      {
+        method: ['urlsWithQueryConditions', conditions],
+      },
+    ]).findAndCountAll({
       subQuery: false, // set limit and offset at end of main query instead of subquery
     })
 

--- a/src/server/util/sequelize.ts
+++ b/src/server/util/sequelize.ts
@@ -1,11 +1,21 @@
 import Sequelize, { Transaction } from 'sequelize'
-import { databaseUri, dbPoolSize, logger } from '../config'
+import {
+  dbPoolSize,
+  logger,
+  masterDatabaseCredentials,
+  replicaDatabaseCredentials,
+} from '../config'
 
-export const sequelize = new Sequelize.Sequelize(databaseUri, {
+export const sequelize = new Sequelize.Sequelize({
+  dialect: 'postgres',
   timezone: '+08:00',
   logging: logger.info.bind(logger),
   pool: {
     max: dbPoolSize,
+  },
+  replication: {
+    read: [replicaDatabaseCredentials],
+    write: masterDatabaseCredentials,
   },
 })
 

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -219,7 +219,7 @@ describe('UrlRepository', () => {
       })
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
-      expect(scope).toHaveBeenCalledWith('getClicks')
+      expect(scope).toHaveBeenCalledWith(['useMasterDb', 'getClicks'])
     })
 
     it('should update non-file links', async () => {
@@ -236,7 +236,7 @@ describe('UrlRepository', () => {
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
       expect(update).toHaveBeenCalledWith({ description }, expect.anything())
-      expect(scope).toHaveBeenCalledWith('getClicks')
+      expect(scope).toHaveBeenCalledWith(['useMasterDb', 'getClicks'])
     })
 
     it('should update non-state changes on file links', async () => {
@@ -385,8 +385,18 @@ describe('UrlRepository', () => {
   })
 
   describe('getLongUrl', () => {
+    const scope = jest.spyOn(urlModelMock, 'scope')
+
+    beforeEach(() => {
+      scope.mockReset()
+      scope.mockReturnValue({
+        findOne: () => urlModelMock.findOne(),
+      })
+    })
+
     it('should return from db when cache is empty', async () => {
       await expect(repository.getLongUrl('a')).resolves.toBe('aa')
+      expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('should return from cache when cache is filled', async () => {
@@ -403,6 +413,7 @@ describe('UrlRepository', () => {
         return false
       })
       await expect(repository.getLongUrl('a')).resolves.toBe('aa')
+      expect(scope).toBeCalledWith('useMasterDb')
     })
   })
 
@@ -434,6 +445,10 @@ describe('UrlRepository', () => {
           },
         ],
       })
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ useMaster: true }),
+      )
     })
 
     it('should call sequelize.query that searches with plain text', async () => {
@@ -459,6 +474,10 @@ describe('UrlRepository', () => {
           },
         ],
       })
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ useMaster: true }),
+      )
     })
   })
 })

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -139,7 +139,7 @@ describe('UrlRepository', () => {
         },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith('getClicks')
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).not.toHaveBeenCalled()
     })
 
@@ -174,7 +174,7 @@ describe('UrlRepository', () => {
         },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith('getClicks')
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).toHaveBeenCalledWith({
         ContentType: file.mimetype,
         Bucket: s3Bucket,
@@ -219,7 +219,7 @@ describe('UrlRepository', () => {
       })
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
-      expect(scope).toHaveBeenCalledWith(['useMasterDb', 'getClicks'])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
     it('should update non-file links', async () => {
@@ -236,7 +236,7 @@ describe('UrlRepository', () => {
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
       expect(update).toHaveBeenCalledWith({ description }, expect.anything())
-      expect(scope).toHaveBeenCalledWith(['useMasterDb', 'getClicks'])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
     it('should update non-state changes on file links', async () => {
@@ -385,18 +385,8 @@ describe('UrlRepository', () => {
   })
 
   describe('getLongUrl', () => {
-    const scope = jest.spyOn(urlModelMock, 'scope')
-
-    beforeEach(() => {
-      scope.mockReset()
-      scope.mockReturnValue({
-        findOne: () => urlModelMock.findOne(),
-      })
-    })
-
     it('should return from db when cache is empty', async () => {
       await expect(repository.getLongUrl('a')).resolves.toBe('aa')
-      expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('should return from cache when cache is filled', async () => {
@@ -413,7 +403,6 @@ describe('UrlRepository', () => {
         return false
       })
       await expect(repository.getLongUrl('a')).resolves.toBe('aa')
-      expect(scope).toBeCalledWith('useMasterDb')
     })
   })
 

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -40,11 +40,19 @@ const expectedUrl = {
 
 describe('UserRepository', () => {
   describe('findById', () => {
-    const findByPk = jest.spyOn(userModelMock, 'findByPk')
+    const { scope } = userModelMock
+    const findByPk = jest.fn()
+
+    beforeEach(() => {
+      scope.mockReset()
+      scope.mockReturnValue({ findByPk })
+      findByPk.mockReset()
+    })
 
     it('returns null if no user found', async () => {
       findByPk.mockReturnValue(null)
       await expect(userRepo.findById(2)).resolves.toBeNull()
+      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
 
     it('returns user without urls if such a user found', async () => {
@@ -57,6 +65,7 @@ describe('UserRepository', () => {
         ...user,
         urls: undefined,
       })
+      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
 
     it('returns user with urls if such a user found', async () => {
@@ -71,16 +80,26 @@ describe('UserRepository', () => {
         email: user.email,
         urls: [expectedUrl],
       })
+      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
   })
 
   describe('findByEmail', () => {
-    const findOne = jest.spyOn(userModelMock, 'findOne')
+    const { scope } = userModelMock
+    const findOne = jest.fn()
+
+    beforeEach(() => {
+      scope.mockReset()
+      scope.mockReturnValue({ findOne })
+      findOne.mockReset()
+    })
+
     it('returns null if no user found', async () => {
       findOne.mockReturnValue(null)
       await expect(
         userRepo.findByEmail('user@agency.gov.sg'),
       ).resolves.toBeNull()
+      await expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('returns user without urls if such a user found', async () => {
@@ -95,6 +114,7 @@ describe('UserRepository', () => {
         ...user,
         urls: undefined,
       })
+      await expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('returns user with urls if such a user found', async () => {
@@ -111,13 +131,28 @@ describe('UserRepository', () => {
         email: user.email,
         urls: [expectedUrl],
       })
+      await expect(scope).toBeCalledWith('useMasterDb')
     })
   })
 
-  it('directs findOrCreateWithEmail to User.findOrCreate', async () => {
-    const findOrCreate = jest.spyOn(userModelMock, 'findOrCreate')
-    await userRepo.findOrCreateWithEmail('user@agency.gov.sg')
-    expect(findOrCreate).toHaveBeenCalled()
+  describe('findOrCreateByEmail', () => {
+    const { scope } = userModelMock
+    const findOrCreate = jest.fn()
+
+    beforeEach(() => {
+      scope.mockReset()
+      scope.mockReturnValue({ findOrCreate })
+      findOrCreate.mockReset()
+    })
+
+    it('directs findOrCreateWithEmail to User.findOrCreate', async () => {
+      const userObject = { email: 'user@agency.gov.sg' }
+      findOrCreate.mockResolvedValue([userObject, null])
+      await expect(
+        userRepo.findOrCreateWithEmail('user@agency.gov.sg'),
+      ).resolves.toBe(userObject)
+      await expect(scope).toHaveBeenCalledWith('useMasterDb')
+    })
   })
 
   describe('findOneUrlForUser', () => {
@@ -135,23 +170,27 @@ describe('UserRepository', () => {
       await expect(
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toBeNull()
-      expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', expectedUrl.shortUrl],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['includeShortUrl', expectedUrl.shortUrl],
+        },
+      ])
     })
 
     it('returns url for user', async () => {
       findOne.mockResolvedValue({
-        get: () => ({
-          Urls: [url],
-        }),
+        Urls: [url],
       })
       await expect(
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toStrictEqual(expectedUrl)
-      expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', expectedUrl.shortUrl],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['includeShortUrl', expectedUrl.shortUrl],
+        },
+      ])
     })
   })
 
@@ -177,9 +216,12 @@ describe('UserRepository', () => {
       ).resolves.toStrictEqual(
         expect.objectContaining({ id: user.id, email: user.email }),
       )
-      expect(scope).toHaveBeenCalledWith({
-        method: ['includeShortUrl', expectedUrl.shortUrl],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['includeShortUrl', expectedUrl.shortUrl],
+        },
+      ])
     })
   })
 
@@ -208,9 +250,12 @@ describe('UserRepository', () => {
       await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
         NotFoundError,
       )
-      expect(scope).toHaveBeenCalledWith({
-        method: ['urlsWithQueryConditions', conditions],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['urlsWithQueryConditions', conditions],
+        },
+      ])
     })
 
     it('throws NotFoundError on findAndCountAll without user', async () => {
@@ -218,13 +263,16 @@ describe('UserRepository', () => {
       await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
         NotFoundError,
       )
-      expect(scope).toHaveBeenCalledWith({
-        method: ['urlsWithQueryConditions', conditions],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['urlsWithQueryConditions', conditions],
+        },
+      ])
     })
 
     it('returns empty result on user without urls', async () => {
-      const rows = [{ get: () => ({ Urls: [] }) }]
+      const rows = [{ Urls: [] }]
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
       await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
         {
@@ -232,13 +280,16 @@ describe('UserRepository', () => {
           count: 0,
         },
       )
-      expect(scope).toHaveBeenCalledWith({
-        method: ['urlsWithQueryConditions', conditions],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['urlsWithQueryConditions', conditions],
+        },
+      ])
     })
 
     it('returns result on user with urls', async () => {
-      const rows = [{ get: () => ({ Urls: [url] }) }]
+      const rows = [{ Urls: [url] }]
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
       await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
         {
@@ -246,9 +297,12 @@ describe('UserRepository', () => {
           count: 1,
         },
       )
-      expect(scope).toHaveBeenCalledWith({
-        method: ['urlsWithQueryConditions', conditions],
-      })
+      expect(scope).toHaveBeenCalledWith([
+        { method: ['useMasterDb'] },
+        {
+          method: ['urlsWithQueryConditions', conditions],
+        },
+      ])
     })
   })
 })

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -40,19 +40,15 @@ const expectedUrl = {
 
 describe('UserRepository', () => {
   describe('findById', () => {
-    const { scope } = userModelMock
-    const findByPk = jest.fn()
+    const findByPk = jest.spyOn(userModelMock, 'findByPk')
 
     beforeEach(() => {
-      scope.mockReset()
-      scope.mockReturnValue({ findByPk })
       findByPk.mockReset()
     })
 
     it('returns null if no user found', async () => {
       findByPk.mockReturnValue(null)
       await expect(userRepo.findById(2)).resolves.toBeNull()
-      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
 
     it('returns user without urls if such a user found', async () => {
@@ -65,7 +61,6 @@ describe('UserRepository', () => {
         ...user,
         urls: undefined,
       })
-      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
 
     it('returns user with urls if such a user found', async () => {
@@ -80,17 +75,13 @@ describe('UserRepository', () => {
         email: user.email,
         urls: [expectedUrl],
       })
-      await expect(scope).toHaveBeenCalledWith('useMasterDb')
     })
   })
 
   describe('findByEmail', () => {
-    const { scope } = userModelMock
-    const findOne = jest.fn()
+    const findOne = jest.spyOn(userModelMock, 'findOne')
 
     beforeEach(() => {
-      scope.mockReset()
-      scope.mockReturnValue({ findOne })
       findOne.mockReset()
     })
 
@@ -99,7 +90,6 @@ describe('UserRepository', () => {
       await expect(
         userRepo.findByEmail('user@agency.gov.sg'),
       ).resolves.toBeNull()
-      await expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('returns user without urls if such a user found', async () => {
@@ -114,7 +104,6 @@ describe('UserRepository', () => {
         ...user,
         urls: undefined,
       })
-      await expect(scope).toBeCalledWith('useMasterDb')
     })
 
     it('returns user with urls if such a user found', async () => {
@@ -131,27 +120,23 @@ describe('UserRepository', () => {
         email: user.email,
         urls: [expectedUrl],
       })
-      await expect(scope).toBeCalledWith('useMasterDb')
     })
   })
 
   describe('findOrCreateByEmail', () => {
-    const { scope } = userModelMock
-    const findOrCreate = jest.fn()
+    const findOrCreate = jest.spyOn(userModelMock, 'findOrCreate')
 
     beforeEach(() => {
-      scope.mockReset()
-      scope.mockReturnValue({ findOrCreate })
       findOrCreate.mockReset()
     })
 
     it('directs findOrCreateWithEmail to User.findOrCreate', async () => {
-      const userObject = { email: 'user@agency.gov.sg' }
-      findOrCreate.mockResolvedValue([userObject, null])
+      const findOrCreate = jest.spyOn(userModelMock, 'findOrCreate')
+      const user = userModelMock.findOne()
+      findOrCreate.mockResolvedValue([user, null])
       await expect(
         userRepo.findOrCreateWithEmail('user@agency.gov.sg'),
-      ).resolves.toBe(userObject)
-      await expect(scope).toHaveBeenCalledWith('useMasterDb')
+      ).resolves.toBe(user)
     })
   })
 
@@ -171,7 +156,7 @@ describe('UserRepository', () => {
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toBeNull()
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -186,7 +171,7 @@ describe('UserRepository', () => {
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toStrictEqual(expectedUrl)
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -217,7 +202,7 @@ describe('UserRepository', () => {
         expect.objectContaining({ id: user.id, email: user.email }),
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -251,7 +236,7 @@ describe('UserRepository', () => {
         NotFoundError,
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -264,7 +249,7 @@ describe('UserRepository', () => {
         NotFoundError,
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -281,7 +266,7 @@ describe('UserRepository', () => {
         },
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -298,7 +283,7 @@ describe('UserRepository', () => {
         },
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['useMasterDb'] },
+        { method: ['defaultScope'] },
         {
           method: ['urlsWithQueryConditions', conditions],
         },

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -156,7 +156,7 @@ describe('UserRepository', () => {
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toBeNull()
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -171,7 +171,7 @@ describe('UserRepository', () => {
         userRepo.findOneUrlForUser(2, expectedUrl.shortUrl),
       ).resolves.toStrictEqual(expectedUrl)
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -202,7 +202,7 @@ describe('UserRepository', () => {
         expect.objectContaining({ id: user.id, email: user.email }),
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['includeShortUrl', expectedUrl.shortUrl],
         },
@@ -236,7 +236,7 @@ describe('UserRepository', () => {
         NotFoundError,
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -249,7 +249,7 @@ describe('UserRepository', () => {
         NotFoundError,
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -266,7 +266,7 @@ describe('UserRepository', () => {
         },
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['urlsWithQueryConditions', conditions],
         },
@@ -283,7 +283,7 @@ describe('UserRepository', () => {
         },
       )
       expect(scope).toHaveBeenCalledWith([
-        { method: ['defaultScope'] },
+        'defaultScope',
         {
           method: ['urlsWithQueryConditions', conditions],
         },


### PR DESCRIPTION
## Problem

Features such as analytics CSV download may prompt a large number of rows to be returned by the database. Too many such queries could exhaust database resources, affecting application stability.

Closes #1304 

## Solution

Configure sequelize to use read replication. Sequelize's default behaviour of using replicas for read operations is problematic for our use-case because we'd like to default to using the primary DB. In this PR, I propose the use of sequelize's `scope`. We specify a `defaultScope` that contains `useMaster: true`, which acts as a safeguard when contributors forget to include the `useMasterDb` scope. One would have to explicitly use `model.unscoped()` to remove the default `useMaster: true` behaviour.

But this approach is not foolproof, as default scopes also get overwritten when `model.scope()` is called; code reviews and further checks might be necessary moving forward.

As a rule of thumb, we are allowing the use of replica for statistics data and those that are usually already cached by redis.

## Deploy Notes

**New environment variables**:

- `REPLICA_URI` : DB_URI for the read replica (compulsory env var)

**New dependencies**:

- `pg-connection-string` : Parses the connection string and returns a struct which is compatible with sequelize's input format.
