### PR TITLE
feat(mergify): automatically merge bot dependency upgrades

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
         type: APPROVE
       merge:
         method: squash
-  - name: Approve and merge non-major version Snyk.io upgrades
+  - name: Approve and merge Snyk.io upgrades
     conditions:
       - author=snyk-bot
       - check-success~=CI

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+  - name: Approve and merge non-major version dependabot upgrades
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - check-success~=CI
+      - check-success~=Test
+      - check-success~=CodeQL
+      - check-success~=GitGuardian
+      - check-success~=coverage
+      - check-success~=snyk
+      - check-success~=End To End Tests
+      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+  - name: Approve and merge non-major version Snyk.io upgrades
+    conditions:
+      - author=snyk-bot
+      - check-success~=CI
+      - check-success~=Test
+      - check-success~=End To End Tests
+      - check-success~=CodeQL
+      - check-success~=GitGuardian
+      - check-success~=coverage
+      - check-success~=snyk
+      - title~=^\[Snyk\]
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - check-success~=CodeQL
       - check-success~=GitGuardian
       - check-success~=coverage
-      - check-success~=snyk
       - check-success~=End To End Tests
       - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
@@ -24,7 +23,6 @@ pull_request_rules:
       - check-success~=CodeQL
       - check-success~=GitGuardian
       - check-success~=coverage
-      - check-success~=snyk
       - title~=^\[Snyk\]
     actions:
       review:


### PR DESCRIPTION
This PR instructs the mergify bot to automatically merge pull requests from

1. dependabot
2. Snyk.io

Pull requests are automatically merged if

1. The proposed upgrade is a non-major version change (dependabot only)
2. All existing CI checks pass

Closes #1418

