### PR TITLE
feat(login-form): add referral to for.edu.sg

### DIFF
--- a/public/locales/edu/en/translation.json
+++ b/public/locales/edu/en/translation.json
@@ -4,6 +4,9 @@
     "shortUrlPrefix": "for.edu.sg/",
     "appTitle": "for.edu.sg",
     "officerType": "education",
+    "referralEmailDomain": "gov.sg",
+    "referralOfficerPhrase": "Public officers",
+    "referralLink": "go.gov.sg",
     "appCatchphrase": {
       "styled": "Trusted short links from <strong><i>education institutions</i></strong>",
       "noStyle": "Trusted short links from education institutions"

--- a/public/locales/gov/en/translation.json
+++ b/public/locales/gov/en/translation.json
@@ -4,6 +4,9 @@
     "shortUrlPrefix": "go.gov.sg/",
     "appTitle": "Go.gov.sg",
     "officerType": "public",
+    "referralEmailDomain": "edu.sg",
+    "referralOfficerPhrase": "Staff from selected schools",
+    "referralLink": "for.edu.sg",
     "appCatchphrase": {
       "styled": "Trusted short links from <strong><i>public officers</i></strong>",
       "noStyle": "Trusted short links from public officers"

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -74,6 +74,7 @@ const useStyles = makeStyles((theme) =>
     },
     loginReferral: {
       fontSize: '0.85rem',
+      color: '#767676',
       marginBottom: theme.spacing(4),
     },
     textInputGroup: {
@@ -243,10 +244,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                       variant="body1"
                     >
                       {i18next.t('general.referralOfficerPhrase')} can use their{' '}
-                      <strong>
-                        {i18next.t('general.referralEmailDomain')}
-                      </strong>{' '}
-                      emails at{' '}
+                      {i18next.t('general.referralEmailDomain')} emails at{' '}
                       <Link
                         href={`https://${i18next.t('general.referralLink')}`}
                       >

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -71,6 +71,9 @@ const useStyles = makeStyles((theme) =>
     },
     loginHeader: {
       marginTop: theme.spacing(1),
+    },
+    loginReferral: {
+      fontSize: '0.85rem',
       marginBottom: theme.spacing(4),
     },
     textInputGroup: {
@@ -234,10 +237,22 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                       Only available for use by{' '}
                       {i18next.t('general.officerType')} officers with an email
                       from <strong>{i18next.t('general.emailDomain')}</strong>.
-                      Staff from selected schools can use their{' '}
-                      <strong>edu.sg</strong> emails at{' '}
-                      <Link href="https://for.edu.sg">for.edu.sg</Link> to
-                      shorten links instead.
+                    </Typography>
+                    <Typography
+                      className={classes.loginReferral}
+                      variant="body1"
+                    >
+                      {i18next.t('general.referralOfficerPhrase')} can use their{' '}
+                      <strong>
+                        {i18next.t('general.referralEmailDomain')}
+                      </strong>{' '}
+                      emails at{' '}
+                      <Link
+                        href={`https://${i18next.t('general.referralLink')}`}
+                      >
+                        {i18next.t('general.referralLink')}
+                      </Link>{' '}
+                      to shorten links instead.
                     </Typography>
                   </span>
                   <span className={classes.textInputGroup}>

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -234,6 +234,10 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                       Only available for use by{' '}
                       {i18next.t('general.officerType')} officers with an email
                       from <strong>{i18next.t('general.emailDomain')}</strong>.
+                      Staff from selected schools can use their{' '}
+                      <strong>edu.sg</strong> emails at{' '}
+                      <Link href="https://for.edu.sg">for.edu.sg</Link> to
+                      shorten links instead.
                     </Typography>
                   </span>
                   <span className={classes.textInputGroup}>


### PR DESCRIPTION
## Problem

Add a quick liner on go.gov.sg to refer edu users to for.edu.sg.

Closes #1428

## Solution

**Features**:

- Modify login form to refer school staff with .edu.sg emails to for.edu.sg

## Screenshots

![Screenshot 2021-05-04 at 4 17 40 PM](https://user-images.githubusercontent.com/21305518/116977371-f0fc5b00-acf4-11eb-9760-53c6a3d03734.png)

## Tests

- [ ] Check that clicking on for.edu.sg redirects the user to for.edu.sg
