### PR TITLE
fix(mergify): do not mention : to pacify yaml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - check-success~=GitGuardian
       - check-success~=coverage
       - check-success~=End To End Tests
-      - title~=^build\(deps[^)]*\): bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - title~=^build\(deps[^)]*\). bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Problem and Solution

Mergify config was broken owing to the use of `:`, so replace it with a wildcard