### PR TITLE
fix/privacy: remove exposure of long URLs from GoDirectory

### DIFF
--- a/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
@@ -250,7 +250,6 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
             <div>
               <span className={classes.domainTextActive}>/{url.shortUrl}</span>
               <br />
-              <p className={classes.longLinkText}>{url.longUrl}</p>
             </div>
           ) : (
             <div>
@@ -258,7 +257,6 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
                 /{url.shortUrl}
               </span>
               <br />
-              <p className={classes.longLinkText}>{url.longUrl}</p>
             </div>
           )}
         </Typography>

--- a/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       [theme.breakpoints.up('md')]: {
         width: '40%',
-        paddingTop: theme.spacing(5.5),
+        paddingTop: theme.spacing(7.5),
         paddingRight: () => '10%',
         marginLeft: () => 0,
       },

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -154,7 +154,6 @@ export class UrlRepository implements UrlRepositoryInterface {
     conditions: DirectoryQueryConditions,
   ) => Promise<UrlDirectoryPaginated> = async (conditions) => {
     const { query, order, limit, offset, state, isFile, isEmail } = conditions
-
     const { tableName: urlTableName } = Url
     const { tableName: urlClicksTableName } = UrlClicks
 
@@ -274,7 +273,7 @@ export class UrlRepository implements UrlRepositoryInterface {
     const queryFile = this.getQueryFileText(isFile)
     const queryState = this.getQueryStateText(state)
     const rawQuery = `
-      SELECT "urls"."shortUrl", "users"."email", "urls"."state", "urls"."isFile", "urls"."longUrl"
+      SELECT "urls"."shortUrl", "users"."email", "urls"."state", "urls"."isFile"
       FROM urls AS "urls"
       JOIN url_clicks
       ON "urls"."shortUrl" = "url_clicks"."shortUrl"

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -54,7 +54,6 @@ export type UrlDirectory = {
   email: string
   state: string
   isFile: boolean
-  longUrl: string
 }
 
 export type UrlDirectoryPaginated = {


### PR DESCRIPTION
## Problem

Exposing the long URL on GoDirectory may reveal sensitive URLs if users are not savvy.

## Solution

Remove the long URL from both the UI and the `/search` API.

**Improvements**:

- Users cannot use GoDirectory to mine links for inactive links

## Screenshots

![image](https://user-images.githubusercontent.com/5690550/118641775-26cd3380-b80d-11eb-8ba7-b86681dbc13f.png)
