### PR TITLE
feat/warning: Warn users that their links will be indexable by search engines

### DIFF
--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -189,7 +189,8 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
             <>
               <div className={classes.fileInputDescWrapper}>
                 <Typography className={classes.labelText} variant="body1">
-                  Choose your file
+                  Choose your file (this will be <strong>publicly</strong>{' '}
+                  indexable by search engines)
                 </Typography>
                 <div className={classes.maxSizeTextWrapper}>
                   <Typography variant="caption" className={classes.maxSizeText}>

--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -158,7 +158,8 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
           {!isFile && (
             <>
               <Typography className={classes.labelText} variant="body1">
-                Original link
+                Original link (this will be <strong>publicly</strong> indexable
+                by search engines)
               </Typography>
               <TextField
                 error={!isValidLongUrl(longUrl, true)}


### PR DESCRIPTION
## Problem

Users may upload sensitive content that ends up being discovered by other users on the directory, or indexed by search engines.

## Solution

Add a suitable message to the creation modal for both link and file creation, that has been endorsed by @lisatjide .

**Improvements**:

- Users should (hopefully!) think twice about making sensitive documents public.


## Screenshots

LInk creation
![image](https://user-images.githubusercontent.com/5690550/118655271-f5a82f80-b81b-11eb-84ae-6217eae25595.png)

File creation
![image](https://user-images.githubusercontent.com/5690550/118655941-9bf43500-b81c-11eb-888c-bea91cad7546.png)
