### PR TITLE
build(deps): bump @sentry/react & @sentry/tracing to 6.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6791,13 +6791,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.2.tgz",
-      "integrity": "sha512-K5UGyEePtVPZIFMoiRafhd4Ov0M1kdozVsVKIPZrOpJyjQdPNX+fYDNL/h0nVmgOlE2S/uu4fl4mEfe/6aLShw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.5.1.tgz",
+      "integrity": "sha512-iVLCdEFwsoWAzE/hNknexPQjjDpMQV7mmaq9Z1P63bD6MfhwVTx4hG4pHn8HEvC38VvCVf1wv0v/LxtoODAYXg==",
       "requires": {
-        "@sentry/core": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/core": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
@@ -6827,46 +6827,46 @@
       }
     },
     "@sentry/core": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.2.tgz",
-      "integrity": "sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
+      "integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/minimal": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/hub": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.2.tgz",
-      "integrity": "sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
+      "integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
       "requires": {
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.2.tgz",
-      "integrity": "sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
+      "integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/types": "6.2.2",
+        "@sentry/hub": "6.5.1",
+        "@sentry/types": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/react": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.2.2.tgz",
-      "integrity": "sha512-yDuxPOD4j2WE5nX1p48GIqXwrrmwkjryFjtYvLgzGJkiGWLmGTrxrSqtUKrbqahJpKt3mi24Nkg0cMlsFB178g==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.5.1.tgz",
+      "integrity": "sha512-YeGi7FzInhMZQxiy5fKqb7kS6W+u4NfsjzsVV3bLjJ1kiVtbpzZ2gs+ObHqW3zVE622V4nL7A4P8/CBHbcm5PA==",
       "requires": {
-        "@sentry/browser": "6.2.2",
-        "@sentry/minimal": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/browser": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       },
@@ -6882,28 +6882,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.2.tgz",
-      "integrity": "sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.1.tgz",
+      "integrity": "sha512-y1W/xFC2hAuKqSuuaovkElHY4pbli3XoXrreesg8PtO7ilX6ZbatOQbHsEsHQyoUv0F6aVA+MABOxWH2jt7tfw==",
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/minimal": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/hub": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.2.tgz",
-      "integrity": "sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
+      "integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA=="
     },
     "@sentry/utils": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.2.tgz",
-      "integrity": "sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
+      "integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
       "requires": {
-        "@sentry/types": "6.2.2",
+        "@sentry/types": "6.5.1",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@material-ui/core": "^4.11.4",
-    "@sentry/react": "^6.2.2",
-    "@sentry/tracing": "^6.2.2",
+    "@sentry/react": "^6.5.1",
+    "@sentry/tracing": "^6.5.1",
     "@types/express-rate-limit": "^5.1.1",
     "aws-sdk": "^2.906.0",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
The only way to upgrade sentry is to [bump them both together](https://github.com/getsentry/sentry-javascript/issues/2670#issuecomment-749848872). Dependabot doesn't have that feature so I'm opening this PR manually