### PR TITLE
feat(user-route): validate type of req.body.email

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -37,7 +37,7 @@ function preprocess(
   _: Express.Response,
   next: Express.NextFunction,
 ) {
-  if (req.body.email) {
+  if (req.body.email && typeof req.body.email === 'string') {
     req.body.email = req.body.email.trim().toLowerCase()
   }
 


### PR DESCRIPTION
## Problem

`req.body` is based on user-controlled input and so `req.body.email` could be crafted with a custom .trim() property. Calling .trim() before validating the variable's type is unsafe.

## Solution

Enforce that the type is a string.

