### PR TITLE
chore: add health cicd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,12 +292,16 @@ jobs:
           local-image: my-image
           image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
   deploy-edu:
-    name: Deploy to Elastic Beanstalk for edu
+    name: Deploy to Elastic Beanstalk and AWS Lambda for edu
     runs-on: ubuntu-18.04
     needs: [ci, test, gatekeep, build-edu]
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Package Dockerrun.aws.json
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
@@ -317,6 +321,13 @@ jobs:
         env:
           TAG: ${{ needs.build-edu.outputs.tag }}
           TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
+      - run: |
+          echo SERVERLESS_SERVICE=edu >> $GITHUB_ENV; 
+          if [[ $GITHUB_REF == $STAGING_BRANCH ]]; then
+            echo SERVERLESS_STAGE=staging >> $GITHUB_ENV;
+          elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
+            echo SERVERLESS_STAGE=production >> $GITHUB_ENV;
+          fi
       - name: Select Elastic Beanstalk variables
         shell: python
         run: |
@@ -349,6 +360,16 @@ jobs:
           use_existing_version_if_available: true
           wait_for_deployment: false
           wait_for_environment_recovery: false
+      - name: serverless deploy
+        uses: opengovsg/serverless-github-action@master
+        with:
+          args: -c "serverless plugin install --name serverless-plugin-include-dependencies && serverless deploy --conceal -v"
+          entrypoint: /bin/bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVERLESS_SERVICE: ${{ env.SERVERLESS_SERVICE }}
+          SERVERLESS_STAGE: ${{ env.SERVERLESS_STAGE }}
   build-health:
     name: Build and push for health
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
           TAG: ${{ needs.build-gogov.outputs.tag }}
           TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
       - run: |
+          echo SERVERLESS_SERVICE=gogovsg >> $GITHUB_ENV;
           if [[ $GITHUB_REF == $STAGING_BRANCH ]]; then
             echo SERVERLESS_STAGE=staging >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
@@ -258,6 +259,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVERLESS_SERVICE: ${{ env.SERVERLESS_SERVICE }}
           SERVERLESS_STAGE: ${{ env.SERVERLESS_STAGE }}
   build-edu:
     name: Build and push for edu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   EB_APP_STAGING: gosg-stag
   EB_ENV_STAGING: gosg-stag
   EB_ENV_EDU_STAGING: edu-staging
+  EB_ENV_HEALTH_STAGING: health-staging
   ECR_URL: 116366738264.dkr.ecr.ap-southeast-1.amazonaws.com
   ECR_REPO: gogovsg
   SENTRY_URL: https://sentry.io/
@@ -340,6 +341,89 @@ jobs:
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           application_name: ${{ steps.select_eb_vars.outputs.eb_app }}
           environment_name: ${{ steps.select_eb_vars.outputs.eb_env_edu }}
+          version_label: ${{ steps.get_label.outputs.label }}
+          region: ap-southeast-1
+          deployment_package: deploy.zip
+          use_existing_version_if_available: true
+          wait_for_deployment: false
+          wait_for_environment_recovery: false
+  build-health:
+    name: Build and push for health
+    runs-on: ubuntu-18.04
+    needs: [gatekeep]
+    if: needs.gatekeep.outputs.proceed == 'true'
+    outputs:
+      branch: ${{ steps.extract_branch.outputs.branch }}
+      tag: ${{steps.extract_tag.outputs.tag}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Extract ECR tag
+        shell: bash
+        run: echo "##[set-output name=tag;]$(echo ghactions-${BRANCH}-${SHA}-health)"
+        id: extract_tag
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          SHA: ${{ github.sha }}
+      - run: docker build --tag my-image --build-arg __ASSET_VARIANT=edu . # TODO: replaced when assets are ready
+      - name: Push to ECR
+        uses: opengovsg/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ap-southeast-1
+          local-image: my-image
+          image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
+  deploy-health:
+    name: Deploy to Elastic Beanstalk for health
+    runs-on: ubuntu-18.04
+    needs: [ci, test, gatekeep, build-health]
+    if: needs.gatekeep.outputs.proceed == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Package Dockerrun.aws.json
+        run: |
+          sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
+          sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
+          zip -r "deploy.zip" Dockerrun.aws.json
+        env:
+          REPO: ${{env.ECR_URL}}/${{env.ECR_REPO}}
+          TAG: ${{ needs.build-health.outputs.tag }}
+      - name: Get timestamp
+        shell: bash
+        run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"
+        id: get_timestamp
+      - name: Get Elastic Beanstalk label
+        shell: bash
+        run: echo "##[set-output name=label;]$(echo ${TAG}-${TIMESTAMP})"
+        id: get_label
+        env:
+          TAG: ${{ needs.build-health.outputs.tag }}
+          TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
+      - name: Select Elastic Beanstalk variables
+        shell: python
+        run: | #TODO: add production actions
+          import os
+          branch = os.environ['GITHUB_REF']
+          staging = os.environ['STAGING_BRANCH']
+          production = os.environ['PRODUCTION_BRANCH']
+          eb_app_staging = os.environ['EB_APP_STAGING']
+          eb_env_health_staging = os.environ['EB_ENV_HEALTH_STAGING']
+          if branch == staging:
+            print('::set-output name=eb_app::' + eb_app_staging)
+            print('::set-output name=eb_env_health::' + eb_env_health_staging)
+        id: select_eb_vars
+      - name: Deploy to EB health
+        uses: opengovsg/beanstalk-deploy@v11
+        if: steps.select_eb_vars.outputs.eb_env_health
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ steps.select_eb_vars.outputs.eb_app }}
+          environment_name: ${{ steps.select_eb_vars.outputs.eb_env_health }}
           version_label: ${{ steps.get_label.outputs.label }}
           region: ap-southeast-1
           deployment_package: deploy.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,12 +380,16 @@ jobs:
           local-image: my-image
           image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
   deploy-health:
-    name: Deploy to Elastic Beanstalk for health
+    name: Deploy to Elastic Beanstalk and AWS Lambda for health
     runs-on: ubuntu-18.04
     needs: [ci, test, gatekeep, build-health]
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Package Dockerrun.aws.json
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
@@ -394,6 +398,13 @@ jobs:
         env:
           REPO: ${{env.ECR_URL}}/${{env.ECR_REPO}}
           TAG: ${{ needs.build-health.outputs.tag }}
+      - run: |
+          echo SERVERLESS_SERVICE=health >> $GITHUB_ENV;
+          if [[ $GITHUB_REF == $STAGING_BRANCH ]]; then
+            echo SERVERLESS_STAGE=staging >> $GITHUB_ENV;
+          elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
+            echo SERVERLESS_STAGE=production >> $GITHUB_ENV;
+          fi
       - name: Get timestamp
         shell: bash
         run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"
@@ -432,3 +443,13 @@ jobs:
           use_existing_version_if_available: true
           wait_for_deployment: false
           wait_for_environment_recovery: false
+      - name: serverless deploy
+        uses: opengovsg/serverless-github-action@master
+        with:
+          args: -c "serverless plugin install --name serverless-plugin-include-dependencies && serverless deploy --conceal -v"
+          entrypoint: /bin/bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVERLESS_SERVICE: ${{ env.SERVERLESS_SERVICE }}
+          SERVERLESS_STAGE: ${{ env.SERVERLESS_STAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   EB_ENV_STAGING: gosg-stag
   EB_ENV_EDU_STAGING: edu-staging
   EB_ENV_HEALTH_STAGING: health-staging
+  EB_ENV_HEALTH_PRODUCTION: health-production
   ECR_URL: 116366738264.dkr.ecr.ap-southeast-1.amazonaws.com
   ECR_REPO: gogovsg
   SENTRY_URL: https://sentry.io/
@@ -439,16 +440,21 @@ jobs:
           TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
       - name: Select Elastic Beanstalk variables
         shell: python
-        run: | #TODO: add production actions
+        run: |
           import os
           branch = os.environ['GITHUB_REF']
           staging = os.environ['STAGING_BRANCH']
           production = os.environ['PRODUCTION_BRANCH']
           eb_app_staging = os.environ['EB_APP_STAGING']
           eb_env_health_staging = os.environ['EB_ENV_HEALTH_STAGING']
+          eb_app_production = os.environ['EB_APP_PRODUCTION']
+           eb_env_health_production = os.environ['EB_ENV_HEALTH_PRODUCTION']
           if branch == staging:
             print('::set-output name=eb_app::' + eb_app_staging)
             print('::set-output name=eb_env_health::' + eb_env_health_staging)
+          elif branch == production: 
+             print('::set-output name=eb_app::' + eb_app_production)
+             print('::set-output name=eb_env_health::' + eb_env_health_production)
         id: select_eb_vars
       - name: Deploy to EB health
         uses: opengovsg/beanstalk-deploy@v11

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: gogovsg
+service: ${env:SERVERLESS_SERVICE}
 frameworkVersion: '2'
 
 provider:


### PR DESCRIPTION
## Context

_How did you solve the problem?_

This PR adds the following deployment actions to our GitHub Actions:
- Deploys GoGov web application to `health-staging` Elastic Beanstalk
- Deploys GoGov web application to `health-production` Elastic Beanstalk
- Deploys GoGov Serverless migration functions to `health-*` Lambda
- Deploys GoGov Serverless migration functions to `edu-*` Lambda

This PR uses the `edu` asset variant in the CI/CD pipeline for building the health environment. We will replace the asset variant in a later PR when the health assets are ready. 

## Tests
_What tests should be run to confirm functionality?_

Push branch to `edge`
- [ ] Verify that all deployment actions occur correctly via GitHub Actions console
- [ ] Verify on Elastic Beanstalk console that EB staging applications have been redeployed 
- [ ] Verify on Lambda console that Lambda staging applications have been redeployed 

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

1) This PR uses the `edu` asset variant in the CI/CD pipeline for building the health environment. We will replace the asset variant in a later PR when the health assets are ready. 

2) `health-production` and `edu-production` Lambda functions have not been set up yet. If the branch is pushed to production, the Lambda functions will be generated from scratch, and we will need to log in to configure the network configurations. 
