### PR TITLE
Fix/url history defaults

### DIFF
--- a/src/server/db_migrations/20220406_add_description_default_value.sql
+++ b/src/server/db_migrations/20220406_add_description_default_value.sql
@@ -1,0 +1,12 @@
+-- This script was written to fix an incorrect url_histories model.
+-- The description column in the url_histories model had a non-null 
+-- constraint without a default value. As edusg and healthsg tables
+-- were set up with the faulty model, there were errors writing into 
+-- the tables when description was empty.
+-- This script was written for migration on edusg and healthsg.
+
+BEGIN TRANSACTION;
+
+ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';
+
+COMMIT;

--- a/src/server/db_migrations/20220406_add_description_default_value.sql
+++ b/src/server/db_migrations/20220406_add_description_default_value.sql
@@ -7,6 +7,6 @@
 
 BEGIN TRANSACTION;
 
-ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';
+ALTER TABLE url_histories ALTER "description" SET DEFAULT '';
 
 COMMIT;

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -69,6 +69,7 @@ export const UrlHistory = <UrlHistoryStatic>sequelize.define('url_history', {
   description: {
     type: Sequelize.TEXT,
     allowNull: false,
+    defaultValue: '',
   },
 })
 

--- a/src/server/serverless/lambda-migrate-url-to-user/migrate_url_to_user.sql
+++ b/src/server/serverless/lambda-migrate-url-to-user/migrate_url_to_user.sql
@@ -16,6 +16,8 @@
 --                                      isSearchable column
 --   16 Nov  2020 @LoneRifle:           Update function's url_history insertion step to remove 
 --                                      isSearchable column
+--   01 Apr  2021 Alexis Goh:           Update function's url_history insertion step to include
+--                                      description column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_url_to_user(short_url_value text, to_user_email text) RETURNS void AS
 $BODY$
@@ -47,8 +49,8 @@ BEGIN
         RAISE EXCEPTION 'No transferring of links to the same user';
     END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","description","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "shortUrl" = short_url LIMIT 1;
 -- Update the link in the URL table

--- a/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
+++ b/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
@@ -18,6 +18,8 @@
 --                            compulsory isSearchable column
 --   16 Nov  2020 @LoneRifle: Update function's url_history insertion step to remove 
 --                            isSearchable column
+--   01 Apr  2021 Alexis Goh: Update function's url_history insertion step to include
+--                            description column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS void AS
 $BODY$
@@ -43,8 +45,8 @@ BEGIN
 		RAISE EXCEPTION 'No transferring of links to the same user';
 	END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","description","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "userId" = from_user_id;
 -- Update the links in the URL table


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Lambda functions for migrating links were not running successfully on `health-staging-db` as the `description` column in `url_histories` tables had a constraint that enforced non-null values but did not set a default value.

Related to this, the two SQL migration functions did not include `description` as an indexed column from `url` table when inserting the link into the `url_histories` table. Hence, when a new migration attempted to occur, the `description` in the `url` table was not being copied into the new row in `url_histories` table, so the column defaulted to `null`, violating the non-null constraint. 

## Solution

_How did you solve the problem?_

- Updated SQL functions to include `description` as an indexed column on `url` table when inserting the link into the `url_histories` table
- Added empty string as a default on `description` column in `url_histories` table in database models

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

_What tests should be run to confirm functionality?_

- [x] Test `migrate-short-link` on `health-staging`
- [x] Test `migrate-user-links` on `health-staging`


## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

### Related fixes

#### Code changes
- [x] Fix migration functions to add `description` when migrating url
- [x] Update Sequelize models to add default empty string “” for `description` column in `url_histories` table

#### Update current databases

Health
- [x] Run migration to fix this in `health-staging`
  - [x] ```ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';```
  - [x] Update migration function `migrate-user-links`
  - [x] Update migration function `migrate-shortUrl-to-user`
- [ ] Verify that this does not occur in `health-prod` since the model should be fixed 

Edu
- [x] Run migration to fix this in `edu-staging`
  - [x] ```ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';```
  - [x] Add migration function `migrate-user-links`
  - [x] Add migration function `migrate-shortUrl-to-user`
- [x] Run migration to fix this in  `edu-prod`
  - [x] ```ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';```
  - [x] Add migration function `migrate-user-links`
  - [x] Add migration function `migrate-shortUrl-to-user`

GoGov
- [x] Run migration to fix this in `gogov-staging`
  - ~```ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';```~ (Not necessary in `gogov-staging` and `gogov-prod` as previous migrations have added a default)
  - [x] Update migration function `migrate-user-links`
  - [x] Update migration function `migrate-shortUrl-to-user`
- [x] Run migration to fix this in `gogov-prod`
  - ~```ALTER TABLE url_histories ADD "description" text NOT NULL DEFAULT '';```~ (Not necessary in `gogov-staging` and `gogov-prod` as previous migrations have added a default)
  - [x]  Update migration function `migrate-user-links`
  - [x] Update migration function `migrate-shortUrl-to-user`

___

- [ ] Look into debugging count for number of rows affected