### PR TITLE
chore: log user email in malicious file upload alert

### DIFF
--- a/src/server/modules/threat/FileCheckController.ts
+++ b/src/server/modules/threat/FileCheckController.ts
@@ -47,7 +47,9 @@ export class FileCheckController {
         if (hasVirus) {
           const user = req.session?.user
           logger.warn(
-            `Malicious file attempt: User ${user?.id} tried to upload ${file.name}`,
+            `Malicious file attempt: User ${
+              user?.email || user?.id
+            } tried to upload ${file.name}`,
           )
           res.badRequest(jsonMessage('File is likely to be malicious.'))
           return


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Currently, malicious file upload alerts only logs user ID, which is unhelpful for debugging purposes as we need to retrieve user email and contact them for tracing purposes. Closes #1785

## Solution

_How did you solve the problem?_

Retrieve user email from session token and logs it in alert for easier retrieval.
<img width="1332" alt="Screenshot 2022-05-11 at 5 26 38 PM" src="https://user-images.githubusercontent.com/39231249/167817079-33ac3a95-01f0-41cd-acda-4d36a2e03882.png">

