### PR TITLE
Chore/trusted by

### DIFF
--- a/public/locales/edu/en/translation.json
+++ b/public/locales/edu/en/translation.json
@@ -48,6 +48,16 @@
       "fileSharing": {
         "description": "Upload your file to share it with anyone, using a customised and trustworthy $t(general.emailDomain) short link."
       }
+    },
+    "trustedBy": {
+      "1": "MOM",
+      "2": "LTA",
+      "3": "MOH",
+      "4": "MSF",
+      "5": "SPF",
+      "6": "IRAS",
+      "7": "MOE",
+      "8": "MHA"
     }
   }
 }

--- a/public/locales/gov/en/translation.json
+++ b/public/locales/gov/en/translation.json
@@ -48,6 +48,16 @@
       "fileSharing": {
         "description": "Upload your file to share it with anyone, using a customised and trustworthy go.gov.sg short link."
       }
+    },
+    "trustedBy": {
+      "1": "MOM",
+      "2": "LTA",
+      "3": "MOH",
+      "4": "MSF",
+      "5": "SPF",
+      "6": "IRAS",
+      "7": "MOE",
+      "8": "MHA"
     }
   }
 }

--- a/public/locales/health/en/translation.json
+++ b/public/locales/health/en/translation.json
@@ -48,6 +48,16 @@
       "fileSharing": {
         "description": "Upload your file to share it with anyone, using a customised and trustworthy $t(general.emailDomain) short link."
       }
+    },
+    "trustedBy": {
+      "1": "MOM",
+      "2": "LTA",
+      "3": "MOH",
+      "4": "MSF",
+      "5": "SPF",
+      "6": "IRAS",
+      "7": "MOE",
+      "8": "MHA"
     }
   }
 }

--- a/src/client/home/components/TrustedBySliver.tsx
+++ b/src/client/home/components/TrustedBySliver.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { Grid, Typography, createStyles, makeStyles } from '@material-ui/core'
+import i18next from 'i18next'
+
 import trustedBy1 from '@assets/components/home/trusted-by-sliver/1.png'
 import trustedBy2 from '@assets/components/home/trusted-by-sliver/2.png'
 import trustedBy3 from '@assets/components/home/trusted-by-sliver/3.png'
@@ -8,8 +10,6 @@ import trustedBy5 from '@assets/components/home/trusted-by-sliver/5.png'
 import trustedBy6 from '@assets/components/home/trusted-by-sliver/6.png'
 import trustedBy7 from '@assets/components/home/trusted-by-sliver/7.png'
 import trustedBy8 from '@assets/components/home/trusted-by-sliver/8.png'
-
-import i18next from 'i18next'
 
 const useStyles = makeStyles((theme) =>
   createStyles({

--- a/src/client/home/components/TrustedBySliver.tsx
+++ b/src/client/home/components/TrustedBySliver.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { Grid, Typography, createStyles, makeStyles } from '@material-ui/core'
-import trustedByMom from '@assets/components/home/trusted-by-sliver/1.png'
-import trustedByLta from '@assets/components/home/trusted-by-sliver/2.png'
-import trustedByMoh from '@assets/components/home/trusted-by-sliver/3.png'
-import trustedByMsf from '@assets/components/home/trusted-by-sliver/4.png'
-import trustedBySpf from '@assets/components/home/trusted-by-sliver/5.png'
-import trustedByIras from '@assets/components/home/trusted-by-sliver/6.png'
-import trustedByMoe from '@assets/components/home/trusted-by-sliver/7.png'
-import trustedByMha from '@assets/components/home/trusted-by-sliver/8.png'
+import trustedBy1 from '@assets/components/home/trusted-by-sliver/1.png'
+import trustedBy2 from '@assets/components/home/trusted-by-sliver/2.png'
+import trustedBy3 from '@assets/components/home/trusted-by-sliver/3.png'
+import trustedBy4 from '@assets/components/home/trusted-by-sliver/4.png'
+import trustedBy5 from '@assets/components/home/trusted-by-sliver/5.png'
+import trustedBy6 from '@assets/components/home/trusted-by-sliver/6.png'
+import trustedBy7 from '@assets/components/home/trusted-by-sliver/7.png'
+import trustedBy8 from '@assets/components/home/trusted-by-sliver/8.png'
+
+import i18next from 'i18next'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -48,18 +50,18 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-const trustedLogos = [
-  { name: 'MOM', icon: trustedByMom },
-  { name: 'LTA', icon: trustedByLta },
-  { name: 'MOH', icon: trustedByMoh },
-  { name: 'MSF', icon: trustedByMsf },
-  { name: 'SPF', icon: trustedBySpf },
-  { name: 'IRAS', icon: trustedByIras },
-  { name: 'MOE', icon: trustedByMoe },
-  { name: 'MHA', icon: trustedByMha },
-]
-
 const TrustedBySliver = () => {
+  const trustedLogos = [
+    { name: i18next.t('homePage.trustedBy.1'), icon: trustedBy1 },
+    { name: i18next.t('homePage.trustedBy.2'), icon: trustedBy2 },
+    { name: i18next.t('homePage.trustedBy.3'), icon: trustedBy3 },
+    { name: i18next.t('homePage.trustedBy.4'), icon: trustedBy4 },
+    { name: i18next.t('homePage.trustedBy.5'), icon: trustedBy5 },
+    { name: i18next.t('homePage.trustedBy.6'), icon: trustedBy6 },
+    { name: i18next.t('homePage.trustedBy.7'), icon: trustedBy7 },
+    { name: i18next.t('homePage.trustedBy.8'), icon: trustedBy8 },
+  ]
+
   const classes = useStyles()
   return (
     <>

--- a/src/client/home/index.tsx
+++ b/src/client/home/index.tsx
@@ -6,7 +6,7 @@ import { useMediaQuery, useTheme } from '@material-ui/core'
 import homeActions from './actions'
 import loginActions from '../login/actions'
 import { USER_PAGE } from '../app/util/types'
-// import TrustedBySliver from './components/TrustedBySliver'
+import TrustedBySliver from './components/TrustedBySliver'
 import StatisticsSliver from './components/StatisticsSliver'
 import DescriptionSliver from './components/FeatureListSliver'
 import Section from '../app/components/Section'
@@ -51,11 +51,11 @@ const HomePage: FunctionComponent = () => {
       }
     >
       <LandingGraphicSilver />
-      {/* <div id="landing-bottom">
+      <div id="landing-bottom">
         <Section backgroundType="light">
           <TrustedBySliver />
         </Section>
-      </div> */}
+      </div>
       <div id="landing-description">
         <Section backgroundType="dark">
           <DescriptionSliver />


### PR DESCRIPTION
## Problem

We would like to add a TrustedBy section to our homepage to help establish more trust in our link shortener, by displaying the logos of some of the agencies that use our link shortener.

## Solution


Previously, we had a TrustedBy section that was commented out as we did not see a use case for it. This PR performs the following changes:
- Restores the TrustedBy section on the homepage
- Refactors the alt text to import text from locales

Importing the alt text from locales will allow us to swap between different trusted organisations across our 3 environments.

## Before & After Screenshots

**AFTER**:
[insert screenshot here]
<img width="1792" alt="Screenshot 2022-05-25 at 18 42 59" src="https://user-images.githubusercontent.com/39231249/170316496-675a0882-187a-4fe7-abea-bd4dd9065f96.png">
