### PR TITLE
fix: pin testcafe version to fix faulty e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Install TestCafe from 'npm' and Run Tests
         uses: DevExpress/testcafe-action@6114d4290399f0e36ac0be3ca56b6713dc2fab3d # pin@v0.0.3
         with:
+          version: "1.18.6"
           args: 'chrome:headless ./test/end-to-end --app "npm run dev" --app-init-delay 270000'
   gatekeep:
     name: Determine if Build & Deploy is needed


### PR DESCRIPTION
## Problem

Our E2E tests are breaking as we have not pinned Testcafe's version, and there seems to be some bugs in handling asynchronicity in Testcafe's new v1.19 release. 

**Details**
Tests are failing with the following error thrown by Testcafe's internal libraries:
```
internal/util.js:279
    throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
    ^
TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function. Received undefined
```

## Solution
[Pin Testcafe to v1.18.6](https://github.com/DevExpress/testcafe-action#version) as we do not want updates to the library to break our testing.

