### PR TITLE
Chore/node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
@@ -55,7 +55,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
@@ -123,7 +123,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
@@ -196,10 +196,10 @@ jobs:
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Package Dockerrun.aws.json
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
@@ -303,10 +303,10 @@ jobs:
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Package Dockerrun.aws.json
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
@@ -412,10 +412,10 @@ jobs:
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Package Dockerrun.aws.json
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ frameworkVersion: '2'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: ${env:SERVERLESS_STAGE}
   region: ap-southeast-1
   memorySize: 256


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Node 12 has reached its EOL and no longer provides any [security support](https://endoflife.date/nodejs). Currently, our Github CI actions for ci, testing and Sentry sourcemap compiling runs on Node 12, as well as our Serverless user functions. We upgrade these to run on Node 14.

Partially closes #1811 

## Solution

_How did you solve the problem?_

- Upgraded GitHub Actions Node runtime from 12 to 14 on staging
- Ran through [release checklist ](https://github.com/opengovsg/GoGovSG/wiki/Release-Checklist) on staging
- Upgraded Serverless functions
- Tested out Serverless functions

## Deploy Notes

For the lambdas, **we will have to reconfigure the VPC and the environment variables and test for functionality after deployment,** as the VPC configurations and environment variables are dropped when the runtimes changes.

As these lambda functions are meant for internal use, we do not foresee this having any public impact. The reconfiguration + tests should not take longer than an hour.
