### PR TITLE
fix: replace gh-ecr-push action for aws-cli-v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,15 +180,23 @@ jobs:
         env:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
           SHA: ${{ github.sha }}
-      - run: docker build --tag my-image .
-      - name: Push to ECR
-        uses: opengovsg/gh-ecr-push@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          region: ap-southeast-1
-          local-image: my-image
-          image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - name: Login to Amazon ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
+          TAG: ${{ steps.extract_tag.outputs.tag }}
+        run: |
+          docker build --tag my-image .
+          docker tag my-image ${REPO}:${TAG}
+          docker push ${REPO}:${TAG}
   deploy-gogov:
     name: Deploy to Elastic Beanstalk and AWS Lambda for gogov
     runs-on: ubuntu-18.04
@@ -287,15 +295,23 @@ jobs:
         env:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
           SHA: ${{ github.sha }}
-      - run: docker build --tag my-image --build-arg __ASSET_VARIANT=edu .
-      - name: Push to ECR
-        uses: opengovsg/gh-ecr-push@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          region: ap-southeast-1
-          local-image: my-image
-          image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - name: Login to Amazon ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
+          TAG: ${{ steps.extract_tag.outputs.tag }}
+        run: |
+          docker build --tag my-image --build-arg __ASSET_VARIANT=edu .
+          docker tag my-image ${REPO}:${TAG}
+          docker push ${REPO}:${TAG}
   deploy-edu:
     name: Deploy to Elastic Beanstalk and AWS Lambda for edu
     runs-on: ubuntu-18.04
@@ -396,15 +412,23 @@ jobs:
         env:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
           SHA: ${{ github.sha }}
-      - run: docker build --tag my-image --build-arg __ASSET_VARIANT=health .
-      - name: Push to ECR
-        uses: opengovsg/gh-ecr-push@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          region: ap-southeast-1
-          local-image: my-image
-          image: ${{ env.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - name: Login to Amazon ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
+          TAG: ${{ steps.extract_tag.outputs.tag }}
+        run: |
+          docker build --tag my-image --build-arg __ASSET_VARIANT=health .
+          docker tag my-image ${REPO}:${TAG}
+          docker push ${REPO}:${TAG}
   deploy-health:
     name: Deploy to Elastic Beanstalk and AWS Lambda for health
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Our Github action workflow [opengovsg/gh-ecr-push@v1](https://github.com/opengovsg/gh-ecr-push/blob/master/main.js) no longer works on Github's Ubuntu 18 virtual machines as the virtual machines [have updated their AWS CLI installation to AWS CLI v2](https://github.com/actions/virtual-environments/commit/17683c89ff78fb10446d23204f908bb888a23730). As a result, the command `aws ecr get-login` ([line 26](https://github.com/opengovsg/gh-ecr-push/blob/5c8dff7f31948b22222e5f2aac5a19074dbb9fa4/main.js#L26)) is deprecated, [causing our CI/CD runs to break](https://github.com/opengovsg/GoGovSG/actions/runs/2547549794). 

## Solution

_How did you solve the problem?_

Initially, we considered 1) pulling the newest version from the [original upstream](https://github.com/jwalton/gh-ecr-push) or 2) updating our OGP fork specifically to be compatible with AWS CLI v2.

However, following [FormSg](https://github.com/opengovsg/FormSG/blob/0cf7f25bb5ecfcd4c6306b09d03bd5f7b44a3135/.github/workflows/deploy-eb.yml#L58-L62) and [Redeem](https://github.com/datagovsg/redeem-api/blob/develop/.github/workflows/ecs-deployment.yml#L50-L60)'s new patterns, I've instead swapped the workflow out to use the official AWS Actions, `aws-actions/configure-aws-credentials@v1` and `aws-actions/amazon-ecr-login@v1` for logging in, and to run the Docker build, tag and push commands separately.

## Tests

_What tests should be run to confirm functionality?_
- [x] Test deployment pipeline on `edge`
  - [x] Deployment should complete successfully
  - [x] Latest images should be in ECR
  - [x] EB should use latest images from ECR
  - [x] Staging environment should be working/ pass manual tests

