### PR TITLE
chore: update Dockerfile.dev to be friendly to M1 Mac machine

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.12
+FROM --platform=amd64 node:14-alpine3.12
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 


### PR DESCRIPTION
## Problem

`npm run dev` doesn't work in M1 Macbook due to Docker build fail. The issue is reported [here](https://github.com/docker/for-mac/issues/6356)

Closes [insert issue #]

## Solution

**Bug Fixes**:

By updating the dockerfile.dev with `--platform=amd64`, we force the platform to be `amd64` and this seems to fix the build. No other solution has been found on this.

