### PR TITLE
chore: update readme with node v14 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ With GoGovSg, citizens are safe in the knowledge that the links are **official**
 
 ## Getting Started
 
+Make sure you have node version `14`, docker-compose version >= `1.23.1` and Docker version >= `18.09.0` installed.
+
 Start by cloning the repository and installing dependencies.
 
 ```bash
@@ -58,8 +60,6 @@ npm install
 ```
 
 ### Running Locally
-
-Make sure you have docker-compose version >= `1.23.1` and Docker version >= `18.09.0` installed. Then run:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Problem

Go is currently on node 14, but this is not reflected in the readme. Using other node versions may lead to developers having issues with setup or npm installation

## Solution

Update readme to direct developers to install and use node 14 through nvm
