### PR TITLE
fix(lambda): return correct number of migrated links from lambda functions

### DIFF
--- a/src/server/serverless/lambda-migrate-url-to-user/index.js
+++ b/src/server/serverless/lambda-migrate-url-to-user/index.js
@@ -16,13 +16,11 @@ async function handler(event) {
     const sqlScript = `SELECT migrate_url_to_user($1, $2)`
     const values = [shortUrl, toUserEmail]
 
-    const { rowCount } = await pgClient.query(sqlScript, values)
+    await pgClient.query(sqlScript, values)
 
     pgClient.end().then(() => console.log('Disconnected'))
 
-    statusMsg = `URL successfully migrated. ${JSON.stringify(
-      rowCount,
-    )} rows affected`
+    statusMsg = 'URL successfully migrated.'
   } catch (err) {
     console.log(err)
     pgClient.end()

--- a/src/server/serverless/lambda-migrate-user-links/index.js
+++ b/src/server/serverless/lambda-migrate-user-links/index.js
@@ -16,7 +16,8 @@ async function handler(event) {
     const sqlScript = `SELECT migrate_user_links($1, $2)`
     const values = [fromUserEmail, toUserEmail]
 
-    const { rowCount } = await pgClient.query(sqlScript, values)
+    const { rows } = await pgClient.query(sqlScript, values)
+    const rowCount = rows[0].migrate_user_links
 
     pgClient.end().then(() => console.log('Disconnected'))
 

--- a/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
+++ b/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
@@ -8,7 +8,7 @@
 -- Parameters:
 --   @from_user_email - email of transferrer
 --   @to_user_email   - email of transferree
--- Returns:     Void
+-- Returns:     Integer - number of links transferred
 --
 -- Change History:
 --   11 July 2019 Yuanruo Liang: Function created
@@ -20,14 +20,16 @@
 --                            isSearchable column
 --   01 Apr  2021 Alexis Goh: Update function's url_history insertion step to include
 --                            description column
+--   12 July 2022 Lim Zi Wei: Update function to return the number of migrated links
 -- =============================================
-CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS void AS
+CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS integer AS
 $BODY$
 DECLARE
     from_user_email text := from_user_email;
     to_user_email text := to_user_email;
     from_user_id integer;
     to_user_id integer;
+    num_migrated_links integer;
 BEGIN
 -- Look for the users in question
     SELECT id INTO from_user_id FROM users WHERE email = from_user_email LIMIT 1;
@@ -54,6 +56,8 @@ BEGIN
         SET "userId" = to_user_id,
             "updatedAt" = CURRENT_TIMESTAMP
         WHERE "userId" = from_user_id;
+    GET DIAGNOSTICS num_migrated_links = ROW_COUNT;
+    RETURN num_migrated_links;
 END
 $BODY$
 LANGUAGE plpgsql;


### PR DESCRIPTION
## Problem

Currently, the lambda functions to migrate links between users always returns the number of rows affected as 1, regardless of the actual number of links transferred.

Closes #1806 

## Solution

- `migrate_user_links` has been updated to return the actual number of rows affected when updating the `urls` table
- As for `migrate_url_to_user`, it might not be necessary to return the number of rows affected, because if not for an error, there should always be exactly 1 link transferred. Is it ok to just remove this then?

## Tests

- [x] Test `migrate_user_links` on staging
- [x] Test `migrate_url_to_user` on staging

~~I've tested this locally by running the javascript code on node (without using aws lambda, which I'm not sure how to use yet), and locally it seems to work well~~

EDIT: have tested invoking the lambda functions both locally and on staging with the help of @yong-jie and it looks good