### PR TITLE
WIP: update transition page flow and wording

### DIFF
--- a/public/assets/edu/styles/colours.css
+++ b/public/assets/edu/styles/colours.css
@@ -11,6 +11,7 @@
     --transition-top-half-color: #2b2e4a;
     --transition-top-half-content-color: #ffffff;
     --transition-top-half-content-link-color: white;
+    --transition-top-half-content-link-hover-color: darkslategray;
     --transition-links-color: #000000;
     --transition-skip-span-color: #48426d;
     --transition-footer-p-color: #bbbbbb;

--- a/public/assets/gov/styles/colours.css
+++ b/public/assets/gov/styles/colours.css
@@ -11,6 +11,7 @@
     --transition-top-half-color: #384a51;
     --transition-top-half-content-color: #ffffff;
     --transition-top-half-content-link-color: white;
+    --transition-top-half-content-link-hover-color: darkslategray;
     --transition-links-color: #000000;
     --transition-skip-span-color: #456682;
     --transition-footer-p-color: #bbbbbb;

--- a/public/assets/health/styles/colours.css
+++ b/public/assets/health/styles/colours.css
@@ -11,6 +11,7 @@
     --transition-top-half-color: #472F40;
     --transition-top-half-content-color: #ffffff;
     --transition-top-half-content-link-color: white;
+    --transition-top-half-content-link-hover-color: darkslategray;
     --transition-links-color: #000000;
     --transition-skip-span-color: #6D4559;
     --transition-footer-p-color: #bbbbbb;

--- a/public/assets/styles/transition-page/transition-page.css
+++ b/public/assets/styles/transition-page/transition-page.css
@@ -27,19 +27,34 @@ body {
   position: absolute;
   bottom: -56px;
   left: 50%;
+  margin-right: -50%;
   transform: translateX(-50%);
 }
 
 .top-half-content h3 {
   font-weight: 600;
-  margin-bottom: 6px;
+}
+
+.top-half-content p {
+  font-size: 16px;
 }
 
 .top-half-content a {
   display: block;
   color: var(--transition-top-half-content-link-color);
-  font-size: 16px;
-  margin-bottom: 35px;
+}
+
+#title {
+  margin-bottom: 16px;
+}
+
+#prompt {
+  margin-bottom: 16px;
+}
+
+#countdown {
+  font-size: 13px;
+  display: inline-block;
 }
 
 .browser-image {
@@ -61,13 +76,14 @@ body {
   width: 100%;
   height: 140px;
   padding-top: 75px;
-  padding-left: 165px;
+  padding-left: 182px;
   color: var(--transition-links-color);
 }
 
 .bottom-half {
   text-align: center;
   min-height: 250px;
+  padding: 0 8px; 
 }
 
 .bottom-half > p {
@@ -75,17 +91,34 @@ body {
   font-size: 13px;
 }
 
-#skip {
-  padding-top: 50px;
-  opacity: 1;
-  display: block;
+#url {
+  font-size: 13px;
   cursor: pointer;
+  display: inline-block;
+  margin-top: 50px;
+  color: var(--transition-skip-span-color);
 }
 
-#skip > span {
-  font-size: 13px;
-  color: var(--transition-skip-span-color);
+#url > span {
   text-decoration: underline;
+}
+
+#url:hover {
+   color: var(--transition-top-half-content-link-hover-color);
+}
+
+#more {
+  margin-top: 35px;
+  opacity: 1;
+  display: inline-block;
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 14px;
+  color: black;
+}
+
+#more:hover {
+  color: var(--transition-top-half-content-link-hover-color);
 }
 
 .footer {
@@ -106,11 +139,6 @@ body {
   display: none;
 }
 
-#url {
-  font-size: 13px;
-  display: inline;
-}
-
 #logo {
   padding-bottom: 20px;
 }
@@ -121,28 +149,49 @@ body {
 
 @media only screen and (max-width: 768px) {
   .links {
-    padding-top: 73px;
-    padding-left: 148px;
+    padding-top: 75px;
+    padding-left: 182px;
   }
 }
 
 @media only screen and (max-width: 512px) {
   .top-half {
-    height: 35vh;
+    height: max(35vh, 290px);
   }
 
   .top-half-content {
     bottom: -58px;
-    width: 80%;
   }
 
   .top-half-content h3 {
-    margin-bottom: 12px;
     font-size: 22px;
+    line-height: 1.5;
+  }
+
+  .top-half-content p {
+    font-size: 14px;
   }
 
   .top-half-content a {
     font-size: 14px;
+    margin-bottom: 12px;
+  }
+
+  #title {
+    margin-bottom: 12px;
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  #prompt {
+    margin-bottom: 6px;
+  }
+
+  #url {
+    margin-bottom: 0;
+  }
+
+  #countdown {
     margin-bottom: 0;
   }
 
@@ -181,14 +230,19 @@ body {
   }
 
   .top-half-content h3 {
-    margin-bottom: 0;
-    margin-left: 8px;
-    margin-right: 8px;
+    font-size: 22px;
+    line-height: 1.5;
   }
 
   .top-half-content a {
     margin-left: 8px;
     margin-right: 8px;
+  }
+
+  #title {
+    margin-bottom: 12px;
+    margin-left: 8px;
+    margin-right: 8px; 
   }
 
   .browser-image {

--- a/public/assets/styles/transition-page/transition-page.css
+++ b/public/assets/styles/transition-page/transition-page.css
@@ -53,6 +53,9 @@ body {
 }
 
 #url-preview {
+  font-size: 13px;
+  cursor: pointer;
+  display: inline;
   text-decoration: underline;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -218,9 +221,5 @@ body {
   .top-half-content h3 {
     font-size: 22px;
     line-height: 1.5;
-  }
-
-  #title {
-    margin-bottom: 12px;
   }
 }

--- a/public/assets/styles/transition-page/transition-page.css
+++ b/public/assets/styles/transition-page/transition-page.css
@@ -11,24 +11,18 @@ body {
   background: var(--transition-body-color);
 }
 
-#main-message p {
-  line-height: 2rem;
-}
-
 .top-half {
   background: var(--transition-top-half-color) ;
-  height: 50vh;
-  position: relative;
+  min-height: 50vh;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
 }
 
 .top-half-content {
   text-align: center;
   color: var(--transition-top-half-content-color);
-  position: absolute;
-  bottom: -56px;
-  left: 50%;
-  margin-right: -50%;
-  transform: translateX(-50%);
+  padding: 0 16px 115px;
 }
 
 .top-half-content h3 {
@@ -46,6 +40,7 @@ body {
 
 #title {
   margin-bottom: 16px;
+  margin-top: 8px;
 }
 
 #prompt {
@@ -54,36 +49,41 @@ body {
 
 #countdown {
   font-size: 13px;
-  display: inline-block;
+  display: inline;
+}
+
+#url-preview {
+  text-decoration: underline;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break:  break-word;
+  hyphens: auto;
 }
 
 .browser-image {
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;
-  max-width: 100%;
   height: 140px;
-  text-align: left;
-  margin-left: auto;
-  margin-right: auto;
-  min-width: 300px;
+  position: relative;
+  top: -95px;
 }
 
 .links {
-  width: 100%;
-  height: 140px;
-  padding-top: 75px;
-  padding-left: 182px;
   color: var(--transition-links-color);
+  position: relative;
+  top: 17px;
+  left: -16px;
 }
 
 .bottom-half {
   text-align: center;
-  min-height: 250px;
+  min-height: 290px;
   padding: 0 8px; 
+  margin-top: -145px;
 }
 
 .bottom-half > p {
@@ -147,27 +147,20 @@ body {
   height: 10px;
 }
 
-@media only screen and (max-width: 768px) {
-  .links {
-    padding-top: 75px;
-    padding-left: 182px;
-  }
-}
-
 @media only screen and (max-width: 512px) {
   .top-half {
-    height: max(35vh, 290px);
+    min-height: 35vh;
   }
 
   .top-half-content {
-    bottom: -58px;
+    padding-bottom: 82px;
   }
 
   .top-half-content h3 {
     font-size: 22px;
     line-height: 1.5;
   }
-
+  
   .top-half-content p {
     font-size: 14px;
   }
@@ -175,42 +168,39 @@ body {
   .top-half-content a {
     font-size: 14px;
     margin-bottom: 12px;
+    line-height: 20px;
   }
 
   #title {
     margin-bottom: 12px;
-    margin-left: 8px;
-    margin-right: 8px;
+    margin-top: 22px;
   }
 
   #prompt {
     margin-bottom: 6px;
   }
-
-  #url {
-    margin-bottom: 0;
-  }
-
+  
   #countdown {
     margin-bottom: 0;
   }
-
+  
   .browser-image {
     width: 300px;
+    margin-left: auto; 
+    margin-right: auto;
+    top: -90px;
   }
 
   .links {
-    padding-top: 73px;
-    padding-left: 115px;
     font-size: 12px;
-    height: 120px;
-    box-sizing: border-box;
+    top: 12px;
+    left: -8px;
   }
-
-  .top-half-content a {
-    line-height: 20px;
+  
+  #url {
+    margin-bottom: 0;
   }
-
+  
   .footer {
     bottom: 30px;
   }
@@ -225,34 +215,12 @@ body {
 }
 
 @media only screen and (max-width: 374px) {
-  .top-half-content {
-    width: 100%;
-  }
-
   .top-half-content h3 {
     font-size: 22px;
     line-height: 1.5;
   }
 
-  .top-half-content a {
-    margin-left: 8px;
-    margin-right: 8px;
-  }
-
   #title {
     margin-bottom: 12px;
-    margin-left: 8px;
-    margin-right: 8px; 
-  }
-
-  .browser-image {
-    width: 300px;
-  }
-
-  .links {
-    padding-top: 73px;
-    padding-left: 115px;
-    font-size: 12px;
-    box-sizing: border-box;
   }
 }

--- a/src/server/modules/redirect/RedirectController.ts
+++ b/src/server/modules/redirect/RedirectController.ts
@@ -95,6 +95,7 @@ export class RedirectController {
 
         res.status(200).render(TRANSITION_PATH, {
           escapedLongUrl: RedirectController.encodeLongUrl(longUrl),
+          urlWithoutQuery: RedirectController.removeQueryString(longUrl),
           rootDomain,
           gaTrackingId,
           assetVariant,
@@ -131,6 +132,11 @@ export class RedirectController {
    */
   private static encodeLongUrl(longUrl: string) {
     return longUrl.replace(/["]/g, encodeURIComponent)
+  }
+
+  // remove query string as URL might be very long and look dodgy
+  private static removeQueryString(longUrl: string) {
+    return longUrl.split('?')[0]
   }
 }
 

--- a/src/server/views/redirect.ejs
+++ b/src/server/views/redirect.ejs
@@ -44,7 +44,7 @@ var intervalId = setInterval(function(){
 }, 1000)
 
 ;(function() {
-    document.getElementById('skip').addEventListener('click', function (e) {
+    document.getElementById('url').addEventListener('click', function (e) {
         proceedToDestination()
     })
 })()

--- a/src/server/views/redirect.ejs
+++ b/src/server/views/redirect.ejs
@@ -47,4 +47,7 @@ var intervalId = setInterval(function(){
     document.getElementById('url').addEventListener('click', function (e) {
         proceedToDestination()
     })
+    document.getElementById('url-preview').addEventListener('click', function (e) {
+        proceedToDestination()
+    })
 })()

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -21,9 +21,12 @@
     <% } %>
     <div class="top-half">
         <div class="top-half-content">
-            <h3>Check your address bar</h3>
-            <a href="https://go.gov.sg/go-antiphishing" target="_blank" rel="noreferrer noopener">Beware of phishing! <br class="mobile-break">Make sure your link starts with <%- displayHostname.toLowerCase() %></a>
-            <p id="url" data-href="<%- escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
+            <h3 id="title">Official short links by <%- displayHostname.toLowerCase() %></h3>
+            <p id="prompt">
+                Check your address bar.
+                <br class="mobile-break">Make sure the link starts with <%- displayHostname.toLowerCase() %>
+            </p>
+            <p id="countdown">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
             <img id="spinner" src="/assets/<%- assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
             <div class="browser-image" style="background-image: url('/assets/<%- assetVariant %>/transition-page/images/browser.svg');">
                 <div class="links" <% if(assetVariant !== 'gov') { %> <%-"style=padding-left:169px;"%> <% } %>><%- displayHostname.toLowerCase() %>/</div>
@@ -31,10 +34,12 @@
         </div>
     </div>
     <div class="bottom-half">
-        
-        <div id="skip">
+        <a id="url" data-href="<%- escapedLongUrl %>">
             <span>I've checked the link. Skip ahead</span>
             <img src="/assets/<%- assetVariant %>/transition-page/icons/icon-arrow-right.svg" alt="right arrow" />
+        </a>
+        <div>
+            <a id="more" href="{{ link to faq page, probably doesnt need to be a gogov link }}">Why are <%- displayHostname.toLowerCase() %> links safe? Find out more ➜</a>
         </div>
         <div class="footer">
             <div id="logo">

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -28,10 +28,10 @@
             </p>
             <p id="countdown">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
             <img id="spinner" src="/assets/<%- assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
-            <div class="browser-image" style="background-image: url('/assets/<%- assetVariant %>/transition-page/images/browser.svg');">
-                <div class="links" <% if(assetVariant !== 'gov') { %> <%-"style=padding-left:169px;"%> <% } %>><%- displayHostname.toLowerCase() %>/</div>
-            </div>
         </div>
+    </div>
+    <div class="browser-image" style="background-image: url('/assets/<%- assetVariant %>/transition-page/images/browser.svg');">
+        <div class="links" <% if(assetVariant !== 'gov') { %> <%-"style=padding-left:169px;"%> <% } %>><%- displayHostname.toLowerCase() %>/</div>
     </div>
     <div class="bottom-half">
         <a id="url" data-href="<%- escapedLongUrl %>">

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -26,7 +26,9 @@
                 Check your address bar.
                 <br class="mobile-break">Make sure the link starts with <%- displayHostname.toLowerCase() %>
             </p>
-            <p id="countdown">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
+            <p id="countdown">
+                You will be redirected to <a id="url-preview"><%- urlWithoutQuery %></a> in <span id="countdown-seconds">6</span> second<span id="s">s</span>
+            </p>
             <img id="spinner" src="/assets/<%- assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
         </div>
     </div>


### PR DESCRIPTION
This PR contains some improvements I believe would improve the go.gov.sg transition page.

After discussing about gogov during interview, I wanted to make some suggestions to the project as I felt the page could be improved. Since gogov is open-source, I thought I might as well propose the changes with practical implementation. I will explain the reasoning behind each change in the list below but bear in mind that some changes are related to each other.

## Change list
#### 1. remove “Beware of phishing!’ prompt.
It might be just me but I feel like this prompt is a little doomsday-ee. Imagine a user just trying to visit their gov pages and the first thing they see is ‘Beware of phishing!’, I think it does not serve the purpose well as most people would not even be aware that the page is for anti-phishing. The first time I saw the page, I thought it looked a bit alarming, and was like *"wat do u mean make sure the link starts with go.gov.sg, that’s how i got here"*. To replace it, I have some options one which I list in the following points.

#### 2. Remove the timer and users must click before proceeding to page. 
I’m sure this point has been heavily discussed within the team before deciding on the current implementation. The aim of the timer is to give people enough time to check their URLs before the page automatically redirects. The two problems with this are 1. users who are slow process information would not be able to do anything within the time. 2, even for people who understand the prompts, they would simply wait or press skip because it is the most prominent, in fact the only call to action. In essence, I feel removing the sense of urgency is the most important reason for removing the timer, so people don't feel pressured or anything. This change should optimally be combined with the next point for the best outcome.

#### 3. Better prompts for people who actually care about what the page is about
In addition to removing the timer, i think it’ll be better to link users to a page explaining the what the page is about. In fact, this link already exists on the current page, but I would have never known if not for looking into the source code. I think one of the main aims of the page is to educate the public on the importance of checking their urls but I think no one is going to think about something that will pass by in a few seconds. That’s why I updated the prompt to say “Why are go.gov.sg links safe?” as it better conveys the idea that go.gov.sg links are safe. This combined with removing the timer the allows users to absorb the information at their own time, and those who are really interested can actually find out more, although probably only 1% of users will ever visit the site. With these changes, i18n also has to be considered if not you’ve essentially blocked non-english speaking users from accessing sites. Ultimately, it is down to whether the benefits of removing the timer outweighs the cost of adding one more click. From the perspective of educating the public, I think it is much better to let users click on their own.

#### 4. Better page heading
This point is linked to the above. The current heading is “Check you address bar” which again I feel does not bring across what the page is about. I think its is better to convey the idea that this page is an official page therefore I updated the heading to say so. 

#### 5. Tell users what page they will be redirected too.
I’m not sure if this would be too tedious to implement, but I think the ideal way is to let people know what page or what agency website they will be redirected to. The main thing is to do with user control and mental model. Users enter a link and expect to directly go to the page they intended, but instead they are presented with a interstitial page with no info of where it’ll redirect next, which is just not aligned with the mental model of web browsing. The best way is to show users a short description of the page to be redirected to, but then old urls will not have this field. ~~Or perhaps Url.description might be suitable.~~ (not being used) On top of that, you still have to consider i18n implication.. Another option maybe simply show the url on the page, but I think that will lead to too much information on the page.

---

Overall, I do think admit that removing the timer and show the page name might be a little confusing, as people have already gotten used to the current behavior, but I feel at the very least the headings and links to more information can be updated to convey a more accurate message.

Lastly, I have to end with a disclaimer that I am just giving some suggestions and I definitely do not have the full context of the entire team. Perhaps the team has already considered all these options and ruled them out, or perhaps have conducted focus testing groups to arrive at the current implementation. If so feel free to disregard this PR, but I still feel it is worth sharing.

## Example screenshots

**simple header**:
<img src="https://user-images.githubusercontent.com/39296145/182429609-d2f554ed-efb6-4275-8f99-0330945afef8.png" width="375">
![simple header wide](https://user-images.githubusercontent.com/39296145/182429644-7e1233eb-da30-48fb-b372-6b781bb11720.png)

**short page description**:
<img src="https://user-images.githubusercontent.com/39296145/182429794-f62180ba-c79e-410c-9f86-943571221364.png" width="375">
![page desc header wide](https://user-images.githubusercontent.com/39296145/182432525-8e1b21a3-a8d1-484b-a2e3-b3e551fcce35.png)


**show url**:
a little too much info i think
<img src="https://user-images.githubusercontent.com/39296145/182430423-233c07b7-7801-47d2-8512-70fe4aad08fc.png" width="375">
![page url header wide](https://user-images.githubusercontent.com/39296145/182430446-1ab5c936-1ebe-42ad-bbdb-70ac915ffd38.png)

### Example FAQ page
![faq](https://user-images.githubusercontent.com/39296145/182726367-7a6ec7d1-6e2b-4e0d-961b-3aef97d3b729.png)

