### PR TITLE
feat: add OTP metrics and logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5481,7 +5481,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -9437,7 +9436,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
       "optional": true
     },
     "filelist": {
@@ -10150,6 +10148,14 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "hot-shots": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-9.2.0.tgz",
+      "integrity": "sha512-MNn/562GiAMo3LIua/CLUHIkIr7Myh8ycGl/0mgbRh9w+iW+uDFme6+TbW2TAGeMMjJmRjvTAJdYetOZn3zGxw==",
+      "requires": {
+        "unix-dgram": "2.0.x"
       }
     },
     "hpack.js": {
@@ -15943,7 +15949,7 @@
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -19233,6 +19239,16 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
+    "unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -19365,7 +19381,7 @@
     "utila": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "file-type": "^16.5.3",
     "helmet": "^4.6.0",
     "history": "^4.10.1",
+    "hot-shots": "^9.2.0",
     "html-webpack-plugin": "^5.3.2",
     "i18next": "^20.4.0",
     "i18next-http-backend": "^1.3.2",

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -1,0 +1,7 @@
+import { StatsD } from 'hot-shots'
+
+const dogstatsd = new StatsD({
+  prefix: 'go.',
+})
+
+export default dogstatsd

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -1,7 +1,9 @@
 import { StatsD } from 'hot-shots'
+import { DEV_ENV } from '../config'
 
 const dogstatsd = new StatsD({
   prefix: 'go.',
+  mock: DEV_ENV,
 })
 
 export default dogstatsd


### PR DESCRIPTION
## Problem

We'd like to have custom metrics to count the number of OTP successes/failures, and log down both success and failure cases as well

Notion issue [here](https://www.notion.so/opengov/Add-metrics-logging-for-OTP-emails-sent-37210652dacf4d91ae9ef2186361989d)

## Solution

Added utility to collect custom Datadog metrics for Go
- Added statsd from `hot-shots` for custom metrics collection (as per the [Datadog documentation](https://docs.datadoghq.com/integrations/node/))
- Added the prefix `go.` to our custom metrics, to differentiate them from other teams' metrics

Added logging for OTP successes/failures and two custom metrics, `go.otp.success` and `go.otp.failure`

## Tests

- [x] Tested on staging, these OTP metrics show up as expected on Datadog's metrics explorer

## Deploy Notes

**New dependencies**:

- `hot-shots` : client to collect and send custom metrics to Datadog
