### PR TITLE
feat: add datadog client tracing

### DIFF
--- a/src/client/app/helpers/monitoring.ts
+++ b/src/client/app/helpers/monitoring.ts
@@ -15,6 +15,14 @@ const initMonitoring = () => {
     premiumSampleRate: 100,
     trackInteractions: true,
     defaultPrivacyLevel: 'mask-user-input',
+    allowedTracingOrigins: [
+      'https://go.gov.sg',
+      'https://for.edu.sg',
+      'https://for.sg',
+      'https://staging.go.gov.sg',
+      'https://staging.for.edu.sg',
+      'https://staging.for.sg',
+    ],
   })
   datadogRum.startSessionReplayRecording()
 }


### PR DESCRIPTION
## Problem

We want to connect Datadog sessions on our client with our server traces

## Solution

Added `allowedTracingOrigins` on our production and staging environments
- Followed the [Datadog documentation](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum) for connecting RUM and traces, and [Redeem's slides](https://docs.google.com/presentation/d/1s1Mho2krp46sdGUNbg8q7-zRDWm_SC-NbIoSSiNfVOQ/edit#slide=id.g11b1a1b1dce_0_296) on setting up front-end tracing

## Tests

- [x] Tested on staging to ensure that our RUM sessions are connected to traces

