### PR TITLE
feat: disallow file uploads for old Microsoft formats

### DIFF
--- a/src/server/modules/threat/services/FileTypeFilterService.ts
+++ b/src/server/modules/threat/services/FileTypeFilterService.ts
@@ -9,7 +9,6 @@ export const DEFAULT_ALLOWED_FILE_EXTENSIONS = [
   'bmp',
   'csv',
   'dgn',
-  'doc',
   'docx',
   'dwf',
   'dwg',
@@ -27,7 +26,6 @@ export const DEFAULT_ALLOWED_FILE_EXTENSIONS = [
   'ods',
   'pdf',
   'png',
-  'ppt',
   'pptx',
   'rtf',
   'sxc',
@@ -38,7 +36,6 @@ export const DEFAULT_ALLOWED_FILE_EXTENSIONS = [
   'tiff',
   'txt',
   'wmv',
-  'xls',
   'xlsx',
 ]
 


### PR DESCRIPTION
## Problem

We currently whitelist old Microsoft formats (`.doc`, `.ppt`, `.xls`) for file uploads, but the `file-type` library that we use for detecting file types does not support them ([documentation](https://github.com/sindresorhus/file-type#supported-file-types)), and recognizes them as `.cfb` instead. As Alexis notes, these old formats can also be weaponized and exploited for malicious uses, so we should disallow them anyway

## Solution

Remove `.doc`, `.ppt`, `.xls` from our `DEFAULT_ALLOWED_FILE_EXTENSIONS`

## Tests

- [x] Tested on dev to ensure that some sample `.doc`, `.ppt`, `.xls` files are not allowed

