### PR TITLE
build: add env variable for datadog service

### DIFF
--- a/.ebextensions/99datadog.config
+++ b/.ebextensions/99datadog.config
@@ -25,7 +25,7 @@ files:
         enabled: true
         apm_non_local_traffic: true
       tags:
-        - service:gogovsg
+        - service:@DD_SERVICE
         - env:@DD_ENV
 
   "/datadog_install_script.sh":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
           TAG: ${{ steps.extract_tag.outputs.tag }}
         run: |
-          docker build --tag my-image --build-arg __DD_ENV=${SERVERLESS_STAGE} .
+          docker build --tag my-image --build-arg __ASSET_VARIANT=gov --build-arg __DD_SERVICE=go-gov --build-arg __DD_ENV=${SERVERLESS_STAGE} .
           docker tag my-image ${REPO}:${TAG}
           docker push ${REPO}:${TAG}
   deploy-gogov:
@@ -225,12 +225,13 @@ jobs:
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
           sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
-          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
+          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_SERVICE|$DD_SERVICE|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
           zip -r "deploy.zip" .ebextensions Dockerrun.aws.json
         env:
           REPO: ${{env.ECR_URL}}/${{env.ECR_REPO}}
           TAG: ${{ needs.build-gogov.outputs.tag }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SERVICE: go-gov
           DD_ENV: ${{ env.SERVERLESS_STAGE }}
       - name: Get timestamp
         shell: bash
@@ -324,7 +325,7 @@ jobs:
           REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
           TAG: ${{ steps.extract_tag.outputs.tag }}
         run: |
-          docker build --tag my-image --build-arg __ASSET_VARIANT=edu --build-arg __DD_ENV=${SERVERLESS_STAGE} .
+          docker build --tag my-image --build-arg __ASSET_VARIANT=edu --build-arg __DD_SERVICE=go-edu --build-arg __DD_ENV=${SERVERLESS_STAGE} .
           docker tag my-image ${REPO}:${TAG}
           docker push ${REPO}:${TAG}
   deploy-edu:
@@ -349,12 +350,13 @@ jobs:
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
           sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
-          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
+          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_SERVICE|$DD_SERVICE|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
           zip -r "deploy.zip" .ebextensions Dockerrun.aws.json
         env:
           REPO: ${{env.ECR_URL}}/${{env.ECR_REPO}}
           TAG: ${{ needs.build-edu.outputs.tag }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SERVICE: go-edu
           DD_ENV: ${{ env.SERVERLESS_STAGE }}
       - name: Get timestamp
         shell: bash
@@ -450,7 +452,7 @@ jobs:
           REPO: ${{ env.ECR_URL }}/${{ env.ECR_REPO }}
           TAG: ${{ steps.extract_tag.outputs.tag }}
         run: |
-          docker build --tag my-image --build-arg __ASSET_VARIANT=health --build-arg __DD_ENV=${SERVERLESS_STAGE} .
+          docker build --tag my-image --build-arg __ASSET_VARIANT=health  --build-arg __DD_SERVICE=go-health --build-arg __DD_ENV=${SERVERLESS_STAGE} .
           docker tag my-image ${REPO}:${TAG}
           docker push ${REPO}:${TAG}
   deploy-health:
@@ -475,12 +477,13 @@ jobs:
         run: |
           sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
           sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
-          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
+          sed -i -e "s|@DD_API_KEY|$DD_API_KEY|g" -e "s|@DD_SERVICE|$DD_SERVICE|g" -e "s|@DD_ENV|$DD_ENV|g" .ebextensions/99datadog.config
           zip -r "deploy.zip" .ebextensions Dockerrun.aws.json
         env:
           REPO: ${{env.ECR_URL}}/${{env.ECR_REPO}}
           TAG: ${{ needs.build-health.outputs.tag }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SERVICE: go-health
           DD_ENV: ${{ env.SERVERLESS_STAGE }}
       - name: Get timestamp
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 ARG __ASSET_VARIANT
 ENV ASSET_VARIANT=${__ASSET_VARIANT:-gov}
 
+ARG __DD_SERVICE
+ENV DD_SERVICE=${__DD_SERVICE}
+
 ARG __DD_ENV
 ENV DD_ENV=${__DD_ENV}
 

--- a/src/client/app/helpers/monitoring.ts
+++ b/src/client/app/helpers/monitoring.ts
@@ -1,13 +1,12 @@
 import { datadogRum } from '@datadog/browser-rum'
-import assetVariant from '../../../shared/util/asset-variant'
-import ddEnv from '../../../shared/util/environment-variables'
+import { ddEnv, ddService } from '../../../shared/util/environment-variables'
 
 const initMonitoring = () => {
   datadogRum.init({
     applicationId: '898ea704-7347-45dc-b40c-bf85359e062e',
     clientToken: 'pub40fb07aa43d3f6f034d8fcc7f1df867b',
     site: 'datadoghq.com',
-    service: assetVariant,
+    service: ddService,
     env: ddEnv,
     // Specify a version number to identify the deployed version of your application in Datadog
     // version: '1.0.0',

--- a/src/shared/util/environment-variables.ts
+++ b/src/shared/util/environment-variables.ts
@@ -1,2 +1,2 @@
-const ddEnv = process.env.DD_ENV
-export default ddEnv as string | undefined
+export const ddService: string | undefined = process.env.DD_SERVICE
+export const ddEnv: string | undefined = process.env.DD_ENV

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,7 +5,7 @@ import SentryCliPlugin from '@sentry/webpack-plugin'
 import webpack from 'webpack'
 
 import assetVariant from './src/shared/util/asset-variant'
-import ddEnv from './src/shared/util/environment-variables'
+import { ddEnv, ddService } from './src/shared/util/environment-variables'
 
 const outputDirectory = 'dist'
 const srcDirectory = path.join(__dirname, 'src/client/app')
@@ -124,6 +124,7 @@ module.exports = () => {
       }),
       new webpack.DefinePlugin({
         'process.env.ASSET_VARIANT': JSON.stringify(assetVariant),
+        'process.env.DD_SERVICE': JSON.stringify(ddService),
         'process.env.DD_ENV': JSON.stringify(ddEnv),
       }),
     ],


### PR DESCRIPTION
## Problem

`DD_SERVICE` is not consistently defined for Go across elastic beanstalk, tracing, logs, and monitoring. It's also defined differently from `DD_ENV` even though they serve similar purposes, which may be confusing

## Solution

Defined `DD_SERVICE` within `ci.yml` in a similar manner to `DD_ENV`, and standardised its naming to `go-[gov/edu/health]` (we should be able to tell whether it's staging or production from `DD_ENV`, so will leave that out of the service naming)

## Tests

- [x] Tested on staging, the new service naming takes effect for tracing, logs, monitoring - some application metrics (e.g. for RDS and ELB) are still stuck with the `gogovsg` naming though, so that's probably configured somewhere else, or the changes will only take effect once it's been released to production
