### PR TITLE
(backend) Feat/link audit

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -49,6 +49,7 @@ function preprocess(
 router.use('/user', userGuard, preprocess, require('./user'))
 router.use('/qrcode', userGuard, require('./qrcode'))
 router.use('/link-stats', userGuard, require('./link-statistics'))
+router.use('/link-audit', userGuard, require('./link-audit'))
 router.use('/directory', userGuard, require('./directory'))
 
 router.use((_, res) => {

--- a/src/server/api/link-audit.ts
+++ b/src/server/api/link-audit.ts
@@ -1,0 +1,37 @@
+import Express from 'express'
+import Joi from '@hapi/joi'
+import { createValidator } from 'express-joi-validation'
+import { DependencyIds } from '../constants'
+import { LinkAuditController } from '../modules/audit'
+import { container } from '../util/inversify'
+import { isValidShortUrl } from '../../shared/util/validation'
+
+const router = Express.Router()
+const validator = createValidator()
+
+const auditController = container.get<LinkAuditController>(
+  DependencyIds.linkAuditController,
+)
+
+/**
+ * Determines whether the link audit request is valid.
+ */
+const linkAuditSchema = Joi.object({
+  url: Joi.string()
+    .custom((url: string, helpers) => {
+      if (!isValidShortUrl(url)) {
+        return helpers.message({ custom: 'Not a valid short link' })
+      }
+      return url
+    })
+    .required(),
+  limit: Joi.number().min(0),
+  offset: Joi.number().min(0),
+})
+
+/**
+ * Endpoint to retrieve link audit for a specified link.
+ */
+router.get('/', validator.query(linkAuditSchema), auditController.getLinkAudit)
+
+module.exports = router

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -35,6 +35,8 @@ export const DependencyIds = {
   linkStatisticsController: Symbol.for('linkStatisticsController'),
   linkStatisticsService: Symbol.for('linkStatisticsService'),
   linkStatisticsRepository: Symbol.for('linkStatisticsRepository'),
+  linkAuditController: Symbol.for('linkAuditController'),
+  linkAuditService: Symbol.for('linkAuditService'),
   deviceCheckService: Symbol.for('deviceCheckService'),
   allowedFileExtensions: Symbol.for('allowedFileExtensions'),
   fileTypeFilterService: Symbol.for('fileTypeFilterService'),

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -37,6 +37,7 @@ export const DependencyIds = {
   linkStatisticsRepository: Symbol.for('linkStatisticsRepository'),
   linkAuditController: Symbol.for('linkAuditController'),
   linkAuditService: Symbol.for('linkAuditService'),
+  urlHistoryRepository: Symbol.for('urlHistoryRepository'),
   deviceCheckService: Symbol.for('deviceCheckService'),
   allowedFileExtensions: Symbol.for('allowedFileExtensions'),
   fileTypeFilterService: Symbol.for('fileTypeFilterService'),

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -53,6 +53,8 @@ import {
   LinkStatisticsService,
 } from './modules/analytics/services'
 import { LinkStatisticsRepository } from './modules/analytics/repositories/LinkStatisticsRepository'
+import { LinkAuditController } from './modules/audit'
+import { LinkAuditService } from './modules/audit/services'
 
 import { SafeBrowsingMapper } from './modules/threat/mappers'
 import { SafeBrowsingRepository } from './modules/threat/repositories/SafeBrowsingRepository'
@@ -146,6 +148,9 @@ export default () => {
     DependencyIds.linkStatisticsRepository,
     LinkStatisticsRepository,
   )
+
+  bindIfUnbound(DependencyIds.linkAuditService, LinkAuditService)
+  bindIfUnbound(DependencyIds.linkAuditController, LinkAuditController)
 
   container.bind(DependencyIds.s3Bucket).toConstantValue(s3Bucket)
 

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -55,6 +55,7 @@ import {
 import { LinkStatisticsRepository } from './modules/analytics/repositories/LinkStatisticsRepository'
 import { LinkAuditController } from './modules/audit'
 import { LinkAuditService } from './modules/audit/services'
+import { UrlHistoryRepository } from './modules/audit/repositories'
 
 import { SafeBrowsingMapper } from './modules/threat/mappers'
 import { SafeBrowsingRepository } from './modules/threat/repositories/SafeBrowsingRepository'
@@ -151,6 +152,7 @@ export default () => {
 
   bindIfUnbound(DependencyIds.linkAuditService, LinkAuditService)
   bindIfUnbound(DependencyIds.linkAuditController, LinkAuditController)
+  bindIfUnbound(DependencyIds.urlHistoryRepository, UrlHistoryRepository)
 
   container.bind(DependencyIds.s3Bucket).toConstantValue(s3Bucket)
 

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -40,7 +40,12 @@ type UrlTypeStatic = typeof Sequelize.Model & {
  * Logs the creation and modification of shorturls.
  * ShortUrl is not included as it is the foreign key.
  */
-interface UrlHistoryType extends IdType, UrlBaseType, Sequelize.Model {}
+export interface UrlHistoryType extends IdType, UrlBaseType, Sequelize.Model {
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly urlShortUrl: string
+  readonly userId: Number
+}
 
 type UrlHistoryStatic = typeof Sequelize.Model & {
   new (values?: object, options?: Sequelize.BuildOptions): UrlHistoryType

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -14,7 +14,7 @@ import { DEV_ENV, emailValidator, ogHostname } from '../config'
 import { StorableUrlState } from '../repositories/enums'
 import { urlSearchVector } from './search'
 
-interface UrlBaseType extends IdType {
+export interface UrlBaseType extends IdType {
   readonly shortUrl: string
   readonly longUrl: string
   readonly state: StorableUrlState

--- a/src/server/modules/audit/LinkAuditController.ts
+++ b/src/server/modules/audit/LinkAuditController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express'
+
+import { injectable } from 'inversify'
+
+@injectable()
+export class LinkAuditController {
+  public getLinkAudit: (req: Request, res: Response) => Promise<void> = async (
+    req,
+    res,
+  ) => {
+    const { url: shortUrl, offset, limit } = req.query
+    console.log(shortUrl, offset, limit)
+    res.status(200).send()
+    return
+  }
+}
+
+export default LinkAuditController

--- a/src/server/modules/audit/LinkAuditController.ts
+++ b/src/server/modules/audit/LinkAuditController.ts
@@ -1,17 +1,48 @@
 import { Request, Response } from 'express'
-
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
+import { LinkAuditService } from './interfaces'
+import { DependencyIds } from '../../constants'
+import jsonMessage from '../../util/json'
 
 @injectable()
 export class LinkAuditController {
+  private linkAuditService: LinkAuditService
+
+  public constructor(
+    @inject(DependencyIds.linkAuditService)
+    linkAuditService: LinkAuditService,
+  ) {
+    this.linkAuditService = linkAuditService
+  }
+
   public getLinkAudit: (req: Request, res: Response) => Promise<void> = async (
     req,
     res,
   ) => {
-    const { url: shortUrl, offset, limit } = req.query
-    console.log(shortUrl, offset, limit)
-    res.status(200).send()
-    return
+    const { url, offset, limit } = req.query
+    const shortUrl = url as string
+    if (!shortUrl) {
+      res.status(404).send(jsonMessage('Short url does not exist'))
+      return
+    }
+    const user = req.session?.user
+    if (!user) {
+      res.status(401).send(jsonMessage('User session does not exist'))
+      return
+    }
+    try {
+      const linkStats = await this.linkAuditService.getLinkAudit(
+        user.id,
+        shortUrl,
+        parseInt(limit as string, 10) || undefined,
+        parseInt(offset as string, 10) || undefined,
+      )
+      res.status(200).json(linkStats)
+      return
+    } catch (error) {
+      res.status(404).send(jsonMessage(error.message))
+      return
+    }
   }
 }
 

--- a/src/server/modules/audit/LinkAuditController.ts
+++ b/src/server/modules/audit/LinkAuditController.ts
@@ -40,6 +40,9 @@ export class LinkAuditController {
       res.status(200).json(linkStats)
       return
     } catch (error) {
+      if (error instanceof Error) {
+        res.status(400).send(jsonMessage(error.message))
+      }
       res.status(404).send(jsonMessage(error.message))
       return
     }

--- a/src/server/modules/audit/__tests__/LinkAuditController.test.ts
+++ b/src/server/modules/audit/__tests__/LinkAuditController.test.ts
@@ -3,6 +3,7 @@ import httpMocks from 'node-mocks-http'
 import { createRequestWithShortUrl } from '../../../../../test/server/api/util'
 import { UserType } from '../../../models/user'
 import { UrlType } from '../../../models/url'
+import { NotFoundError } from '../../../util/error'
 
 import { LinkAuditController } from '..'
 
@@ -108,7 +109,7 @@ describe('LinkAuditController test', () => {
     expect(responseSpy).toBeCalledWith(200)
   })
 
-  test('LinkAuditService throws error', async () => {
+  test('LinkAuditService throws error for invalid limit or offset', async () => {
     const req = createRequestWithShortUrl('')
     const res = httpMocks.createResponse()
     const responseSpy = jest.spyOn(res, 'status')
@@ -116,6 +117,25 @@ describe('LinkAuditController test', () => {
     req.session!.user = userCredentials
 
     getLinkAudit.mockRejectedValue(new Error(':('))
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).toBeCalledWith(
+      userCredentials.id,
+      'test',
+      undefined,
+      undefined,
+    )
+    expect(responseSpy).toBeCalledWith(400)
+  })
+
+  test('LinkAuditService throws NotFoundError', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.query.url = 'test'
+    req.session!.user = userCredentials
+
+    getLinkAudit.mockRejectedValue(new NotFoundError(':('))
 
     await controller.getLinkAudit(req, res)
     expect(getLinkAudit).toBeCalledWith(

--- a/src/server/modules/audit/__tests__/LinkAuditController.test.ts
+++ b/src/server/modules/audit/__tests__/LinkAuditController.test.ts
@@ -1,0 +1,129 @@
+import httpMocks from 'node-mocks-http'
+
+import { createRequestWithShortUrl } from '../../../../../test/server/api/util'
+import { UserType } from '../../../models/user'
+import { UrlType } from '../../../models/url'
+
+import { LinkAuditController } from '..'
+
+const getLinkAudit = jest.fn()
+const getChangeSets = jest.fn()
+const computeInitialChangeSet = jest.fn()
+const computePairwiseChangeSet = jest.fn()
+getLinkAudit.mockResolvedValue({
+  changes: [
+    {
+      type: 'update',
+      key: 'state',
+      prevValue: 'ACTIVE',
+      currValue: 'INACTIVE',
+      updatedAt: '2022-08-05T11:57:38.417Z',
+    },
+    {
+      type: 'create',
+      key: 'longUrl',
+      prevValue: '',
+      currValue: 'https://abc.com',
+      updatedAt: '2022-05-30T04:45:55.204Z',
+    },
+  ],
+  limit: 10,
+  offset: 10,
+  totalCount: 12,
+})
+
+const controller = new LinkAuditController({
+  getLinkAudit,
+  getChangeSets,
+  computeInitialChangeSet,
+  computePairwiseChangeSet,
+})
+const userCredentials = {
+  id: 1,
+  email: 'hello@open.gov.sg',
+  Urls: [{ shortUrl: 'test' } as UrlType],
+} as UserType
+
+describe('LinkAuditController test', () => {
+  test('no short url included', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).not.toHaveBeenCalled()
+    expect(responseSpy).toBeCalledWith(404)
+  })
+
+  test('authenticated user with no short url', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.session!.user = userCredentials
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).not.toHaveBeenCalled()
+    expect(responseSpy).toBeCalledWith(404)
+  })
+
+  test('unauthenticated user with short url', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.query.url = 'test'
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).not.toHaveBeenCalled()
+    expect(responseSpy).toBeCalledWith(401)
+  })
+
+  test('authenticated user with short url', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.query.url = 'test'
+    req.session!.user = userCredentials
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).toBeCalledWith(
+      userCredentials.id,
+      'test',
+      undefined,
+      undefined,
+    )
+    expect(responseSpy).toBeCalledWith(200)
+  })
+
+  test('authenticated user with short url, limit and offset', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.query.url = 'test'
+    req.query.offset = '10'
+    req.query.limit = '10'
+    req.session!.user = userCredentials
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).toBeCalledWith(userCredentials.id, 'test', 10, 10)
+    expect(responseSpy).toBeCalledWith(200)
+  })
+
+  test('LinkAuditService throws error', async () => {
+    const req = createRequestWithShortUrl('')
+    const res = httpMocks.createResponse()
+    const responseSpy = jest.spyOn(res, 'status')
+    req.query.url = 'test'
+    req.session!.user = userCredentials
+
+    getLinkAudit.mockRejectedValue(new Error(':('))
+
+    await controller.getLinkAudit(req, res)
+    expect(getLinkAudit).toBeCalledWith(
+      userCredentials.id,
+      'test',
+      undefined,
+      undefined,
+    )
+    expect(responseSpy).toBeCalledWith(404)
+  })
+})

--- a/src/server/modules/audit/index.ts
+++ b/src/server/modules/audit/index.ts
@@ -1,0 +1,4 @@
+export {
+  LinkAuditController,
+  LinkAuditController as default,
+} from './LinkAuditController'

--- a/src/server/modules/audit/interfaces/LinkAuditService.ts
+++ b/src/server/modules/audit/interfaces/LinkAuditService.ts
@@ -1,8 +1,20 @@
-interface LinkChangeSet {
-  type: string
+import { UrlHistoryRecord } from './UrlHistoryRepository'
+
+export type LinkChangeKey =
+  | 'description'
+  | 'isFile'
+  | 'state'
+  | 'userEmail'
+  | 'longUrl'
+
+export type LinkChangeType = 'create' | 'update'
+
+export interface LinkChangeSet {
+  type: LinkChangeType
+  key: LinkChangeKey
   prevValue: string
   currValue: string
-  updatedAt: Date
+  updatedAt: string
 }
 
 export interface LinkAudit {
@@ -13,6 +25,22 @@ export interface LinkAudit {
 }
 
 export interface LinkAuditService {
+  computePairwiseChangeSet(
+    currUrlHistory: UrlHistoryRecord,
+    prevUrlHistory: UrlHistoryRecord,
+    keysToTrack?: LinkChangeKey[],
+  ): LinkChangeSet[]
+
+  computeInitialChangeSets(
+    currUrlHistory: UrlHistoryRecord,
+    keysToTrack?: LinkChangeKey[],
+  ): LinkChangeSet[]
+
+  getChangeSets(
+    urlHistories: UrlHistoryRecord[],
+    isLastCreate: boolean,
+  ): LinkChangeSet[]
+
   /**
    * Retrieves the link audit log by limit and offset for a specified link.
    *
@@ -20,6 +48,7 @@ export interface LinkAuditService {
    * @param shortUrl The short url which audit log is to be returned.
    * @param limit Number of changes in audit log to return, starting at offset number and ordered by recency.
    * @param offset Offset number in audit log to return limit number of changes after.
+   * @returns Link audit log for given short link.
    */
   getLinkAudit(
     userId: number,

--- a/src/server/modules/audit/interfaces/LinkAuditService.ts
+++ b/src/server/modules/audit/interfaces/LinkAuditService.ts
@@ -1,11 +1,9 @@
 import { UrlHistoryRecord } from './UrlHistoryRepository'
+import { UrlBaseType } from '../../../models/url'
 
 export type LinkChangeKey =
-  | 'description'
-  | 'isFile'
-  | 'state'
+  | keyof Pick<UrlBaseType, 'description' | 'isFile' | 'state' | 'longUrl'>
   | 'userEmail'
-  | 'longUrl'
 
 export type LinkChangeType = 'create' | 'update'
 

--- a/src/server/modules/audit/interfaces/LinkAuditService.ts
+++ b/src/server/modules/audit/interfaces/LinkAuditService.ts
@@ -12,8 +12,8 @@ export type LinkChangeType = 'create' | 'update'
 export interface LinkChangeSet {
   type: LinkChangeType
   key: LinkChangeKey
-  prevValue: string
-  currValue: string
+  prevValue: string | boolean
+  currValue: string | boolean
   updatedAt: string
 }
 
@@ -31,7 +31,7 @@ export interface LinkAuditService {
     keysToTrack?: LinkChangeKey[],
   ): LinkChangeSet[]
 
-  computeInitialChangeSets(
+  computeInitialChangeSet(
     currUrlHistory: UrlHistoryRecord,
     keysToTrack?: LinkChangeKey[],
   ): LinkChangeSet[]

--- a/src/server/modules/audit/interfaces/LinkAuditService.ts
+++ b/src/server/modules/audit/interfaces/LinkAuditService.ts
@@ -1,0 +1,32 @@
+interface LinkChangeSet {
+  type: string
+  prevValue: string
+  currValue: string
+  updatedAt: Date
+}
+
+export interface LinkAudit {
+  changes: LinkChangeSet[]
+  offset: number
+  limit: number
+  totalCount: number
+}
+
+export interface LinkAuditService {
+  /**
+   * Retrieves the link audit log by limit and offset for a specified link.
+   *
+   * @param userId The user id of the requester.
+   * @param shortUrl The short url which audit log is to be returned.
+   * @param limit Number of changes in audit log to return, starting at offset number and ordered by recency.
+   * @param offset Offset number in audit log to return limit number of changes after.
+   */
+  getLinkAudit(
+    userId: number,
+    shortUrl: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<LinkAudit | null>
+}
+
+export default LinkAuditService

--- a/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
+++ b/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
@@ -1,0 +1,30 @@
+import { UrlHistoryType } from '../../../models/url'
+
+export type UrlHistoryRecord = Pick<
+  UrlHistoryType,
+  // to change depending on what records are requested for
+  'longUrl' | 'state' | 'shortUrl' | 'createdAt'
+> & { userEmail: string }
+
+export interface UrlHistoryRepository {
+  /**
+   * Retrieve history of URL record changes.
+   * Starting at offset, retrieves limit num of records.
+   *
+   * @param shortUrl Short url to retrieve records for.
+   * @param limit Number of records to return.
+   * @param offset Offset number of records before retrieval.
+   */
+  findByShortUrl(
+    shortUrl: string,
+    limit: number,
+    offset: number,
+  ): Promise<UrlHistoryRecord[]>
+
+  /**
+   * Retrieve total count of history changes for a shortUrl.
+   *
+   * @param shortUrl
+   */
+  getCountByShortUrl(shortUrl: string): Promise<number>
+}

--- a/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
+++ b/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
@@ -1,10 +1,13 @@
-import { UrlHistoryType } from '../../../models/url'
-
-export type UrlHistoryRecord = Pick<
-  UrlHistoryType,
-  // to change depending on what records are requested for
-  'longUrl' | 'state' | 'shortUrl' | 'createdAt'
-> & { userEmail: string }
+export interface UrlHistoryRecord {
+  // to change depending on what records changes are requested for
+  userEmail: string
+  longUrl: string
+  shortUrl: string
+  state: string
+  description: string
+  isFile: boolean
+  createdAt: string
+}
 
 export interface UrlHistoryRepository {
   /**

--- a/src/server/modules/audit/interfaces/index.ts
+++ b/src/server/modules/audit/interfaces/index.ts
@@ -1,6 +1,8 @@
 export {
   LinkAudit,
   LinkAuditService,
-  LinkAuditService as default,
+  LinkChangeSet,
+  LinkChangeKey,
+  LinkChangeType,
 } from './LinkAuditService'
 export { UrlHistoryRecord, UrlHistoryRepository } from './UrlHistoryRepository'

--- a/src/server/modules/audit/interfaces/index.ts
+++ b/src/server/modules/audit/interfaces/index.ts
@@ -3,3 +3,4 @@ export {
   LinkAuditService,
   LinkAuditService as default,
 } from './LinkAuditService'
+export { UrlHistoryRecord, UrlHistoryRepository } from './UrlHistoryRepository'

--- a/src/server/modules/audit/interfaces/index.ts
+++ b/src/server/modules/audit/interfaces/index.ts
@@ -1,0 +1,5 @@
+export {
+  LinkAudit,
+  LinkAuditService,
+  LinkAuditService as default,
+} from './LinkAuditService'

--- a/src/server/modules/audit/repositories/UrlHistoryRepository.ts
+++ b/src/server/modules/audit/repositories/UrlHistoryRepository.ts
@@ -1,0 +1,53 @@
+import { injectable } from 'inversify'
+import _ from 'lodash'
+
+import { UrlHistory, UrlHistoryType } from '../../../models/url'
+import { User, UserType } from '../../../models/user'
+import * as interfaces from '../interfaces'
+
+type UrlAuditHistoryType = UrlHistoryType & {
+  user: UserType
+}
+
+@injectable()
+export class UrlHistoryRepository implements interfaces.UrlHistoryRepository {
+  public findByShortUrl: (
+    shortUrl: string,
+    limit: number,
+    offset: number,
+  ) => Promise<interfaces.UrlHistoryRecord[]> = async (
+    shortUrl,
+    limit,
+    offset,
+  ) => {
+    const urlHistories = (await UrlHistory.findAll({
+      include: [{ model: User }],
+      order: [['updatedAt', 'DESC']],
+      raw: true,
+      nest: true,
+      offset,
+      limit,
+      where: { urlShortUrl: shortUrl },
+    })) as UrlAuditHistoryType[]
+
+    return urlHistories.map((urlHistory) => {
+      return {
+        longUrl: urlHistory.longUrl,
+        state: urlHistory.state,
+        shortUrl: urlHistory.urlShortUrl,
+        createdAt: urlHistory.createdAt,
+        userEmail: urlHistory.user.email,
+        description: urlHistory.description,
+        isFile: urlHistory.isFile,
+      }
+    })
+  }
+
+  public getCountByShortUrl: (shortUrl: string) => Promise<number> = async (
+    shortUrl,
+  ) => {
+    return UrlHistory.count({ where: { urlShortUrl: shortUrl } })
+  }
+}
+
+export default UrlHistoryRepository

--- a/src/server/modules/audit/repositories/index.ts
+++ b/src/server/modules/audit/repositories/index.ts
@@ -1,0 +1,4 @@
+export {
+  UrlHistoryRepository,
+  UrlHistoryRepository as default,
+} from './UrlHistoryRepository'

--- a/src/server/modules/audit/services/LinkAuditService.ts
+++ b/src/server/modules/audit/services/LinkAuditService.ts
@@ -1,15 +1,138 @@
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
 import * as interfaces from '../interfaces'
+import { NotFoundError } from '../../../util/error'
+import { DependencyIds } from '../../../constants'
+import { UserRepositoryInterface } from '../../../repositories/interfaces/UserRepositoryInterface'
 
 @injectable()
 export class LinkAuditService implements interfaces.LinkAuditService {
+  private userRepository: UserRepositoryInterface
+
+  private urlHistoryRepository: interfaces.UrlHistoryRepository
+
+  constructor(
+    @inject(DependencyIds.userRepository)
+    userRepository: UserRepositoryInterface,
+    @inject(DependencyIds.urlHistoryRepository)
+    urlHistoryRepository: interfaces.UrlHistoryRepository,
+  ) {
+    this.userRepository = userRepository
+    this.urlHistoryRepository = urlHistoryRepository
+  }
+
+  // Helper function to compute pairwise changes between two rows of url histories
+  computePairwiseChangeSet: (
+    currUrlHistory: interfaces.UrlHistoryRecord,
+    prevUrlHistory: interfaces.UrlHistoryRecord,
+    keysToTrack?: interfaces.LinkChangeKey[],
+  ) => interfaces.LinkChangeSet[] = (
+    currUrlHistory,
+    prevUrlHistory,
+    keysToTrack = ['state', 'userEmail', 'longUrl'],
+  ) => {
+    const changeSets: interfaces.LinkChangeSet[] = []
+
+    keysToTrack.forEach((keyToTrack) => {
+      const currValue =
+        currUrlHistory[keyToTrack as keyof interfaces.UrlHistoryRecord]
+      const prevValue =
+        prevUrlHistory[keyToTrack as keyof interfaces.UrlHistoryRecord]
+      if (!_.isEqual(currValue, prevValue)) {
+        changeSets.push({
+          type: 'update',
+          key: keyToTrack as interfaces.LinkChangeKey,
+          prevValue,
+          currValue,
+          updatedAt: currUrlHistory.createdAt,
+        })
+      }
+    })
+    return changeSets
+  }
+
+  // Helper function to compute change sets for initial url creation
+  computeInitialChangeSets: (
+    currUrlHistory: interfaces.UrlHistoryRecord,
+    keysToTrack?: interfaces.LinkChangeKey[],
+  ) => interfaces.LinkChangeSet[] = (
+    currUrlHistory,
+    keysToTrack = ['longUrl'],
+  ) => {
+    const changeSets: interfaces.LinkChangeSet[] = []
+
+    keysToTrack.forEach((keyToTrack) => {
+      changeSets.push({
+        type: 'create',
+        key: keyToTrack as interfaces.LinkChangeKey,
+        prevValue: '',
+        currValue:
+          currUrlHistory[keyToTrack as keyof interfaces.UrlHistoryRecord],
+        updatedAt: currUrlHistory.createdAt,
+      })
+    })
+    return changeSets
+  }
+
+  getChangeSets: (
+    urlHistories: interfaces.UrlHistoryRecord[],
+    isLastCreate: boolean,
+  ) => interfaces.LinkChangeSet[] = (urlHistories, isLastCreate = false) => {
+    const changeSets = []
+    for (let i = 0; i < urlHistories.length - 1; i += 1) {
+      changeSets.push(
+        ...this.computePairwiseChangeSet(urlHistories[i], urlHistories[i + 1]),
+      )
+    }
+    if (isLastCreate) {
+      changeSets.push(
+        ...this.computeInitialChangeSets(urlHistories[urlHistories.length - 1]),
+      )
+    }
+    return changeSets
+  }
+
   getLinkAudit: (
     userId: number,
     shortUrl: string,
     limit: number,
     offset: number,
-  ) => Promise<null> = async () => {
-    return null
+  ) => Promise<interfaces.LinkAudit | null> = async (
+    userId,
+    shortUrl,
+    limit = 10,
+    offset = 0,
+  ) => {
+    const userOwnsLink = !!(await this.userRepository.findOneUrlForUser(
+      userId,
+      shortUrl,
+    ))
+    if (!userOwnsLink) {
+      throw new NotFoundError('User does not own this short url')
+    }
+    const totalCount = await this.urlHistoryRepository.getCountByShortUrl(
+      shortUrl,
+    )
+
+    const urlHistories = await this.urlHistoryRepository.findByShortUrl(
+      shortUrl,
+      limit + 1,
+      offset,
+    )
+
+    if (urlHistories.length === 0) {
+      // invalid limit or offset
+      throw new Error('Invalid offset or limit provided')
+    }
+
+    const includesCreate = limit + 1 + offset > totalCount
+
+    return {
+      changes: this.getChangeSets(urlHistories, includesCreate),
+      limit,
+      offset,
+      totalCount,
+    }
   }
 }
 

--- a/src/server/modules/audit/services/LinkAuditService.ts
+++ b/src/server/modules/audit/services/LinkAuditService.ts
@@ -97,7 +97,7 @@ export class LinkAuditService implements interfaces.LinkAuditService {
     shortUrl: string,
     limit?: number,
     offset?: number,
-  ) => Promise<interfaces.LinkAudit | null> = async (
+  ) => Promise<interfaces.LinkAudit> = async (
     userId,
     shortUrl,
     limit = 10,

--- a/src/server/modules/audit/services/LinkAuditService.ts
+++ b/src/server/modules/audit/services/LinkAuditService.ts
@@ -52,7 +52,7 @@ export class LinkAuditService implements interfaces.LinkAuditService {
   }
 
   // Helper function to compute change sets for initial url creation
-  computeInitialChangeSets: (
+  computeInitialChangeSet: (
     currUrlHistory: interfaces.UrlHistoryRecord,
     keysToTrack?: interfaces.LinkChangeKey[],
   ) => interfaces.LinkChangeSet[] = (
@@ -86,7 +86,7 @@ export class LinkAuditService implements interfaces.LinkAuditService {
     }
     if (isLastCreate) {
       changeSets.push(
-        ...this.computeInitialChangeSets(urlHistories[urlHistories.length - 1]),
+        ...this.computeInitialChangeSet(urlHistories[urlHistories.length - 1]),
       )
     }
     return changeSets
@@ -95,8 +95,8 @@ export class LinkAuditService implements interfaces.LinkAuditService {
   getLinkAudit: (
     userId: number,
     shortUrl: string,
-    limit: number,
-    offset: number,
+    limit?: number,
+    offset?: number,
   ) => Promise<interfaces.LinkAudit | null> = async (
     userId,
     shortUrl,

--- a/src/server/modules/audit/services/LinkAuditService.ts
+++ b/src/server/modules/audit/services/LinkAuditService.ts
@@ -1,0 +1,16 @@
+import { injectable } from 'inversify'
+import * as interfaces from '../interfaces'
+
+@injectable()
+export class LinkAuditService implements interfaces.LinkAuditService {
+  getLinkAudit: (
+    userId: number,
+    shortUrl: string,
+    limit: number,
+    offset: number,
+  ) => Promise<null> = async () => {
+    return null
+  }
+}
+
+export default LinkAuditService

--- a/src/server/modules/audit/services/__tests__/LinkAuditService.test.ts
+++ b/src/server/modules/audit/services/__tests__/LinkAuditService.test.ts
@@ -1,0 +1,289 @@
+import { LinkAuditService } from '..'
+import { LinkChangeKey, LinkChangeSet } from '../../interfaces'
+
+const NO_OP = jest.fn()
+
+const findOneUrlForUser = jest.fn()
+
+const findByShortUrl = jest.fn()
+const getCountByShortUrl = jest.fn()
+
+const service = new LinkAuditService(
+  {
+    findById: NO_OP,
+    findByEmail: NO_OP,
+    findOneUrlForUser,
+    findOrCreateWithEmail: NO_OP,
+    findUrlsForUser: NO_OP,
+    findUserByUrl: NO_OP,
+  },
+  { findByShortUrl, getCountByShortUrl },
+)
+
+const prevUrlHistory = {
+  longUrl: 'https://abc.com',
+  state: 'INACTIVE',
+  shortUrl: 'abc',
+  createdAt: '2022-08-05T11:57:41.309Z',
+  userEmail: 'alexis@open.gov.sg',
+  description: '',
+  isFile: true,
+}
+const currUrlHistory = {
+  longUrl: 'https://google.com',
+  state: 'INACTIVE',
+  shortUrl: 'abc',
+  createdAt: '2022-10-01T13:31:39.419Z',
+  userEmail: 'alexis@open.gov.sg',
+  description: '',
+  isFile: true,
+}
+
+/**
+ * Unit tests for LinkAuditService.
+ */
+describe('LinkAuditService tests', () => {
+  describe('computePairwiseChangeSet', () => {
+    it('should correctly compute changes between two url records for all tracked keys', () => {
+      const keysToTrack = ['longUrl', 'state', 'userEmail'] as LinkChangeKey[]
+      expect(
+        service.computePairwiseChangeSet(
+          currUrlHistory,
+          prevUrlHistory,
+          keysToTrack,
+        ),
+      ).toStrictEqual([
+        {
+          type: 'update',
+          key: 'longUrl',
+          prevValue: 'https://abc.com',
+          currValue: 'https://google.com',
+          updatedAt: '2022-10-01T13:31:39.419Z',
+        },
+      ])
+    })
+
+    it('should return empty list if changes between two url records are not in tracked keys', () => {
+      const keysToTrack = [] as LinkChangeKey[]
+      expect(
+        service.computePairwiseChangeSet(
+          currUrlHistory,
+          prevUrlHistory,
+          keysToTrack,
+        ),
+      ).toStrictEqual([])
+    })
+  })
+
+  describe('computeInitialChangeSet', () => {
+    it('should correctly compute initial change set for all tracked keys', () => {
+      const keysToTrack = ['longUrl', 'state'] as LinkChangeKey[]
+      expect(
+        service.computeInitialChangeSet(currUrlHistory, keysToTrack),
+      ).toStrictEqual([
+        {
+          type: 'create',
+          key: 'longUrl',
+          prevValue: '',
+          currValue: 'https://google.com',
+          updatedAt: '2022-10-01T13:31:39.419Z',
+        },
+        {
+          type: 'create',
+          key: 'state',
+          prevValue: '',
+          currValue: 'INACTIVE',
+          updatedAt: '2022-10-01T13:31:39.419Z',
+        },
+      ])
+    })
+
+    it('should return empty list if changes in initial change set not in tracked keys', () => {
+      const keysToTrack = [] as LinkChangeKey[]
+      expect(
+        service.computeInitialChangeSet(currUrlHistory, keysToTrack),
+      ).toStrictEqual([])
+    })
+  })
+
+  describe('getChangeSets', () => {
+    it('should not call computePairwiseChangeSet if only one url record', () => {
+      const urlHistories = [currUrlHistory]
+      const isLastCreate = true
+      const changeSet = {
+        type: 'create',
+        key: 'longUrl',
+        prevValue: '',
+        currValue: 'https://google.com',
+        updatedAt: '2022-10-01T13:31:39.419Z',
+      } as LinkChangeSet
+
+      jest
+        .spyOn(service, 'computeInitialChangeSet')
+        .mockImplementation(() => [changeSet])
+      jest
+        .spyOn(service, 'computePairwiseChangeSet')
+        .mockImplementation(() => [])
+
+      expect(service.getChangeSets(urlHistories, isLastCreate)).toStrictEqual([
+        changeSet,
+      ])
+      expect(service.computeInitialChangeSet).toHaveBeenCalledWith(
+        currUrlHistory,
+      )
+      expect(service.computePairwiseChangeSet).not.toHaveBeenCalled()
+
+      jest.restoreAllMocks()
+    })
+
+    it('should not call computeInitialChangeSet if records does not include initial creation', () => {
+      const urlHistories = [currUrlHistory, prevUrlHistory] // ordered from most recent
+      const isLastCreate = false
+      const changeSet = {
+        type: 'update',
+        key: 'longUrl',
+        prevValue: 'https://abc.com',
+        currValue: 'https://google.com',
+        updatedAt: '2022-10-01T13:31:39.419Z',
+      } as LinkChangeSet
+
+      jest
+        .spyOn(service, 'computeInitialChangeSet')
+        .mockImplementation(() => [])
+      jest
+        .spyOn(service, 'computePairwiseChangeSet')
+        .mockImplementation(() => [changeSet])
+
+      expect(service.getChangeSets(urlHistories, isLastCreate)).toStrictEqual([
+        changeSet,
+      ])
+      expect(service.computeInitialChangeSet).not.toHaveBeenCalled()
+      expect(service.computePairwiseChangeSet).toHaveBeenCalledWith(
+        currUrlHistory,
+        prevUrlHistory,
+      )
+
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('findByShortUrl', () => {
+    it('should retrieve url history records from repository', async () => {
+      const shortUrl = 'hello'
+      const defaultLimit = 10
+      const defaultOffset = 0
+      const urlHistories = [currUrlHistory, prevUrlHistory]
+      const totalUrlHistories = urlHistories.length
+      const changeSets = [
+        {
+          type: 'update',
+          key: 'longUrl',
+          prevValue: 'https://abc.com',
+          currValue: 'https://google.com',
+          updatedAt: '2022-10-01T13:31:39.419Z',
+        },
+        {
+          type: 'create',
+          key: 'longUrl',
+          prevValue: '',
+          currValue: 'https://abc.com',
+          updatedAt: '2022-08-05T11:57:41.309Z',
+        },
+      ] as LinkChangeSet[]
+
+      findOneUrlForUser.mockResolvedValue({
+        shortUrl,
+        longUrl: 'https://open.gov.sg',
+        state: 'ACTIVE',
+        clicks: 100,
+        isFile: false,
+        createdAt: '',
+        updatedAt: '',
+      })
+      findByShortUrl.mockResolvedValue(urlHistories)
+      getCountByShortUrl.mockResolvedValue(totalUrlHistories)
+
+      jest.spyOn(service, 'getChangeSets').mockImplementation(() => changeSets)
+
+      await expect(service.getLinkAudit(123, shortUrl)).resolves.toStrictEqual({
+        changes: changeSets,
+        totalCount: totalUrlHistories,
+        limit: defaultLimit,
+        offset: defaultOffset,
+      })
+      expect(getCountByShortUrl).toHaveBeenCalledWith(shortUrl)
+      expect(findByShortUrl).toHaveBeenCalledWith(
+        shortUrl,
+        defaultLimit + 1,
+        defaultOffset,
+      )
+      expect(service.getChangeSets).toHaveBeenCalledWith(urlHistories, true)
+      jest.restoreAllMocks()
+    })
+
+    it('should forward limit and offset to repository', async () => {
+      const shortUrl = 'hello'
+      const limit = 1
+      const offset = 0
+      const urlHistories = [currUrlHistory, prevUrlHistory]
+      const totalUrlHistories = urlHistories.length
+      const changeSets = [
+        {
+          type: 'update',
+          key: 'longUrl',
+          prevValue: 'https://abc.com',
+          currValue: 'https://google.com',
+          updatedAt: '2022-10-01T13:31:39.419Z',
+        },
+      ] as LinkChangeSet[]
+
+      findOneUrlForUser.mockResolvedValue({
+        shortUrl,
+        longUrl: 'https://open.gov.sg',
+        state: 'ACTIVE',
+        clicks: 100,
+        isFile: false,
+        createdAt: '',
+        updatedAt: '',
+      })
+      findByShortUrl.mockResolvedValue(urlHistories)
+      getCountByShortUrl.mockResolvedValue(totalUrlHistories)
+
+      jest.spyOn(service, 'getChangeSets').mockImplementation(() => changeSets)
+
+      await expect(
+        service.getLinkAudit(123, shortUrl, limit, offset),
+      ).resolves.toStrictEqual({
+        changes: changeSets,
+        totalCount: totalUrlHistories,
+        limit,
+        offset,
+      })
+      expect(getCountByShortUrl).toHaveBeenCalledWith(shortUrl)
+      expect(findByShortUrl).toHaveBeenCalledWith(shortUrl, limit + 1, offset)
+      expect(service.getChangeSets).toHaveBeenCalledWith(urlHistories, false)
+      jest.restoreAllMocks()
+    })
+
+    it('should throw error if invalid offset or limit provided', async () => {
+      const shortUrl = 'hello'
+      const limit = 10
+      const offset = 100000002
+
+      findOneUrlForUser.mockResolvedValue({
+        shortUrl,
+        longUrl: 'https://open.gov.sg',
+        state: 'ACTIVE',
+        clicks: 100,
+        isFile: false,
+        createdAt: '',
+        updatedAt: '',
+      })
+      findByShortUrl.mockResolvedValue([])
+
+      await expect(
+        service.getLinkAudit(123, shortUrl, limit, offset),
+      ).rejects.toThrow('Invalid offset or limit provided')
+    })
+  })
+})

--- a/src/server/modules/audit/services/index.ts
+++ b/src/server/modules/audit/services/index.ts
@@ -1,0 +1,4 @@
+export {
+  LinkAuditService,
+  LinkAuditService as default,
+} from './LinkAuditService'


### PR DESCRIPTION
## Problem

We want to provide an audit trail for link creators, so that they can know who has changed what on their link, and when.

See [Notion story](https://www.notion.so/opengov/As-a-user-I-want-to-know-what-has-changed-on-my-link-and-by-whom-cf452a2d99864ac8850f01e0f6721296) for details on user journey.

We currently store this data in our `url_histories` table. We parse the url records and expose an endpoint for the frontend to retrieve the records.

## Solution

- Add repository layer to retrieve url records
- Add service layer to parse url records to return pairwise change sets
- Add controller and exposes endpoint `/api/link-audit`

For authenticated query:
```
GET /api/link-audit?url=<shortUrl>&limit=10&offset=10
```

Returns: (JSON) HttpStatus 200 for success
```
{
  changes: [ // ordered from most recent
    {
      "type": "update",
      "key": "state",
      "prevValue": "ACTIVE",
      "currValue": "INACTIVE",
      "updatedAt": "2022-04-06 09:15:26.272+00",
    },
    {
      "type": "update",
      "key": "longUrl",
      "prevValue": "https://google.com",
      "currValue": "https://twitter.com",
      "updatedAt": "2022-03-01 13:59:01.341+00',
    },
    {
      "type": "create",
      "key": "longUrl",
      "prevValue": "",
      "currValue": "https://abc.com",
      "updatedAt": "2022-01-30T04:45:55.204Z"
    }
  ],
  offset: 10, 
  limit: 10, 
  count: 13, // total count of results
}
```

`changes` is an array of type `changeSets[]`

**Values:**
- **type (string):** One of `'create', 'update'`
- **key (string):** One of `'state','userEmail','longUrl'`
- **prevValue (string):** string representation of previous key value
- **currValue (string):** string representation of current key value
- **updatedAt**


Refer to [Notion doc](https://www.notion.so/opengov/20220803-Link-Audit-7cd6cc4040bd4e90b9a331ea5ddbf721) for technical design.

## Tests

_What tests should be run to confirm functionality?_

## Future work

**Improving pagination**
We use the simplest approach to pagination currently (via limit and offset). There are various ways to improve this:
- primary-key-based offsets e.g. “where id < last_id_seen” in the query
- `ORDER BY id` rather than something like `ORDER BY created_at`

The rationale for these optimizations are documented in the [Notion technical document](https://www.notion.so/opengov/20220803-Link-Audit-7cd6cc4040bd4e90b9a331ea5ddbf721) - we can do these optimisations at a later date if we evaluate that this is a performance issue.
