### PR TITLE
chore: log OTP verification successes and failures

### DIFF
--- a/src/server/modules/auth/LoginController.ts
+++ b/src/server/modules/auth/LoginController.ts
@@ -1,6 +1,10 @@
 import Express from 'express'
 import { inject, injectable } from 'inversify'
-import { loginMessage, validEmailDomainGlobExpression } from '../../config'
+import {
+  logger,
+  loginMessage,
+  validEmailDomainGlobExpression,
+} from '../../config'
 import { DependencyIds } from '../../constants'
 import jsonMessage from '../../util/json'
 import { AuthService } from './interfaces'
@@ -59,7 +63,7 @@ export class LoginController {
       const user = await this.authService.verifyOtp(email, otp)
       req.session!.user = user
       res.ok(jsonMessage('OTP hash verification ok.'))
-      console.info(`Login success for user:\t${user.email}`)
+      logger.info(`OTP login success for user:\t${user.email}`)
       return
     } catch (error) {
       if (error instanceof InvalidOtpError) {
@@ -68,12 +72,12 @@ export class LoginController {
             `OTP hash verification failed, ${error.retries} attempt(s) remaining.`,
           ),
         )
-        console.info(`Login OTP verification failed for user:\t${email}`)
+        logger.error(`Login OTP verification failed for user:\t${email}`)
         return
       }
       if (error instanceof NotFoundError) {
         res.unauthorized(jsonMessage('OTP expired/not found.'))
-        console.info(`Login email not found for user:\t${email}`)
+        logger.error(`Login email not found for user:\t${email}`)
         return
       }
       res.serverError(jsonMessage(error.message))


### PR DESCRIPTION
## Problem

Apart from logging down successes/failures for OTP generation, we'd like to do so for OTP verification as well. Currently for OTP verification we have some console outputs - these can be seen on CloudWatch, but moving them to logger will make them also visible on Datadog

## Solution

Change `console.info` to `logger.info` and `logger.error`

## Tests

- [x] Tested on staging to ensure that OTP verification logs are visible on both CloudWatch and Datadog
