### PR TITLE
Feat/postman

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       - ASSET_VARIANT=gov
       - SES_HOST=maildev
       - SES_PORT=25
+      - POSTMAN_API_KEY=
+      - POSTMAN_API_URL=
+      - ACTIVATE_POSTMAN_FALLBACK=
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/package-lock.json
+++ b/package-lock.json
@@ -5117,6 +5117,32 @@
       "integrity": "sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+          "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@sentry/webpack-plugin": "^1.15.1",
     "@types/express-rate-limit": "^5.1.3",
     "aws-sdk": "^2.1101.0",
+    "axios": "^0.27.2",
     "babel-polyfill": "^6.26.0",
     "bcrypt": "^5.0.1",
     "body-parser": "^1.18.3",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -237,3 +237,7 @@ const displayHostnameMap = {
   health: 'For.sg',
 }
 export const displayHostname = displayHostnameMap[assetVariant]
+export const postmanApiUrl: string | undefined = process.env.POSTMAN_API_URL
+export const postmanApiKey: string | undefined = process.env.POSTMAN_API_KEY
+export const activatePostmanFallback: boolean =
+  process.env.ACTIVATE_POSTMAN_FALLBACK === 'true'

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -68,7 +68,8 @@ export class MailerNode implements Mailer {
       if (e instanceof Error) {
         logger.error(e.message)
       }
-      throw e
+      // TODO: please help to check FE error handling before throwing the exception
+      // throw e
     }
 
     return
@@ -110,7 +111,7 @@ export class MailerNode implements Mailer {
       return Promise.resolve()
     }
 
-    const emailHTML = `Your OTP is <b>${otp}</b>. It wii'll expire in ${Math.floor(
+    const emailHTML = `Your OTP is <b>${otp}</b>. It will expire in ${Math.floor(
       otpExpiry / 60,
     )} minutes.
     Please use this to login to your account.


### PR DESCRIPTION
## Solution

Implemented Postman fallback mailer.

### Notes
Postman fallback mailer will only be activated if env variable `ACTIVATE_POSTMAN_FALLBACK` is set to `true`. If not, it should still use the default SES email transport. 

## Tests

- [x] add env variables to Go-staging
- [x] push to edge
- [x] verify that non-SGMail inboxes can receive OTP from go-staging (via Postman)
- [x] verify that SGMail inboxes can receive OTP from go-staging (via Postman)
- [x] verify that non-SGMail inboxes can receive OTP from edu-staging or health-staging (via SES)
- [ ] verify whether SGMail inboxes can receive OTP from edu-staging or health-staging (via SES)

## Other todos
- [ ] **Determine if we should apply Postman fallback to health and edu environments as well**

## Deploy Notes

- [ ] add env variables to prod 
  - [ ] `POSTMAN_API_KEY` - 1Password
  - [ ] `POSTMAN_API_URL` - `https://api.postman.gov.sg/v1/transactional/email/send`
  - [ ] `ACTIVATE_POSTMAN_FALLBACK` - `true`
- [ ] deploy to prod


