### PR TITLE
Feat/sns consumer lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -37,4 +37,16 @@ functions:
           - 'src/server/serverless/lambda-migrate-user-links/**'
           - 'package-lock.json'
           - 'package.json'
+  capture-ses-events:
+    handler: src/server/serverless/capture-ses-events/index.handler
+    memorySize: 128
+    description: SNS subscriber for SES events
+    package:
+      excludeDevDependencies: true
+      patterns:
+          - '!./**'
+          - 'src/server/serverless/capture-ses-events/**'
+          - 'package-lock.json'
+          - 'package.json'
+
   

--- a/src/server/serverless/capture-ses-events/index.js
+++ b/src/server/serverless/capture-ses-events/index.js
@@ -1,0 +1,14 @@
+const crossFetch = require('cross-fetch')
+
+async function handler(event) {
+  console.log(event)
+  const { SubscribeUrl } = event
+  console.log('subscribe url is', SubscribeUrl)
+  if (SubscribeUrl) {
+    await crossFetch(SubscribeUrl, {
+      method: 'GET',
+    })
+  }
+}
+
+module.exports.handler = handler

--- a/src/server/serverless/capture-ses-events/index.js
+++ b/src/server/serverless/capture-ses-events/index.js
@@ -1,16 +1,6 @@
-const crossFetch = require('cross-fetch')
-
 async function handler(event) {
-  event.Records.map((e) => {
-    console.log(e)
-    console.log(e.sns)
-    const { SubscribeUrl } = e
-    if (SubscribeUrl) {
-      return crossFetch(SubscribeUrl, {
-        method: 'GET',
-      })
-    }
-    return Promise.resolve()
+  event.Records.forEach((e) => {
+    console.log(e.Sns)
   })
 }
 

--- a/src/server/serverless/capture-ses-events/index.js
+++ b/src/server/serverless/capture-ses-events/index.js
@@ -1,14 +1,17 @@
 const crossFetch = require('cross-fetch')
 
 async function handler(event) {
-  console.log(event)
-  const { SubscribeUrl } = event
-  console.log('subscribe url is', SubscribeUrl)
-  if (SubscribeUrl) {
-    await crossFetch(SubscribeUrl, {
-      method: 'GET',
-    })
-  }
+  event.Records.map((e) => {
+    console.log(e)
+    console.log(e.sns)
+    const { SubscribeUrl } = e
+    if (SubscribeUrl) {
+      return crossFetch(SubscribeUrl, {
+        method: 'GET',
+      })
+    }
+    return Promise.resolve()
+  })
 }
 
 module.exports.handler = handler


### PR DESCRIPTION
## Problem

We need a way to capture SES email sending events, which are currently published to an SNS topic.

## Solution

Create a lambda that acts as a subscriber to said SNS topic. The actual subscription needs to be done manually, and we can probably just use one single lambda (gov-production maybe?) as the subscriber. In the future, we can split the SES events for gov, edu and health into separate SNS topics and have their respect lambdas subscribe to them.

## Deploy Notes

Grab the ARN of the newly created lambda and add it as a subscriber to the SNS topic.

## Alternatives considered

We can also introduce an API endpoint in our application, but that introduces unnecessary coupling of the app to this auxiliary feature.
