### PR TITLE
Fix/mail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5117,32 +5117,6 @@
       "integrity": "sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==",
       "dev": true
     },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-          "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@sentry/webpack-plugin": "^1.15.1",
     "@types/express-rate-limit": "^5.1.3",
     "aws-sdk": "^2.1101.0",
-    "axios": "^0.27.2",
     "babel-polyfill": "^6.26.0",
     "bcrypt": "^5.0.1",
     "body-parser": "^1.18.3",

--- a/src/server/modules/auth/services/AuthService.ts
+++ b/src/server/modules/auth/services/AuthService.ts
@@ -54,19 +54,20 @@ export class AuthService implements interfaces.AuthService {
         logger.error(`Could not save OTP hash:\t${saveError}`)
         throw new Error('Could not save OTP hash.')
       }
-      // Email out the otp (nodemailer)
-      try {
-        await this.mailer.mailOTP(email, otp, ip)
-      } catch (error) {
-        logger.error(`Error mailing OTP: ${error}`)
-        throw new Error('Error mailing OTP, please try again later.')
-      }
       logger.info(`OTP generation successful for ${email}`)
       dogstatsd.increment('otp.success', 1, 1)
     } catch (error) {
       logger.error(`OTP generation failed unexpectedly for ${email}:\t${error}`)
       dogstatsd.increment('otp.failure', 1, 1)
       throw new Error('OTP generation failed unexpectedly.')
+    }
+
+    // Email out the otp
+    try {
+      await this.mailer.mailOTP(email, otp, ip)
+    } catch (error) {
+      logger.error(`Error mailing OTP: ${error}`)
+      throw new Error('Error mailing OTP, please try again later.')
     }
   }
 

--- a/src/server/services/__tests__/email.test.ts
+++ b/src/server/services/__tests__/email.test.ts
@@ -1,0 +1,111 @@
+import { MailBody } from '../email'
+/* eslint-disable global-require */
+
+/**
+ * Unit tests for Mailer.
+ */
+describe('Mailer tests', () => {
+  const testMailBody = {
+    to: 'alexis@open.gov.sg',
+    body: 'Hi',
+    subject: 'Hi from postman',
+    senderDomain: 'go.gov.sg',
+  } as MailBody
+
+  const mockFetch = jest.fn()
+
+  beforeEach(() => {
+    jest.resetModules()
+    mockFetch.mockReset()
+  })
+
+  afterAll(jest.resetModules)
+
+  describe('sendPostmanMail', () => {
+    it('should throw error if postman api key is undefined', async () => {
+      jest.mock('../../config', () => ({
+        logger: console,
+        postmanApiKey: '',
+      }))
+      const { MailerNode } = require('../email')
+      const service = new MailerNode()
+
+      await expect(service.sendPostmanMail(testMailBody)).rejects.toThrowError()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('should throw error if postman api url is undefined', async () => {
+      jest.mock('../../config', () => ({
+        logger: console,
+        postmanApiUrl: '',
+        postmanApiKey: 'hey',
+      }))
+      const { MailerNode } = require('../email')
+      const service = new MailerNode()
+
+      await expect(service.sendPostmanMail(testMailBody)).rejects.toThrowError()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    // TODO: uncomment this test when we fix the FE error handling
+    // it('should throw error if response is not ok', async () => {
+    //   const { MailerNode } = require('../email')
+    //   const service = new MailerNode()
+    //   mockFetch.mockResolvedValue({ ok: false })
+
+    //   await expect(service.sendPostmanMail(testMailBody)).toThrowError()
+    //   expect(mockFetch).toHaveBeenCalled()
+    // })
+  })
+
+  describe('sendMail', () => {
+    it('should send via nodemailer by default', async () => {
+      const sendMailMock = jest.fn((_, callback) => callback())
+      jest.mock('nodemailer', () => ({
+        createTransport: jest.fn().mockImplementation(() => ({
+          sendMail: sendMailMock,
+        })),
+      }))
+
+      const { MailerNode } = require('../email')
+      const service = new MailerNode()
+      service.initMailer()
+      await service.sendMail(testMailBody)
+      expect(sendMailMock).toHaveBeenCalled()
+    })
+
+    it('should send via Postman if activatePostmanFallback is true', async () => {
+      jest.mock('cross-fetch', () => mockFetch)
+      jest.mock('../../config', () => ({
+        logger: console,
+        activatePostmanFallback: true,
+        postmanApiKey: 'key',
+        postmanApiUrl: 'url',
+      }))
+      const { MailerNode } = require('../email')
+      const service = new MailerNode()
+
+      const postmanSpy = jest.spyOn(service, 'sendPostmanMail')
+      mockFetch.mockResolvedValue({ ok: true })
+
+      await service.sendMail(testMailBody)
+      expect(postmanSpy).toHaveBeenCalledWith(testMailBody)
+      expect(mockFetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('mailOTP', () => {
+    const { MailerNode } = require('../email')
+    const service = new MailerNode()
+
+    it('should not send mail if email or otp is undefined', async () => {
+      const testEmail = 'test@email.com'
+      const testOtp = undefined
+      const testIp = '1.1.1.1'
+
+      const sendMailSpy = jest.spyOn(service, 'sendMail')
+      await service.mailOTP(testEmail, testOtp, testIp)
+      expect(sendMailSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/server/services/__tests__/email.test.ts
+++ b/src/server/services/__tests__/email.test.ts
@@ -47,15 +47,13 @@ describe('Mailer tests', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
-    // TODO: uncomment this test when we fix the FE error handling
-    // it('should throw error if response is not ok', async () => {
-    //   const { MailerNode } = require('../email')
-    //   const service = new MailerNode()
-    //   mockFetch.mockResolvedValue({ ok: false })
+    it('should throw error if response is not ok', async () => {
+      const { MailerNode } = require('../email')
+      const service = new MailerNode()
+      mockFetch.mockResolvedValue({ ok: false })
 
-    //   await expect(service.sendPostmanMail(testMailBody)).toThrowError()
-    //   expect(mockFetch).toHaveBeenCalled()
-    // })
+      await expect(service.sendPostmanMail(testMailBody)).rejects.toThrowError()
+    })
   })
 
   describe('sendMail', () => {

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -76,8 +76,7 @@ export class MailerNode implements Mailer {
         }\thttpResponse: ${response.status}\t body:${JSON.stringify(response)}`,
       )
       logger.error(error.message)
-      // TODO: please help to check FE error handling before throwing the exception
-      // throw e
+      throw error
     }
     return
   }

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -19,14 +19,15 @@ const domainVariantMap = {
   gov: 'go.gov.sg',
   edu: 'for.edu.sg',
   health: 'for.sg',
-}
+} as const
 const domainVariant = domainVariantMap[assetVariant]
 
-interface MailBody {
+type SenderDomain = typeof domainVariantMap[keyof typeof domainVariantMap]
+export interface MailBody {
   to: string
   body: string
   subject: string
-  senderDomain?: string
+  senderDomain: SenderDomain
 }
 
 let transporter: nodemailer.Transport
@@ -34,7 +35,7 @@ export interface Mailer {
   initMailer(): void
 
   /**
-   * Sends email to SES / MailDev to send out.
+   * Sends email to SES / MailDev to send out. Falls back to Postman.
    */
   mailOTP(email: string, otp: string, ip: string): Promise<void>
 }


### PR DESCRIPTION
## Problem

I broke our Coveralls tests unknowingly (fell below 75%) when I made the changes to include a Postman fallback option (#1912) without adding tests. 

Closes #1915 and #1928

## Solution

- Added test routes for email module
- Replaced `axios` with `cross-fetch`
- Fixed `try-catch` nesting for OTP generation and sending

## Other notes
~I would love to propose that we run Coveralls against PRs to `develop`. Currently, Coveralls runs on PRs to `release`, but that since merges to `releases` are usually after we complete feature development and are prepared to cut a stable version, the coverage tests comes a little belated.~ Seems like Coveralls runs against `develop` too, my bad.

## Tests

- See [Coveralls coverage now](https://coveralls.io/jobs/104841285/source_files/24604087889#L115)
- Jest coverage now <img width="846" alt="Screenshot 2022-08-22 at 12 45 14" src="https://user-images.githubusercontent.com/39231249/185841217-a5b59302-14ea-4a5b-bdab-cad2902e4cec.png">


