### PR TITLE
feat(datadog): add metrics and set RUM user

### DIFF
--- a/src/client/login/actions/index.ts
+++ b/src/client/login/actions/index.ts
@@ -1,3 +1,4 @@
+import { datadogRum } from '@datadog/browser-rum'
 import { Minimatch } from 'minimatch'
 import { Dispatch } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
@@ -211,8 +212,13 @@ const isLoggedIn =
       return response.json().then((json) => {
         if (isOk) {
           const { user } = json
+          datadogRum.setUser({
+            id: user.id,
+            email: user.email,
+          })
           dispatch<IsLoggedInSuccessAction>(isLoggedInSuccess(user))
         } else {
+          datadogRum.removeUser()
           dispatch<IsLoggedOutAction>(isLoggedOut())
         }
       })

--- a/src/server/modules/auth/services/AuthService.ts
+++ b/src/server/modules/auth/services/AuthService.ts
@@ -7,7 +7,6 @@ import { UserRepositoryInterface } from '../../../repositories/interfaces/UserRe
 import { StorableOtp, StorableUser } from '../../../repositories/types'
 import * as interfaces from '../interfaces'
 import { InvalidOtpError, NotFoundError } from '../../../util/error'
-import dogstatsd from '../../../util/dogstatsd'
 
 @injectable()
 export class AuthService implements interfaces.AuthService {
@@ -55,10 +54,8 @@ export class AuthService implements interfaces.AuthService {
         throw new Error('Could not save OTP hash.')
       }
       logger.info(`OTP generation successful for ${email}`)
-      dogstatsd.increment('otp.success', 1, 1)
     } catch (error) {
       logger.error(`OTP generation failed unexpectedly for ${email}:\t${error}`)
-      dogstatsd.increment('otp.failure', 1, 1)
       throw new Error('OTP generation failed unexpectedly.')
     }
 
@@ -66,7 +63,7 @@ export class AuthService implements interfaces.AuthService {
     try {
       await this.mailer.mailOTP(email, otp, ip)
     } catch (error) {
-      logger.error(`Error mailing OTP: ${error}`)
+      logger.error(`Error mailing OTP to ${email}: ${error}`)
       throw new Error('Error mailing OTP, please try again later.')
     }
   }
@@ -78,7 +75,7 @@ export class AuthService implements interfaces.AuthService {
       try {
         retrievedOtp = await this.otpRepository.getOtpForEmail(email)
       } catch (error) {
-        logger.error(`Error verifying OTP:\t${error}`)
+        logger.error(`Error verifying OTP for ${email}:\t${error}`)
         throw error
       }
 

--- a/src/server/modules/redirect/RedirectController.ts
+++ b/src/server/modules/redirect/RedirectController.ts
@@ -1,6 +1,7 @@
 import Express from 'express'
 import { inject, injectable } from 'inversify'
 import { displayHostname, gaTrackingId, logger } from '../../config'
+import dogstatsd from '../../util/dogstatsd'
 import { NotFoundError } from '../../util/error'
 import parseDomain from '../../util/domain'
 import { DependencyIds, ERROR_404_PATH } from '../../constants'
@@ -89,6 +90,7 @@ export class RedirectController {
 
       req.session!.visits = visitedUrls
 
+      dogstatsd.increment('shortlink.clicks', 1, 1)
       if (redirectType === RedirectType.TransitionPage) {
         // Extract root domain from long url.
         const rootDomain: string = parseDomain(longUrl)

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -3,7 +3,6 @@ import { inject, injectable } from 'inversify'
 
 import Sequelize from 'sequelize'
 import { OwnershipTransferRequest, UrlCreationRequest, UrlEditRequest } from '.'
-import dogstatsd from '../../util/dogstatsd'
 import jsonMessage from '../../util/json'
 import { DependencyIds } from '../../constants'
 import {
@@ -67,7 +66,6 @@ export class UserController {
         longUrl,
         file,
       )
-      dogstatsd.increment('shortlink.create', 1, 1, [`isfile:${!!file}`])
       res.ok(result)
       return
     } catch (error) {

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'inversify'
 
 import Sequelize from 'sequelize'
 import { OwnershipTransferRequest, UrlCreationRequest, UrlEditRequest } from '.'
+import dogstatsd from '../../util/dogstatsd'
 import jsonMessage from '../../util/json'
 import { DependencyIds } from '../../constants'
 import {
@@ -66,6 +67,7 @@ export class UserController {
         longUrl,
         file,
       )
+      dogstatsd.increment('shortlink.create', 1, 1, [`isfile:${!!file}`])
       res.ok(result)
       return
     } catch (error) {

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -6,6 +6,7 @@ import {
   UrlsPaginated,
   UserUrlsQueryConditions,
 } from '../../../repositories/types'
+import dogstatsd from '../../../util/dogstatsd'
 import {
   AlreadyExistsError,
   AlreadyOwnLinkError,
@@ -68,6 +69,7 @@ export class UrlManagementService implements interfaces.UrlManagementService {
       },
       storableFile,
     )
+    dogstatsd.increment('shortlink.create', 1, 1, [`isfile:${!!file}`])
 
     return result
   }


### PR DESCRIPTION
## Problem

We want to collect more useful product metrics for Go

## Solution

**Features**:

- Set user ID and email for datadog RUM on login, remove user on logout. The user ID/email helps us to track how many unique users are using our app over some time period
- `go.otp.generate.(success/failure)`: number of OTP generation successes/failures. This used to be `go.otp.(success/failure)`, but made it more specific to generation
- `go.otp.verify.(success/failure)`: number of OTP verification successes/failures
- `go.shortlink.clicks`: number of user clicks to existing short links
- `go.shortlink.create`: number of created short links, tagged with `isFile`
- `go.user.new`: number of new users

**Improvements**:

- Made some logger OTP messages more descriptive with user email

## Tests

- [x] Test on staging to ensure that new metrics are collected (except `go.user.new`, because I don't have any new account)
- [x] Test on staging to ensure that user details are collected on RUM

**Problem**:

Note (just FYI): we use `go.shortlink.(clicks/create)` instead of `go.shorturl.(clicks/create)` because the latter doesn't work. I suspect datadog is blocking `go.shorturl.(clicks/create)` from being used by dogstatsd, because I had previously tried [generating them from spans](https://docs.datadoghq.com/tracing/trace_pipeline/generate_metrics/), causing a naming conflict.
