### PR TITLE
chore(lambda): remove excludeDevDependencies for capture-ses-events

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,7 +41,6 @@ functions:
     memorySize: 128
     description: SNS subscriber for SES events
     package:
-      excludeDevDependencies: true
       patterns:
           - '!./**'
           - 'src/server/serverless/capture-ses-events/**'


### PR DESCRIPTION
## Problem

GitHub action for the `edge` branch is failing at the `serverless deploy` step ([example](https://github.com/opengovsg/GoGovSG/runs/8007465383?check_suite_focus=true)). 

Likely because the serverless functions were upgraded to v3 in #1900 which involved removing `excludeDevDepdencies`, but the `capture-ses-events` lambda function from #1913 still had `excludeDevDependencies` that was incompatible with v3

## Solution

Removed `excludeDevDependencies: true` from `capture-ses-events`, action now passes

## Tests

- [x] Tested on health staging that's using SES, can see the logs for sending OTPs on CloudWatch
