### PR TITLE
build: bump alpine to 3.16 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.12
+FROM node:14-alpine3.16
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=amd64 node:14-alpine3.12
+FROM --platform=amd64 node:14-alpine3.16
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 


### PR DESCRIPTION
## Problem

We have some Dockerfile vulnerabilities from using alpine 3.12 ([Zlib out-of-bounds write](https://app.snyk.io/org/gogovsg/project/a466db86-e13b-4dd1-8b90-2eae048e51da#issue-SNYK-ALPINE312-OPENSSL-2426332), [openssl infinite-loop](https://app.snyk.io/org/gogovsg/project/a466db86-e13b-4dd1-8b90-2eae048e51da#issue-SNYK-ALPINE312-OPENSSL-2426332))

## Solution

Bump alpine to v3.16, which removes the Dockerfile vulnerabilities

## Tests

- [x] Test on staging to ensure that the functionalities and main user flows are OK
- [x] Test on development
