### PR TITLE
chore: send request logs to datadog

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -70,8 +70,14 @@ morgan.token('userId', (req: express.Request) =>
 )
 
 const MORGAN_LOG_FORMAT =
-  ':client-ip - [:date[clf]] ":method :url HTTP/:http-version" :status ' +
+  ':client-ip - ":method :url HTTP/:http-version" :status ' +
   '":redirectUrl" ":userId" :res[content-length] ":referrer" ":user-agent" :response-time ms'
+
+const morganOutputStream = {
+  write: (message: string) => {
+    logger.info(message.trim())
+  },
+}
 
 const connectSrc = [
   "'self'",
@@ -178,7 +184,7 @@ initDb()
     ]
 
     // Log http requests
-    app.use(morgan(MORGAN_LOG_FORMAT))
+    app.use(morgan(MORGAN_LOG_FORMAT, { stream: morganOutputStream }))
 
     const redirectController = container.get<RedirectController>(
       DependencyIds.redirectController,


### PR DESCRIPTION
## Problem

HTTP request logs are not being forwarded to Datadog 

## Solution

Forward logs to Datadog by configuring Morgan, our middleware for logging HTTP requests, to send these logs via `logger.info` rather than the default `process.stdout` (see [Morgan documentation](https://github.com/expressjs/morgan#stream), [Stack Overflow question](https://stackoverflow.com/a/28824464)). 

`logger.info` will then output the logs to both the console and Datadog. The `message` is also trimmed to remove an additional newline inserted by morgan.

**Improvements**:
- Removed date/time from morgan log format, because `logger` already takes down the time 

## Before & After Screenshots

After (on CloudWatch):
![Screenshot 2022-08-29 at 1 36 53 PM](https://user-images.githubusercontent.com/41856541/187130290-422391c8-b61e-490d-8fcd-4604281b1590.png)

After (on Datadog):
![Screenshot 2022-08-29 at 1 37 51 PM](https://user-images.githubusercontent.com/41856541/187130296-82948e72-f2bf-41fd-a5da-7adf7e6d7ceb.png)

I blacked out my IP address

## Tests

- [x] Test on staging to ensure request logs are forwarded to Datadog
- [x] Test on staging to ensure request logs are still available on CloudWatch
