### PR TITLE
chore: refactor FileInputField component

### DIFF
--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -223,33 +223,13 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
               </div>
               <FileInputField
                 textFieldHeight={TEXT_FIELD_HEIGHT}
-                text={file ? file.name : 'No file selected'}
+                fileNameText={file ? file.name : 'No file selected'}
                 uploadFileError={uploadFileError}
-                inputId="file"
                 setFile={setFile}
                 setUploadFileError={setUploadFileError}
-                endAdornment={
-                  <div className={classes.uploadFileInputEndWrapper}>
-                    <Typography
-                      variant="body2"
-                      className={classes.fileSizeText}
-                    >
-                      {file ? formatBytes(file.size) : ''}
-                    </Typography>
-                    {/* eslint-disable-next-line */}
-                    <label htmlFor="file">
-                      <Button
-                        variant="contained"
-                        className={classes.uploadFileButton}
-                        component="span"
-                        color="primary"
-                        disabled={isUploading}
-                      >
-                        Browse
-                      </Button>
-                    </label>
-                  </div>
-                }
+                buttonText="Browse"
+                fileSizeText={file ? formatBytes(file.size) : ''}
+                isUploading={isUploading}
               />
               <CollapsibleMessage
                 visible={!!uploadFileError}
@@ -366,35 +346,21 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
               </div>
               <FileInputField
                 textFieldHeight={TEXT_FIELD_HEIGHT}
-                text={file ? file.name : 'No file selected'}
+                fileNameText={file ? file.name : 'No file selected'}
                 uploadFileError={uploadFileError}
-                inputId="file"
                 setFile={setFile}
                 setUploadFileError={setUploadFileError}
-                endAdornment={
-                  <div className={classes.uploadFileInputEndWrapper}>
-                    <Typography
-                      variant="body2"
-                      className={classes.fileSizeText}
-                    >
-                      {file ? formatBytes(file.size) : ''}
-                    </Typography>
-                    {/* eslint-disable-next-line */}
-                    <label htmlFor="file">
-                      <Button
-                        variant="contained"
-                        className={classes.uploadFileButton}
-                        component="span"
-                        color="primary"
-                        disabled={isUploading}
-                      >
-                        Browse
-                      </Button>
-                    </label>
-                  </div>
-                }
+                buttonText="Browse"
+                fileSizeText={file ? formatBytes(file.size) : ''}
+                isUploading={isUploading}
                 acceptedTypes=".csv"
               />
+              <CollapsibleMessage
+                visible={!!uploadFileError}
+                type={CollapsibleMessageType.Error}
+              >
+                {uploadFileError}
+              </CollapsibleMessage>
               <div className={classes.maxSizeTextWrapper}>
                 <Typography variant="caption" className={classes.maxSizeText}>
                   Only CSV format files are allowed. <br />
@@ -402,12 +368,6 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
                   &gt; Save As &gt; CSV (Comma delimited).
                 </Typography>
               </div>
-              <CollapsibleMessage
-                visible={!!uploadFileError}
-                type={CollapsibleMessageType.Error}
-              >
-                {uploadFileError}
-              </CollapsibleMessage>
             </>
           )}
           <Button

--- a/src/client/user/components/CreateUrlModal/styles/createLinkForm.ts
+++ b/src/client/user/components/CreateUrlModal/styles/createLinkForm.ts
@@ -157,27 +157,6 @@ const useCreateLinkFormStyles = makeStyles((theme) =>
       display: 'flex',
       alignItems: 'center',
     },
-    fileSizeText: {
-      fontWeight: 400,
-      display: 'flex',
-      alignItems: 'center',
-      paddingRight: theme.spacing(1.5),
-    },
-    uploadFileInputEndWrapper: {
-      display: 'flex',
-      alignItems: 'stretch',
-    },
-    uploadFileButton: {
-      padding: 0,
-      margin: 0,
-      width: '81px',
-      height: '100%',
-      borderRadius: 0,
-      color: theme.palette.background.default,
-      [theme.breakpoints.up('sm')]: {
-        width: '146px',
-      },
-    },
     shortLinkError: {
       color: 'black',
       textDecoration: 'none',

--- a/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
@@ -1,18 +1,11 @@
 import React, { useState } from 'react'
-import {
-  CircularProgress,
-  createStyles,
-  makeStyles,
-  useMediaQuery,
-  useTheme,
-} from '@material-ui/core'
+import { createStyles, makeStyles } from '@material-ui/core'
 import { FileInputField } from '../../../../widgets/FileInputField'
 import CollapsibleMessage from '../../../../../app/components/CollapsibleMessage'
 import {
   CollapsibleMessagePosition,
   CollapsibleMessageType,
 } from '../../../../../app/components/CollapsibleMessage/types'
-import TrailingButton from './TrailingButton'
 import ConfigOption, {
   TrailingPosition,
 } from '../../../../widgets/ConfigOption'
@@ -40,8 +33,6 @@ const useStyles = makeStyles((theme) =>
 
 export default function FileEditor() {
   const classes = useStyles()
-  const theme = useTheme()
-  const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const drawerStates = useDrawerState()
   const { shortLinkDispatch, shortLinkState, isUploading } = useShortLink(
     drawerStates.relevantShortLink!,
@@ -68,8 +59,9 @@ export default function FileEditor() {
             className={classes.fileInputField}
             uploadFileError={uploadFileError}
             textFieldHeight="44px"
-            inputId="replace-file-input"
-            text={originalLongUrl}
+            fileNameText={originalLongUrl}
+            buttonText="Replace file"
+            isUploading={isUploading}
             setFile={(newFile) => {
               shortLinkDispatch?.replaceFile(newFile, setUploadFileError)
             }}
@@ -84,25 +76,7 @@ export default function FileEditor() {
           </CollapsibleMessage>
         </>
       }
-      trailing={
-        <label htmlFor="replace-file-input">
-          <TrailingButton
-            onClick={() => {}}
-            disabled={isUploading}
-            variant={isMobileView ? 'contained' : 'outlined'}
-            fullWidth={isMobileView}
-            component="span"
-          >
-            {isUploading ? (
-              <CircularProgress color="primary" size={20} />
-            ) : (
-              'Replace file'
-            )}
-          </TrailingButton>
-        </label>
-      }
-      wrapTrailing={isMobileView}
-      trailingPosition={TrailingPosition.end}
+      trailingPosition={TrailingPosition.none}
     />
   )
 }

--- a/src/client/user/widgets/ConfigOption.tsx
+++ b/src/client/user/widgets/ConfigOption.tsx
@@ -60,7 +60,7 @@ type ConfigOptionProps = {
   mobile?: boolean
   subtitle?: string
   leading?: React.ReactNode
-  trailing: React.ReactNode
+  trailing?: React.ReactNode
   trailingPosition: TrailingPosition
   wrapTrailing?: boolean
 }

--- a/src/client/user/widgets/FileInputField.tsx
+++ b/src/client/user/widgets/FileInputField.tsx
@@ -1,5 +1,7 @@
-import React, { FunctionComponent, ReactElement } from 'react'
+import React, { FunctionComponent } from 'react'
 import {
+  Button,
+  CircularProgress,
   Hidden,
   Typography,
   createStyles,
@@ -17,11 +19,12 @@ type FileInputFieldStyleProps = {
 type FileInputFieldProps = {
   uploadFileError: string | null
   textFieldHeight: number | string
-  text: string
-  endAdornment?: ReactElement
-  inputId: string
+  fileNameText: string
+  fileSizeText?: string
+  buttonText?: string
   setFile: (file: File | null) => void
   setUploadFileError: (error: string) => void
+  isUploading: boolean
   className?: string
   acceptedTypes?: string
 }
@@ -69,17 +72,36 @@ const useStyles = makeStyles((theme) =>
         backgroundColor: '#e8e8e8',
       },
     },
+    fileSizeText: {
+      fontWeight: 400,
+      display: 'flex',
+      alignItems: 'center',
+      paddingRight: theme.spacing(1.5),
+    },
+    fileInputEndWrapper: {
+      display: 'flex',
+      alignItems: 'stretch',
+    },
+    uploadButtonText: {
+      padding: 0,
+      margin: 0,
+      width: '120px',
+      height: '100%',
+      borderRadius: 0,
+      color: theme.palette.background.default,
+    },
   }),
 )
 
 export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
   textFieldHeight,
-  text,
-  uploadFileError,
-  endAdornment,
-  inputId,
+  fileNameText = '',
+  fileSizeText = '',
+  buttonText = '',
   setFile,
+  uploadFileError,
   setUploadFileError,
+  isUploading = false,
   className,
   acceptedTypes = '',
 }: FileInputFieldProps) => {
@@ -94,11 +116,11 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
       </Hidden>
       <div className={classes.fileInput}>
         <Typography variant="body2" className={classes.fileNameText}>
-          {text}
+          {fileNameText}
         </Typography>
         <input
           type="file"
-          id={inputId}
+          id="file"
           className={classes.fileInputInvis}
           onChange={(event) => {
             if (!event.target.files) {
@@ -120,7 +142,27 @@ export const FileInputField: FunctionComponent<FileInputFieldProps> = ({
           }}
           accept={acceptedTypes}
         />
-        {endAdornment}
+        <Typography variant="body2" className={classes.fileSizeText}>
+          {fileSizeText}
+        </Typography>
+      </div>
+      <div className={classes.fileInputEndWrapper}>
+        {/* eslint-disable-next-line */}
+        <label htmlFor="file">
+          <Button
+            variant="contained"
+            className={classes.uploadButtonText}
+            component="span"
+            color="primary"
+            disabled={isUploading}
+          >
+            {isUploading ? (
+              <CircularProgress color="primary" size={20} />
+            ) : (
+              buttonText
+            )}
+          </Button>
+        </label>
       </div>
     </div>
   )


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

The `FileInputField` component does not have an inbuilt upload button, which means that every developer using the component has to add their own upload button via the `endAdornment` functionality.

This means that when the component is duplicated, the upload button also has to be duplicated, causing the code to bloat.

## Solution

Move the upload button into `FileInputField`. 

#### Note
I've reused the upload button from `CreateLinkModal`. This means that the look and feel of the button in the Drawer modal changes (see screenshots below). Have checked with Feli about this and she is ok with the current design. 

## Before & After Screenshots

**BEFORE**:
<img width="1786" alt="Screenshot 2022-09-13 at 18 21 10" src="https://user-images.githubusercontent.com/39231249/189877307-6687162c-136f-40f3-af73-e750a80440e9.png">

<img width="571" alt="Screenshot 2022-09-14 at 09 54 29" src="https://user-images.githubusercontent.com/39231249/190041036-128f9321-59c3-40bb-9877-085986681351.png">


**AFTER**:
<img width="1792" alt="Screenshot 2022-09-13 at 18 26 05" src="https://user-images.githubusercontent.com/39231249/189878255-c50dcbb7-18ce-4f17-8d55-c9fc1e2cc2a1.png">

<img width="496" alt="Screenshot 2022-09-14 at 09 54 01" src="https://user-images.githubusercontent.com/39231249/190040986-6a36ef0d-e832-4231-99b1-d950852b72b1.png">

