### PR TITLE
chore(datadog): refactor custom metric names

### DIFF
--- a/src/server/modules/auth/LoginController.ts
+++ b/src/server/modules/auth/LoginController.ts
@@ -11,7 +11,12 @@ import { AuthService } from './interfaces'
 import { InvalidOtpError, NotFoundError } from '../../util/error'
 import { EmailProperty, VerifyOtpRequest } from '.'
 import getIp from '../../util/request'
-import dogstatsd from '../../util/dogstatsd'
+import dogstatsd, {
+  OTP_GENERATE_FAILURE,
+  OTP_GENERATE_SUCCESS,
+  OTP_VERIFY_FAILURE,
+  OTP_VERIFY_SUCCESS,
+} from '../../util/dogstatsd'
 
 @injectable()
 export class LoginController {
@@ -46,12 +51,12 @@ export class LoginController {
     try {
       await this.authService.generateOtp(email, getIp(req))
     } catch (error) {
-      dogstatsd.increment('otp.generate.failure', 1, 1)
+      dogstatsd.increment(OTP_GENERATE_FAILURE, 1, 1)
       res.serverError(jsonMessage(error.message))
       return
     }
 
-    dogstatsd.increment('otp.generate.success', 1, 1)
+    dogstatsd.increment(OTP_GENERATE_SUCCESS, 1, 1)
     res.ok(jsonMessage('OTP generated and sent.'))
     return
   }
@@ -66,11 +71,11 @@ export class LoginController {
       const user = await this.authService.verifyOtp(email, otp)
       req.session!.user = user
       res.ok(jsonMessage('OTP hash verification ok.'))
-      dogstatsd.increment('otp.verify.success', 1, 1)
+      dogstatsd.increment(OTP_VERIFY_SUCCESS, 1, 1)
       logger.info(`OTP login success for user:\t${user.email}`)
       return
     } catch (error) {
-      dogstatsd.increment('otp.verify.failure', 1, 1)
+      dogstatsd.increment(OTP_VERIFY_FAILURE, 1, 1)
       if (error instanceof InvalidOtpError) {
         res.unauthorized(
           jsonMessage(

--- a/src/server/modules/redirect/RedirectController.ts
+++ b/src/server/modules/redirect/RedirectController.ts
@@ -1,7 +1,7 @@
 import Express from 'express'
 import { inject, injectable } from 'inversify'
 import { displayHostname, gaTrackingId, logger } from '../../config'
-import dogstatsd from '../../util/dogstatsd'
+import dogstatsd, { SHORTLINK_CLICKS } from '../../util/dogstatsd'
 import { NotFoundError } from '../../util/error'
 import parseDomain from '../../util/domain'
 import { DependencyIds, ERROR_404_PATH } from '../../constants'
@@ -90,7 +90,7 @@ export class RedirectController {
 
       req.session!.visits = visitedUrls
 
-      dogstatsd.increment('shortlink.clicks', 1, 1)
+      dogstatsd.increment(SHORTLINK_CLICKS, 1, 1)
       if (redirectType === RedirectType.TransitionPage) {
         // Extract root domain from long url.
         const rootDomain: string = parseDomain(longUrl)

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -6,7 +6,10 @@ import {
   UrlsPaginated,
   UserUrlsQueryConditions,
 } from '../../../repositories/types'
-import dogstatsd from '../../../util/dogstatsd'
+import dogstatsd, {
+  SHORTLINK_CREATE,
+  SHORTLINK_CREATE_TAG_IS_FILE,
+} from '../../../util/dogstatsd'
 import {
   AlreadyExistsError,
   AlreadyOwnLinkError,
@@ -60,9 +63,9 @@ export class UrlManagementService implements interfaces.UrlManagementService {
           mimetype: file.mimetype,
         }
       : undefined
+
     // Success
-    dogstatsd.increment('shortlink.create', 1, 1, [`isfile:${!!file}`])
-    return this.urlRepository.create(
+    const result = await this.urlRepository.create(
       {
         userId: user.id,
         longUrl,
@@ -71,6 +74,11 @@ export class UrlManagementService implements interfaces.UrlManagementService {
       },
       storableFile,
     )
+    dogstatsd.increment(SHORTLINK_CREATE, 1, 1, [
+      `${SHORTLINK_CREATE_TAG_IS_FILE}:${!!file}`,
+    ])
+
+    return result
   }
 
   updateUrl: (

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -1,6 +1,5 @@
 import { inject, injectable } from 'inversify'
 import { Op } from 'sequelize'
-import dogstatsd from '../util/dogstatsd'
 import {
   StorableUrl,
   StorableUser,
@@ -12,6 +11,7 @@ import { User, UserType } from '../models/user'
 import { Mapper } from '../mappers/Mapper'
 import { DependencyIds } from '../constants'
 import { Url, UrlType } from '../models/url'
+import dogstatsd, { USER_NEW } from '../util/dogstatsd'
 import { NotFoundError } from '../util/error'
 import { Tag } from '../models/tag'
 import { UrlClicks } from '../models/statistics/clicks'
@@ -55,7 +55,7 @@ export class UserRepository implements UserRepositoryInterface {
   ) => {
     return User.findOrCreate({ where: { email } }).then(([user, created]) => {
       if (created) {
-        dogstatsd.increment('user.new', 1, 1)
+        dogstatsd.increment(USER_NEW, 1, 1)
       }
       return user
     })

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -1,6 +1,15 @@
 import { StatsD } from 'hot-shots'
 import { DEV_ENV } from '../config'
 
+export const OTP_GENERATE_FAILURE = 'otp.generate.failure'
+export const OTP_GENERATE_SUCCESS = 'otp.generate.success'
+export const OTP_VERIFY_FAILURE = 'otp.verify.failure'
+export const OTP_VERIFY_SUCCESS = 'otp.verify.success'
+export const SHORTLINK_CLICKS = 'shortlink.clicks'
+export const SHORTLINK_CREATE = 'shortlink.create'
+export const SHORTLINK_CREATE_TAG_IS_FILE = 'isfile'
+export const USER_NEW = 'user.new'
+
 const dogstatsd = new StatsD({
   prefix: 'go.',
   mock: DEV_ENV,


### PR DESCRIPTION
## Problem

Follow-up from #1937: names for custom metrics should be extracted and put into a separate file

## Solution

Made a small refactoring: moved custom metric names into `dogstatsd.ts`

