### PR TITLE
feat: search for tags in lower cap

### DIFF
--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -249,7 +249,7 @@ export class UserController {
     const { userId } = req.body
     let { searchText = '' } = req.query
     const limit = 5
-    searchText = searchText.toString()
+    searchText = searchText.toString().toLowerCase()
     const queryConditions = { searchText, userId, limit }
     const validationResult = userTagsQueryConditions.validate(queryConditions)
     if (validationResult.error) {

--- a/src/server/repositories/TagRepository.ts
+++ b/src/server/repositories/TagRepository.ts
@@ -22,7 +22,7 @@ export class TagRepository implements TagRepositoryInterface {
   ) => Promise<string[]> = async (conditions) => {
     const tags = await Tag.scope(['defaultScope']).findAll({
       where: {
-        tagString: {
+        tagKey: {
           [Op.like]: `${conditions.searchText}%`,
         },
       },

--- a/test/server/repositories/TagRepository.test.ts
+++ b/test/server/repositories/TagRepository.test.ts
@@ -32,7 +32,7 @@ describe('TagRepository', () => {
     expect(scope).toHaveBeenCalledWith(['defaultScope'])
     expect(findAll).toHaveBeenCalledWith({
       where: {
-        tagString: {
+        tagKey: {
           [Op.like]: `${conditions.searchText}%`,
         },
       },


### PR DESCRIPTION
## Problem

The backend should return tag suggestions in both upper and lower cap

Closes [insert issue #]

## Solution

SQL query to perform LIKE operation on tagKey field and searchText input needs to be in lower cap.


