### PR TITLE
feat(tagging): add tags to link audit history

### DIFF
--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -22,6 +22,7 @@ export interface UrlBaseType extends IdType {
   readonly isFile: boolean
   readonly contactEmail: string | null
   readonly description: string
+  readonly tagStrings: string
 }
 
 export interface UrlType extends IdType, UrlBaseType, Sequelize.Model {
@@ -30,7 +31,6 @@ export interface UrlType extends IdType, UrlBaseType, Sequelize.Model {
   readonly createdAt: string
   readonly updatedAt: string
   readonly email: string
-  readonly tagStrings: string
 }
 
 // For sequelize define

--- a/src/server/modules/audit/interfaces/LinkAuditService.ts
+++ b/src/server/modules/audit/interfaces/LinkAuditService.ts
@@ -2,7 +2,10 @@ import { UrlHistoryRecord } from './UrlHistoryRepository'
 import { UrlBaseType } from '../../../models/url'
 
 export type LinkChangeKey =
-  | keyof Pick<UrlBaseType, 'description' | 'isFile' | 'state' | 'longUrl'>
+  | keyof Pick<
+      UrlBaseType,
+      'description' | 'isFile' | 'state' | 'longUrl' | 'tagStrings'
+    >
   | 'userEmail'
 
 export type LinkChangeType = 'create' | 'update'

--- a/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
+++ b/src/server/modules/audit/interfaces/UrlHistoryRepository.ts
@@ -7,6 +7,7 @@ export interface UrlHistoryRecord {
   description: string
   isFile: boolean
   createdAt: string
+  tagStrings: string
 }
 
 export interface UrlHistoryRepository {

--- a/src/server/modules/audit/repositories/UrlHistoryRepository.ts
+++ b/src/server/modules/audit/repositories/UrlHistoryRepository.ts
@@ -39,6 +39,7 @@ export class UrlHistoryRepository implements interfaces.UrlHistoryRepository {
         userEmail: urlHistory.user.email,
         description: urlHistory.description,
         isFile: urlHistory.isFile,
+        tagStrings: urlHistory.tagStrings,
       }
     })
   }

--- a/src/server/modules/audit/services/LinkAuditService.ts
+++ b/src/server/modules/audit/services/LinkAuditService.ts
@@ -29,7 +29,7 @@ export class LinkAuditService implements interfaces.LinkAuditService {
   ) => interfaces.LinkChangeSet[] = (
     currUrlHistory,
     prevUrlHistory,
-    keysToTrack = ['state', 'userEmail', 'longUrl'],
+    keysToTrack = ['state', 'userEmail', 'longUrl', 'tagStrings'],
   ) => {
     const changeSets: interfaces.LinkChangeSet[] = []
 


### PR DESCRIPTION
## Problem

Link audit history should return the changes to `tagStrings` as well on the backend

(Did this as a pair programming exercise with @thanhdatle)

## Solution

- Changed link audit service to consider `tagStrings` as a potentially changeable key
- Changed URL history repository to return `tagStrings` from the URL history
- Minor refactoring: extracted out some repetitive URL into a `mockUrl`

## Tests

- Changed tests for `LinkAuditService` to include URLs with tag strings