### PR TITLE
fix: return successful response when no URLs are found

### DIFF
--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -123,9 +123,6 @@ export class UserRepository implements UserRepositoryInterface {
     }
     let { rows } = urlsAndCount
     let { count } = urlsAndCount
-    if (!rows || count === 0) {
-      throw new NotFoundError(notFoundMessage)
-    }
     if (conditions.tags && conditions.tags.length > 0) {
       // Perform a second DB read to retrieve all tags
       const shortUrls = rows.map((urlType) => {

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -245,14 +245,6 @@ describe('UserRepository', () => {
       expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
-    it('throws NotFoundError on findAndCountAll without user', async () => {
-      findAndCountAll.mockResolvedValue({ rows: [], count: 0 })
-      await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
-        NotFoundError,
-      )
-      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
-    })
-
     it('returns result on user with urls', async () => {
       const rows = [url]
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
@@ -268,8 +260,11 @@ describe('UserRepository', () => {
     it('returns empty result on user no url', async () => {
       const rows: any = []
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
-      await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
-        NotFoundError,
+      await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
+        {
+          urls: [],
+          count: 0,
+        },
       )
       expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })


### PR DESCRIPTION
## Problem

Closes #1978, see problem description in issue 

## Solution

Backend returns a successful 200 response with body `{ urls: [], count: 0 }` when there's no URLs found, instead of throwing a 404 error with `Urls not found`.

**Improvements**:

- Handle errors better on the frontend, in cases where the JSON it receives from the backend cannot be parsed

## Tests

- Updated backend tests to reflect the new changes
- Removed the test case for `throws NotFoundError on findAndCountAll without user`, because it looks to be a duplicate/didn't seem to add much value
