### PR TITLE
fix: revise findUrlsForUser to return urls in correct order

### DIFF
--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -3,6 +3,7 @@ import { injectable } from 'inversify'
 import { StorableUrl } from '../repositories/types'
 import { UrlType } from '../models/url'
 import { Mapper } from './Mapper'
+import { TAG_SEPARATOR } from '../../shared/constants'
 
 @injectable()
 export class UrlMapper implements Mapper<StorableUrl, UrlType> {
@@ -14,19 +15,16 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
     const { UrlClicks: urlClicks } = urlType
     if (!urlClicks || !Number.isInteger(urlClicks.clicks))
       throw new Error('UrlClicks object not populated.')
-
-    let tagStrings: string[] = []
-    const { tags } = urlType
-    if (tags) {
-      tagStrings = tags.map((tag) => tag.tagString)
+    let tags: string[] = []
+    if (urlType.tagStrings !== '') {
+      tags = urlType.tagStrings.split(TAG_SEPARATOR)
     }
-
     return {
       shortUrl: urlType.shortUrl,
       longUrl: urlType.longUrl,
       state: urlType.state,
       clicks: urlClicks.clicks,
-      tags: tagStrings,
+      tags,
       isFile: urlType.isFile,
       createdAt: urlType.createdAt,
       updatedAt: urlType.updatedAt,

--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -16,7 +16,7 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
     if (!urlClicks || !Number.isInteger(urlClicks.clicks))
       throw new Error('UrlClicks object not populated.')
     let tags: string[] = []
-    if (urlType.tagStrings !== '') {
+    if (urlType.tagStrings !== undefined) {
       tags = urlType.tagStrings.split(TAG_SEPARATOR)
     }
     return {

--- a/src/server/models/url.ts
+++ b/src/server/models/url.ts
@@ -13,7 +13,7 @@ import { IdType } from '../../types/server/models'
 import { DEV_ENV, emailValidator, ogHostname } from '../config'
 import { StorableUrlState } from '../repositories/enums'
 import { urlSearchVector } from './search'
-import { Tag, TagType } from './tag'
+import { TagType } from './tag'
 
 export interface UrlBaseType extends IdType {
   readonly shortUrl: string
@@ -254,13 +254,6 @@ export const Url = <UrlTypeStatic>sequelize.define(
           {
             model: UrlClicks,
             as: 'UrlClicks',
-          },
-        ],
-      },
-      getTags: {
-        include: [
-          {
-            model: Tag,
           },
         ],
       },

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -95,7 +95,7 @@ export class UrlRepository implements UrlRepositoryInterface {
       }
 
       // Do a fresh read which eagerly loads the associated UrlClicks field.
-      return Url.scope(['defaultScope', 'getClicks', 'getTags']).findByPk(
+      return Url.scope(['defaultScope', 'getClicks']).findByPk(
         properties.shortUrl,
         {
           transaction: t,
@@ -114,11 +114,7 @@ export class UrlRepository implements UrlRepositoryInterface {
   ) => Promise<StorableUrl> = async (originalUrl, changes, file) => {
     const { shortUrl } = originalUrl
     let updateParams: any = { ...changes }
-    const url = await Url.scope([
-      'defaultScope',
-      'getClicks',
-      'getTags',
-    ]).findOne({
+    const url = await Url.scope(['defaultScope', 'getClicks']).findOne({
       where: { shortUrl },
     })
     if (!url) {
@@ -167,7 +163,7 @@ export class UrlRepository implements UrlRepositoryInterface {
         }
       }
       // Do a fresh read which eagerly loads the associated tags field.
-      return Url.scope(['defaultScope', 'getClicks', 'getTags']).findOne({
+      return Url.scope(['defaultScope', 'getClicks']).findOne({
         where: { shortUrl },
         transaction: t,
       })

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -140,13 +140,11 @@ export class UserRepository implements UserRepositoryInterface {
         },
       ],
     }
-    let whereConditions: any =
-      conditions.searchText.length > 0
-        ? {
-            ...searchTextCondition,
-            userId: conditions.userId,
-          }
-        : { userId: conditions.userId }
+    let whereConditions: any = { userId: conditions.userId }
+    if (conditions.searchText.length > 0) {
+      whereConditions = { ...whereConditions, ...searchTextCondition }
+    }
+
     if (conditions.tags && conditions.tags.length > 0) {
       const searchTagConditions = {
         [Op.or]: conditions.tags.map((tag) => {

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -118,9 +118,6 @@ export class UserRepository implements UserRepositoryInterface {
       throw new NotFoundError(notFoundMessage)
     }
     const { rows, count } = urlsAndCount
-    if (!rows || count === 0) {
-      throw new NotFoundError(notFoundMessage)
-    }
     const urls = rows.map((urlType) => this.urlMapper.persistenceToDto(urlType))
     return { urls, count }
   }

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -154,7 +154,7 @@ export class UserRepository implements UserRepositoryInterface {
           return { tagStrings: { [Op.substring]: `${tag}` } }
         }),
       }
-      whereConditions = { ...whereConditions, searchTagConditions }
+      whereConditions = { ...whereConditions, ...searchTagConditions }
     }
     if (conditions.state) {
       whereConditions.state = conditions.state

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -150,7 +150,7 @@ export class UserRepository implements UserRepositoryInterface {
     if (conditions.tags && conditions.tags.length > 0) {
       const searchTagConditions = {
         [Op.or]: conditions.tags.map((tag) => {
-          return { tagStrings: { [Op.substring]: `%${tag}%` } }
+          return { tagStrings: { [Op.iLike]: `%${tag}%` } }
         }),
       }
       whereConditions = { ...whereConditions, ...searchTagConditions }

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -117,8 +117,7 @@ export class UserRepository implements UserRepositoryInterface {
     if (!urlsAndCount) {
       throw new NotFoundError(notFoundMessage)
     }
-    const { rows } = urlsAndCount
-    const { count } = urlsAndCount
+    const { rows, count } = urlsAndCount
     if (!rows || count === 0) {
       throw new NotFoundError(notFoundMessage)
     }
@@ -151,7 +150,7 @@ export class UserRepository implements UserRepositoryInterface {
     if (conditions.tags && conditions.tags.length > 0) {
       const searchTagConditions = {
         [Op.or]: conditions.tags.map((tag) => {
-          return { tagStrings: { [Op.substring]: `${tag}` } }
+          return { tagStrings: { [Op.substring]: `%${tag}%` } }
         }),
       }
       whereConditions = { ...whereConditions, ...searchTagConditions }

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -165,11 +165,7 @@ describe('UrlRepository', () => {
         expect.anything(),
       )
       expect(tagFindOrCreate).toHaveBeenCalledTimes(0)
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).not.toHaveBeenCalled()
     })
 
@@ -191,11 +187,7 @@ describe('UrlRepository', () => {
         },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).not.toHaveBeenCalled()
       expect(baseUrlWithTags.addTags).toHaveBeenCalledTimes(1)
     })
@@ -232,11 +224,7 @@ describe('UrlRepository', () => {
         },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).toHaveBeenCalledWith({
         ContentType: file.mimetype,
         Bucket: s3Bucket,
@@ -284,11 +272,7 @@ describe('UrlRepository', () => {
         },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
       expect(putObject).toHaveBeenCalledWith({
         ContentType: file.mimetype,
         Bucket: s3Bucket,
@@ -335,11 +319,7 @@ describe('UrlRepository', () => {
       })
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
     it('should update non-file links', async () => {
@@ -357,11 +337,7 @@ describe('UrlRepository', () => {
       expect(putObject).not.toHaveBeenCalled()
       expect(putObjectAcl).not.toHaveBeenCalled()
       expect(update).toHaveBeenCalledWith({ description }, expect.anything())
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
     it('should update tags on non-file links', async () => {
@@ -392,11 +368,7 @@ describe('UrlRepository', () => {
         { description, tags: newTags, tagStrings: baseTagStrings },
         expect.anything(),
       )
-      expect(scope).toHaveBeenCalledWith([
-        'defaultScope',
-        'getClicks',
-        'getTags',
-      ])
+      expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })
 
     it('should update non-state changes on file links', async () => {

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -260,11 +260,8 @@ describe('UserRepository', () => {
     it('returns empty result on user no url', async () => {
       const rows: any = []
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
-      await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
-        {
-          urls: [],
-          count: 0,
-        },
+      await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
+        NotFoundError,
       )
       expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -260,8 +260,11 @@ describe('UserRepository', () => {
     it('returns empty result on user no url', async () => {
       const rows: any = []
       findAndCountAll.mockResolvedValue({ rows, count: rows.length })
-      await expect(userRepo.findUrlsForUser(conditions)).rejects.toBeInstanceOf(
-        NotFoundError,
+      await expect(userRepo.findUrlsForUser(conditions)).resolves.toStrictEqual(
+        {
+          urls: [],
+          count: 0,
+        },
       )
       expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
     })


### PR DESCRIPTION
## Problem

findUrlsForUser function doesn't return urls according to `ORDER BY` correctly
This is due to a common problem found in Sequelize while querying many-to-many rel, this is stil unresolved by now. 
[sequelize-issue](https://github.com/sequelize/sequelize/issues/7344)
The common practice is to write raw query when encountering this bug.
I am keeping the `url_tag` table, in case we need to re-write the query with raw query.

## Solution

Revised the findUrlsForUser to search for tag by looking for subString in tagStrings column.


