### PR TITLE
fix(tagging): reset tags state after link creation

### DIFF
--- a/src/client/user/reducers/index.ts
+++ b/src/client/user/reducers/index.ts
@@ -143,6 +143,7 @@ const user: (state: UserState, action: UserActionType) => UserState = (
       nextState = {
         shortUrl: '',
         longUrl: '',
+        tags: [],
       }
       break
     case UserAction.WIPE_USER_STATE:


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

After a user successfully creates a link with some tags, those same tags will show up again when the user tries to create another new link. This is probably not the behaviour that we want

## Solution

_How did you solve the problem?_

Set `tags: []` when the user state is reset. Its action is dispatched after a link creation is successful 
