### PR TITLE
fix(tagging): remove empty tag when tagStrings is empty

### DIFF
--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -16,7 +16,7 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
     if (!urlClicks || !Number.isInteger(urlClicks.clicks))
       throw new Error('UrlClicks object not populated.')
     let tags: string[] = []
-    if (urlType.tagStrings !== undefined) {
+    if (urlType.tagStrings !== undefined && urlType.tagStrings !== '') {
       tags = urlType.tagStrings.split(TAG_SEPARATOR)
     }
     return {


### PR DESCRIPTION
## Problem

Empty tag shows up when `tagStrings` is empty.

## Solution

Ensure that there are no tags when `tagStrings` is empty.

TODO: write tests to ensure that empty `tagStrings` doesn't result in an empty tag.