### PR TITLE
fix: fix urlMapper to correctly check for empty tagStrings before par…

### DIFF
--- a/src/server/mappers/UrlMapper.ts
+++ b/src/server/mappers/UrlMapper.ts
@@ -16,7 +16,7 @@ export class UrlMapper implements Mapper<StorableUrl, UrlType> {
     if (!urlClicks || !Number.isInteger(urlClicks.clicks))
       throw new Error('UrlClicks object not populated.')
     let tags: string[] = []
-    if (urlType.tagStrings !== undefined) {
+    if (urlType.tagStrings) {
       tags = urlType.tagStrings.split(TAG_SEPARATOR)
     }
     return {

--- a/test/server/mappers/UrlMapper.test.ts
+++ b/test/server/mappers/UrlMapper.test.ts
@@ -1,0 +1,21 @@
+import { UrlMapper } from '../../../src/server/mappers/UrlMapper'
+import { UrlType } from '../../../src/server/models/url'
+
+describe('url mapper', () => {
+  it('url contains empty tags', () => {
+    const urlMapper = new UrlMapper()
+    const storableUrl = urlMapper.persistenceToDto({
+      UrlClicks: { clicks: 0 },
+      tagStrings: '',
+    } as UrlType)
+    expect(storableUrl.tags).toHaveLength(0)
+  })
+  it('url contains 2 tags', () => {
+    const urlMapper = new UrlMapper()
+    const storableUrl = urlMapper.persistenceToDto({
+      UrlClicks: { clicks: 0 },
+      tagStrings: 'tag1;tag2',
+    } as UrlType)
+    expect(storableUrl.tags).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
…sing

## Problem

urlMapper didn't check for empty tagStrings properly

Closes [insert issue #]

## Solution

fix urlMapper to correctly check for empty tagStrings before parsing