### PR TITLE
fix(tagging): serialize single tags for file uploads

### DIFF
--- a/src/client/user/actions/index.ts
+++ b/src/client/user/actions/index.ts
@@ -818,7 +818,10 @@ const uploadFile =
     const data = new FormData()
     data.append('file', file, file.name)
     data.append('shortUrl', shortUrl)
-    tags.forEach((tag) => data.append('tags', tag))
+    if (tags) {
+      // Serialize the tags in JSON format as a string
+      data.append('tags', JSON.stringify(tags))
+    }
 
     const response = await postFormData('/api/user/url', data)
     dispatch<SetIsUploadingAction>(setIsUploading(false))

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -50,6 +50,7 @@ function preprocessPotentialIncomingFile(
   if (req.files) {
     req.body.files = req.files
     if (req.body.tags) {
+      // Tags for files sent as FormData should be deserialised from JSON format
       try {
         req.body.tags = JSON.parse(req.body.tags)
       } catch (e) {

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -3,6 +3,7 @@ import fileUpload from 'express-fileupload'
 import { createValidator } from 'express-joi-validation'
 import { DependencyIds } from '../../constants'
 import { container } from '../../util/inversify'
+import jsonMessage from '../../util/json'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../shared/constants'
 import {
   ownershipTransferSchema,
@@ -43,11 +44,19 @@ const validator = createValidator({ passError: true })
  */
 function preprocessPotentialIncomingFile(
   req: Express.Request,
-  _: Express.Response,
+  res: Express.Response,
   next: Express.NextFunction,
 ) {
   if (req.files) {
     req.body.files = req.files
+    if (req.body.tags) {
+      try {
+        req.body.tags = JSON.parse(req.body.tags)
+      } catch (e) {
+        res.badRequest(jsonMessage('Tags are invalid.'))
+        return
+      }
+    }
   }
   next()
 }


### PR DESCRIPTION
## Problem

Currently, creating files fails when creating single tags (as opposed to 0 or many). This is due to the behaviour of formdata uploads, which does not interpret a single key-value pair as an array.

## Solution

- Serialize as JSON in the frontend, and deserialize JSON in the backend.
- Return a bad request if the JSON cannot be parsed in the backend.

(Done w pair programming with @thanhdatle)