### PR TITLE
fix(tagging): escape searching by tags with underscores

### DIFF
--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -10,10 +10,11 @@ import { UserRepositoryInterface } from './interfaces/UserRepositoryInterface'
 import { User, UserType } from '../models/user'
 import { Mapper } from '../mappers/Mapper'
 import { DependencyIds } from '../constants'
+import { UrlClicks } from '../models/statistics/clicks'
 import { Url, UrlType } from '../models/url'
 import dogstatsd, { USER_NEW } from '../util/dogstatsd'
 import { NotFoundError } from '../util/error'
-import { UrlClicks } from '../models/statistics/clicks'
+import { escapeWildcard } from '../util/sequelize'
 
 /**
  * A user repository that handles access to the data store of Users.
@@ -145,7 +146,7 @@ export class UserRepository implements UserRepositoryInterface {
     if (conditions.tags && conditions.tags.length > 0) {
       const searchTagConditions = {
         [Op.or]: conditions.tags.map((tag) => {
-          return { tagStrings: { [Op.iLike]: `%${tag}%` } }
+          return { tagStrings: { [Op.iLike]: `%${escapeWildcard(tag)}%` } }
         }),
       }
       whereConditions = { ...whereConditions, ...searchTagConditions }

--- a/src/server/util/sequelize.ts
+++ b/src/server/util/sequelize.ts
@@ -24,3 +24,7 @@ export function transaction<T>(
 ): Promise<T> {
   return sequelize.transaction(autoCallback)
 }
+
+export function escapeWildcard(str: string) {
+  return str.replace(/(_|%|\\)/g, '\\$1')
+}

--- a/test/server/repositories/UserRepository.test.ts
+++ b/test/server/repositories/UserRepository.test.ts
@@ -232,6 +232,18 @@ describe('UserRepository', () => {
       tags: [],
     }
 
+    const conditionsWithTags = {
+      limit: 2,
+      offset: 0,
+      orderBy: 'date',
+      sortDirection: 'asc',
+      searchText: '',
+      userId: 2,
+      state: undefined,
+      isFile: undefined,
+      tags: ['tag', 'tag_foo_bar'],
+    }
+
     beforeEach(() => {
       scope.mockReset()
       findAndCountAll.mockReset()
@@ -268,6 +280,20 @@ describe('UserRepository', () => {
         },
       )
       expect(scope).toHaveBeenCalledWith(['defaultScope', 'getClicks'])
+    })
+
+    it('escapes underscores in tags', async () => {
+      const rows: any = []
+      findAndCountAll.mockResolvedValue({ rows, count: rows.length })
+      await userRepo.findUrlsForUser(conditionsWithTags)
+      expect(findAndCountAll).toHaveBeenCalled()
+      expect(findAndCountAll.mock.calls[0][0].where).toMatchObject({
+        userId: 2,
+        [Symbol('or')]: [
+          { tagStrings: { [Symbol('iLike')]: '%tag%' } },
+          { tagStrings: { [Symbol('iLike')]: '%tag\\_foo\\_bar%' } },
+        ],
+      })
     })
   })
 })


### PR DESCRIPTION
## Problem

Closes #1994, see problem description in issue

## Solution

Created function to escape wildcard characters like `_`, `%`, `\`, and used it to escape underscores in tags at the repo layer before searching. Credits to [this StackOverflow Q&A](https://stackoverflow.com/questions/42519805/how-to-escape-like-wildcard-characters-and-in-sequelize)

## Tests

Added a test to ensure that underscores are escaped correctly in the where conditions passed to Sequelize
