### PR TITLE
fix(tagging): include underscores in error message for invalid tags

### DIFF
--- a/src/client/user/widgets/TagsAutocomplete.tsx
+++ b/src/client/user/widgets/TagsAutocomplete.tsx
@@ -149,7 +149,7 @@ export default function TagsAutocomplete({
               value={tagInput}
               helperText={(() => {
                 if (!isValidTag(tagInput, true)) {
-                  return `Tags should only consist of letters, numbers and hyphens and be no more than ${MAX_TAG_LENGTH} characters long.`
+                  return `Tags should only consist of letters, numbers, hyphens and underscores and be no more than ${MAX_TAG_LENGTH} characters long.`
                 }
                 if (tags.includes(tagInput)) {
                   return 'This tag already exists.'


### PR DESCRIPTION
## Problem

The error message for invalid tags on the create new link modal currently does not include underscores in its description.

## Solution

Add underscores to the error message for invalid tags.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2022-10-06 at 7 32 45 PM](https://user-images.githubusercontent.com/41856541/194302148-f3615368-d225-4211-a984-2669294184b7.png)

**AFTER**:
![Screenshot 2022-10-06 at 7 29 57 PM](https://user-images.githubusercontent.com/41856541/194301689-4000b78a-c711-41ff-96af-ae1fbd36c452.png)

