### PR TITLE
chore(lambda): update sql scripts for transferring links with `tagStrings`

### DIFF
--- a/src/server/serverless/lambda-migrate-url-to-user/migrate_url_to_user.sql
+++ b/src/server/serverless/lambda-migrate-url-to-user/migrate_url_to_user.sql
@@ -20,6 +20,8 @@
 --                                      description column
 --   03 Oct  2022 Alexis Goh:           Update function's url_history insertion step to include
 --                                      source column
+--   07 Oct  2022 Lim Zi Wei:           Update function's url_history insertion step to include
+--                                      tagStrings column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_url_to_user(short_url_value text, to_user_email text) RETURNS void AS
 $BODY$
@@ -51,8 +53,8 @@ BEGIN
         RAISE EXCEPTION 'No transferring of links to the same user';
     END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","source","description","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "source", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","source","tagStrings","description","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "source", "tagStrings", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "shortUrl" = short_url LIMIT 1;
 -- Update the link in the URL table

--- a/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
+++ b/src/server/serverless/lambda-migrate-user-links/migrate_user_links.sql
@@ -23,6 +23,8 @@
 --   12 July 2022 Lim Zi Wei: Update function to return the number of migrated links
 --   03 Oct  2022 Alexis Goh: Update function's url_history insertion step to include
 --                            source column
+--   07 Oct  2022 Lim Zi Wei: Update function's url_history insertion step to include
+--                            tagStrings column
 -- =============================================
 CREATE OR REPLACE FUNCTION migrate_user_links(from_user_email text, to_user_email text) RETURNS integer AS
 $BODY$
@@ -49,8 +51,8 @@ BEGIN
 		RAISE EXCEPTION 'No transferring of links to the same user';
 	END IF;
 -- Insert the intended changes into URL history table
-    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","source","description","createdAt","updatedAt")
-        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "source", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    INSERT INTO url_histories ("urlShortUrl","longUrl","state","userId","isFile","source","tagStrings","description","createdAt","updatedAt")
+        SELECT "shortUrl", "longUrl", "state", "to_user_id", "isFile", "source", "tagStrings", "description", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         FROM urls
         WHERE "userId" = from_user_id;
 -- Update the links in the URL table


### PR DESCRIPTION
## Problem

When using lambda functions to transfer links, the url history records created should contain the `tagStrings` as well

## Solution

Add `tagStrings` as a column to be inserted into `url_histories` in the SQL scripts

## Tests

- [x] Test both lambda functions for transferring links on staging

## Deploy Notes

- Post deploy: the SQL functions need to be updated
