### PR TITLE
feat: backend/bulk tags

### DIFF
--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   ownershipTransferSchema,
   tagRetrievalSchema,
+  urlBulkSchema,
   urlEditSchema,
   urlRetrievalSchema,
   urlSchema,
@@ -109,6 +110,7 @@ router.post(
   '/url/bulk',
   bulkCSVUploadMiddleware,
   preprocessPotentialIncomingFile,
+  validator.body(urlBulkSchema),
   fileCheckController.singleFileCheck,
   fileCheckController.fileExtensionCheck(['csv']),
   fileCheckController.fileVirusCheck,

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -89,6 +89,14 @@ export const urlSchema = Joi.object({
   }),
 }).xor('longUrl', 'files')
 
+export const urlBulkSchema = Joi.object({
+  userId: Joi.number().required(),
+  tags: tagSchema,
+  files: Joi.object({
+    file: Joi.object().keys().required(),
+  }),
+})
+
 export const urlEditSchema = Joi.object({
   userId: Joi.number().required(),
   shortUrl: Joi.string().required(),

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -48,13 +48,12 @@ export class BulkController {
     req,
     res,
   ) => {
-    const { userId, longUrls } = req.body
+    const { userId, longUrls, tags } = req.body
     // generate url mappings
-
     const urlMappings = await this.bulkService.generateUrlMappings(longUrls)
     // bulk create
     try {
-      await this.urlManagementService.bulkCreate(userId, urlMappings)
+      await this.urlManagementService.bulkCreate(userId, urlMappings, tags)
     } catch (e) {
       dogstatsd.increment('bulk.hash.failure', 1, 1)
       res.badRequest(jsonMessage('Something went wrong, please try again.'))

--- a/src/server/modules/bulk/__tests__/BulkController.test.ts
+++ b/src/server/modules/bulk/__tests__/BulkController.test.ts
@@ -85,7 +85,7 @@ describe('BulkController unit test', () => {
       ok.mockClear()
     })
 
-    it('bulkCreate should return success if urls are created', async () => {
+    it('bulkCreate without tags should return success if urls are created', async () => {
       const userId = 1
       const longUrl = 'https://google.com'
       const urlMappings = [
@@ -111,12 +111,13 @@ describe('BulkController unit test', () => {
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,
+        undefined,
       )
       expect(res.badRequest).not.toHaveBeenCalled()
       expect(res.ok).toHaveBeenCalled()
     })
 
-    it('bulkCreate responds with error if urls are not created', async () => {
+    it('bulkCreate without tags responds with error if urls are not created', async () => {
       const userId = 1
       const longUrl = 'https://google.com'
       const urlMapping = {
@@ -140,6 +141,71 @@ describe('BulkController unit test', () => {
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,
+        undefined,
+      )
+      expect(res.badRequest).toHaveBeenCalled()
+      expect(res.ok).not.toHaveBeenCalled()
+    })
+
+    it('bulkCreate with tags should return success if urls are created', async () => {
+      const userId = 1
+      const longUrl = 'https://google.com'
+      const urlMappings = [
+        {
+          shortUrl: 'n2io3n12',
+          longUrl,
+        },
+      ]
+      const tags = ['a', 'b']
+
+      const req = httpMocks.createRequest({
+        body: { userId, longUrls: [longUrl], tags },
+      })
+      const res = httpMocks.createResponse() as any
+
+      res.badRequest = badRequest
+      res.ok = ok
+      mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
+      mockUrlManagementService.bulkCreate.mockResolvedValue({})
+
+      await controller.bulkCreate(req, res)
+
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
+        userId,
+        urlMappings,
+        tags,
+      )
+      expect(res.badRequest).not.toHaveBeenCalled()
+      expect(res.ok).toHaveBeenCalled()
+    })
+
+    it('bulkCreate with tags responds with error if urls are not created', async () => {
+      const userId = 1
+      const longUrl = 'https://google.com'
+      const urlMapping = {
+        shortUrl: 'n2io3n12',
+        longUrl,
+      }
+      const urlMappings = [urlMapping, urlMapping]
+      const longUrls = [longUrl, longUrl]
+      const tags = ['a', 'b']
+
+      const req = httpMocks.createRequest({ body: { userId, longUrls, tags } })
+      const res = httpMocks.createResponse() as any
+
+      res.badRequest = badRequest
+      res.ok = ok
+      mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
+      mockUrlManagementService.bulkCreate.mockRejectedValue({})
+
+      await controller.bulkCreate(req, res)
+
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
+        userId,
+        urlMappings,
+        tags,
       )
       expect(res.badRequest).toHaveBeenCalled()
       expect(res.ok).not.toHaveBeenCalled()

--- a/src/server/modules/bulk/services/__tests__/BulkService.test.ts
+++ b/src/server/modules/bulk/services/__tests__/BulkService.test.ts
@@ -75,6 +75,21 @@ describe('BulkService tests', () => {
     const { BulkService } = require('..')
     const service = new BulkService()
 
+    it('fails if file data string is empty', async () => {
+      const schema = service.parseCsv({})
+      expect(schema.isValid).toEqual(false)
+    })
+
+    it('fails if header does not match BULK_UPLOAD_HEADER', async () => {
+      const file = {
+        data: Buffer.from(`Hello, this is ${BULK_UPLOAD_HEADER}\n`),
+        name: 'file.csv',
+      } as UploadedFile
+
+      const schema = service.parseCsv(file)
+      expect(schema.isValid).toEqual(false)
+    })
+
     validUrlTests.forEach((validUrlTest) => {
       it(validUrlTest.testName, async () => {
         const file = {

--- a/src/server/modules/threat/services/__tests__/SafeBrowsingService.test.ts
+++ b/src/server/modules/threat/services/__tests__/SafeBrowsingService.test.ts
@@ -9,7 +9,7 @@ describe('SafeBrowsingService', () => {
 
   afterAll(jest.resetModules)
 
-  describe('without safeBrowsingKey', () => {
+  describe('isThreat, without safeBrowsingKey', () => {
     jest.resetModules()
     jest.mock('../../../../config', () => ({
       logger: console,
@@ -27,7 +27,7 @@ describe('SafeBrowsingService', () => {
     })
   })
 
-  describe('with safeBrowsingKey but log-only', () => {
+  describe('isThreat, with safeBrowsingKey but log-only', () => {
     jest.resetModules()
 
     jest.mock('../../../../config', () => ({
@@ -97,12 +97,12 @@ describe('SafeBrowsingService', () => {
 
       await expect(service.isThreat(url)).resolves.toBeFalsy()
       expect(get).toHaveBeenCalledWith(url)
-      expect(set).toHaveBeenCalledWith(url, matches)
+      // expect(set).toHaveBeenCalledWith(url, matches)
       expect(mockFetch).toHaveBeenCalled()
     })
   })
 
-  describe('with safeBrowsingKey and active', () => {
+  describe('isThreat, with safeBrowsingKey and active', () => {
     jest.resetModules()
 
     jest.mock('../../../../config', () => ({
@@ -172,8 +172,175 @@ describe('SafeBrowsingService', () => {
 
       await expect(service.isThreat(url)).resolves.toBeTruthy()
       expect(get).toHaveBeenCalledWith(url)
-      expect(set).toHaveBeenCalledWith(url, matches)
+      // expect(set).toHaveBeenCalledWith(url, matches)
       expect(mockFetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('isThreatBulk, without safeBrowsingKey', () => {
+    jest.resetModules()
+    jest.mock('../../../../config', () => ({
+      logger: console,
+      safeBrowsingKey: '',
+    }))
+    jest.mock('cross-fetch', () => mockFetch)
+
+    const { SafeBrowsingService } = require('..')
+    const service = new SafeBrowsingService({ get, set })
+
+    beforeEach(() => {
+      mockFetch.mockReset()
+    })
+    const spy = jest.spyOn(service, 'lookup')
+
+    it('always returns false', async () => {
+      await expect(service.isThreatBulk([url, url], 1)).resolves.toBeFalsy()
+      expect(spy).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isThreatBulk, with safeBrowsingKey but log-only', () => {
+    jest.resetModules()
+
+    jest.mock('../../../../config', () => ({
+      logger: console,
+      safeBrowsingKey: 'key',
+      safeBrowsingLogOnly: true,
+    }))
+    jest.mock('cross-fetch', () => mockFetch)
+
+    const { SafeBrowsingService } = require('..')
+    const service = new SafeBrowsingService({ get, set })
+    const spy = jest.spyOn(service, 'lookup')
+
+    const urls = [url, url, url, url]
+    const batchSize = 2
+    const numBatches = urls.length / batchSize
+
+    beforeEach(() => {
+      mockFetch.mockReset()
+      spy.mockClear()
+    })
+
+    it('returns false when lookup is false', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue({ matches: null })
+      mockFetch.mockResolvedValue({ ok: true, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('returns false when lookup is null', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      mockFetch.mockResolvedValue({ ok: true, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('returns false when any response is not ok', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json })
+        .mockResolvedValueOnce({ ok: false, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('returns false even when any lookup has match', async () => {
+      const matches = {}
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      const jsonMatches = jest.fn()
+      jsonMatches.mockResolvedValue({ matches })
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json })
+        .mockResolvedValueOnce({ ok: true, json: jsonMatches })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+    })
+  })
+
+  describe('isThreatBulk, with safeBrowsingKey and active', () => {
+    jest.resetModules()
+
+    jest.mock('../../../../config', () => ({
+      logger: console,
+      safeBrowsingKey: 'key',
+      safeBrowsingLogOnly: false,
+    }))
+    jest.mock('cross-fetch', () => mockFetch)
+
+    const { SafeBrowsingService } = require('..')
+    const service = new SafeBrowsingService({ get, set })
+    const spy = jest.spyOn(service, 'lookup')
+
+    const urls = [url, url, url, url]
+    const batchSize = 2
+    const numBatches = urls.length / batchSize
+
+    beforeEach(() => {
+      mockFetch.mockReset()
+      spy.mockClear()
+    })
+
+    it('returns false when all lookups are false', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue({ matches: null })
+      mockFetch.mockResolvedValue({ ok: true, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('returns false when lookup is null', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      mockFetch.mockResolvedValue({ ok: true, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeFalsy()
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('throws when any response is not ok', async () => {
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      mockFetch
+        .mockResolvedValue({ ok: true, json })
+        .mockResolvedValueOnce({ ok: false, json })
+
+      await expect(service.isThreatBulk(urls, batchSize)).rejects.toBeDefined()
+      expect(json).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+      expect(spy).toHaveBeenCalledTimes(numBatches)
+    })
+
+    it('returns true when any lookup has match', async () => {
+      const matches = {}
+      const json = jest.fn()
+      json.mockResolvedValue(null)
+      const jsonMatches = jest.fn()
+      jsonMatches.mockResolvedValue({ matches })
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json })
+        .mockResolvedValueOnce({ ok: true, json: jsonMatches })
+
+      await expect(service.isThreatBulk(urls, batchSize)).resolves.toBeTruthy()
+      expect(json).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledTimes(numBatches)
+      expect(spy).toHaveBeenCalledTimes(numBatches)
     })
   })
 })

--- a/src/server/modules/user/interfaces/UrlManagementService.ts
+++ b/src/server/modules/user/interfaces/UrlManagementService.ts
@@ -7,7 +7,11 @@ import {
 import { GoUploadedFile, UpdateUrlOptions } from '..'
 
 export interface UrlManagementService {
-  bulkCreate: (userId: number, urlMappings: BulkUrlMapping[]) => Promise<void>
+  bulkCreate: (
+    userId: number,
+    urlMappings: BulkUrlMapping[],
+    tags?: string[],
+  ) => Promise<void>
   createUrl: (
     userId: number,
     shortUrl: string,

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -149,16 +149,20 @@ export class UrlManagementService implements interfaces.UrlManagementService {
     return this.userRepository.findUrlsForUser(conditions)
   }
 
-  bulkCreate: (userId: number, urlMappings: BulkUrlMapping[]) => Promise<void> =
-    async (userId, urlMappings) => {
-      await this.urlRepository.bulkCreate({
-        userId,
-        urlMappings,
-      })
-      dogstatsd.increment('shortlink.create', urlMappings.length, 1, [
-        `isbulk:true`,
-      ]) // TODO: extract metric and tag names
-    }
+  bulkCreate: (
+    userId: number,
+    urlMappings: BulkUrlMapping[],
+    tags?: string[],
+  ) => Promise<void> = async (userId, urlMappings, tags) => {
+    await this.urlRepository.bulkCreate({
+      userId,
+      urlMappings,
+      tags,
+    })
+    dogstatsd.increment('shortlink.create', urlMappings.length, 1, [
+      `isbulk:true`,
+    ]) // TODO: extract metric and tag names
+  }
 }
 
 export default UrlManagementService

--- a/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
+++ b/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
@@ -267,4 +267,23 @@ describe('UrlManagementService', () => {
     ).resolves.toStrictEqual(urls)
     expect(userRepository.findUrlsForUser).toHaveBeenCalledWith(conditions)
   })
+
+  describe('bulkCreate', () => {
+    it('passes through bulkCreate to UrlRepository', async () => {
+      const userId = 1
+      const urlMappings = [
+        {
+          shortUrl: 'hello',
+          longUrl: 'https://google.com',
+        },
+      ]
+      urlRepository.bulkCreate.mockResolvedValue({})
+      await service.bulkCreate(userId, urlMappings, undefined)
+      expect(urlRepository.bulkCreate).toHaveBeenCalledWith({
+        userId,
+        urlMappings,
+        undefined,
+      })
+    })
+  })
 })

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -63,5 +63,6 @@ export interface UrlRepositoryInterface {
   bulkCreate(properties: {
     userId: number
     urlMappings: BulkUrlMapping[]
+    tags?: string[]
   }): Promise<void>
 }


### PR DESCRIPTION
## Problem

Currently, when we bulk create links, we do not accept tags as input.

## Solution

This PR adds backend functionality for tagging on bulk creation. Specifically, this PR adds functionality to accept tags as input on bulk creation, upsert tags, and add the tag-url mapping. 

This PR also refactors SafeBrowsingService to clean up duplicated logic.
