### PR TITLE
fix(tagging): allow tags to be added on space, comma, clickaway

### DIFF
--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -19,6 +19,7 @@ import {
   isValidLongUrl,
   isValidShortUrl,
   isValidTag,
+  isValidTags,
 } from '../../../../shared/util/validation'
 import { MAX_NUM_TAGS_PER_LINK } from '../../../../shared/constants'
 import ModalMargins from './ModalMargins'
@@ -91,7 +92,7 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
     (isFile && !!uploadFileError) ||
     isUploading ||
     !!createShortLinkError ||
-    tags.some((tag) => !isValidTag(tag)) ||
+    !isValidTags(tags) ||
     !isValidTag(tagInput, true) ||
     tags.includes(tagInput)
 

--- a/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
@@ -68,10 +68,11 @@ export default function TagsEditor() {
         <TrailingButton
           disabled={
             !isValidTags(tags) ||
-            _.isEqual([...tags].sort(), [...initialTags].sort())
+            _.isEqual([...tags].sort(), [...initialTags].sort()) ||
+            !isValidTag(tagInput, true)
           }
           onClick={() => {
-            // Ensure that tags are updated with any remaining tag input before saving -- might be hacky though
+            // Ensure tags are updated with any remaining tag input before saving
             const tagsForSaving =
               tagInput && isValidTag(tagInput) && !tags.includes(tagInput)
                 ? [...tags, tagInput]

--- a/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
@@ -16,7 +16,10 @@ import TagsAutocomplete from '../../../../widgets/TagsAutocomplete'
 import Tooltip from '../../../../widgets/Tooltip'
 import { MAX_NUM_TAGS_PER_LINK } from '../../../../../../shared/constants'
 import TrailingButton from './TrailingButton'
-import { isValidTags } from '../../../../../../shared/util/validation'
+import {
+  isValidTag,
+  isValidTags,
+} from '../../../../../../shared/util/validation'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -67,7 +70,14 @@ export default function TagsEditor() {
             !isValidTags(tags) ||
             _.isEqual([...tags].sort(), [...initialTags].sort())
           }
-          onClick={() => shortLinkDispatch?.applyEditTags(tags)}
+          onClick={() => {
+            // Ensure that tags are updated with any remaining tag input before saving -- might be hacky though
+            const tagsForSaving =
+              tagInput && isValidTag(tagInput) && !tags.includes(tagInput)
+                ? [...tags, tagInput]
+                : tags
+            shortLinkDispatch?.applyEditTags(tagsForSaving)
+          }}
           fullWidth={isMobileView}
           variant={isMobileView ? 'contained' : 'outlined'}
         >

--- a/src/client/user/widgets/TagsAutocomplete.tsx
+++ b/src/client/user/widgets/TagsAutocomplete.tsx
@@ -78,6 +78,18 @@ export default function TagsAutocomplete({
     setTagSuggestions([])
   }
 
+  function addTagInputToTags() {
+    if (isValidTag(tagInput) && !tags.includes(tagInput)) {
+      setTagInput('')
+      setTags([...tags, tagInput])
+    }
+  }
+
+  function onClickAway() {
+    resetTagSuggestions()
+    addTagInputToTags()
+  }
+
   useEffect(() => {
     async function getTagSuggestions() {
       const res = await get(`/api/user/tag?searchText=${tagInput}`)
@@ -101,7 +113,7 @@ export default function TagsAutocomplete({
   }, [tagInput])
 
   return (
-    <ClickAwayListener onClickAway={resetTagSuggestions}>
+    <ClickAwayListener onClickAway={onClickAway}>
       <div>
         <Autocomplete
           multiple
@@ -124,13 +136,11 @@ export default function TagsAutocomplete({
               error={!isValidTag(tagInput, true) || tags.includes(tagInput)}
               className={classes.tagsText}
               onKeyDown={(event) => {
-                if (event.key !== 'Enter') return
-                event.preventDefault() // prevent form from submitting
+                // Use enter, comma, or space to create a new tag
+                if (!['Enter', ',', ' '].includes(event.key)) return
+                event.preventDefault() // prevent form from submitting when enter key is pressed
                 event.stopPropagation() // prevent freeSolo from clearing text input
-                if (isValidTag(tagInput) && !tags.includes(tagInput)) {
-                  setTagInput('')
-                  setTags([...tags, tagInput])
-                }
+                addTagInputToTags()
               }}
               inputProps={params.inputProps}
               InputProps={{


### PR DESCRIPTION
## Problem

Currently, adding tags requires the user to press enter, which can be non-obvious and unintuitive. 

## Solution

Allow tags to be added when the user presses enter, space, comma, or clicks away from the tags input.

~But a slight ordering problem happens when the user clicks away from the tags input to the "create link" or "save" button at one go:~
~- When the user clicks "create link" on the create link form, first the tag input is added, then the link is created;~
~- When the user clicks "save" on the edit link form, first the link is saved, then the tag input is added.~

edit: above problem is fixed, always adds tags before saving. but the solution might be a little unclean though

Some extra fixes: slight amendments to logic for disabling save/create link buttons
