### PR TITLE
fix(tagging): clear tag input when tag is removed

### DIFF
--- a/src/client/user/widgets/TagsAutocomplete.tsx
+++ b/src/client/user/widgets/TagsAutocomplete.tsx
@@ -114,7 +114,11 @@ export default function TagsAutocomplete({
               <FormTag
                 key={tag}
                 tag={tag}
-                onClose={() => setTags(tags.filter((t) => t !== tag))}
+                onClose={() => {
+                  setTags(tags.filter((t) => t !== tag))
+                  setTagInput('')
+                  resetTagSuggestions()
+                }}
               />
             ))
           }


### PR DESCRIPTION
## Problem

The decision is to just stick with clearing the tag input when a tag is removed. However, the underlying React state for the tag input is not cleared even when the input looks to be cleared, so we need to clear the state as well.

Closes #2027

## Solution

Clear tag input state (and tag suggestions) when the user removes a tag.
