### PR TITLE
fix(tagging): align error text with save button on edit link drawer

### DIFF
--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -328,6 +328,7 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
               tagInput={tagInput}
               setTagInput={setTagInput}
               disabled={isUploading || tags.length >= MAX_NUM_TAGS_PER_LINK}
+              fixHelperTextPosition={false}
             />
           </div>
           <Button

--- a/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/TagsEditor.tsx
@@ -58,6 +58,7 @@ export default function TagsEditor() {
             tagInput={tagInput}
             setTagInput={setTagInput}
             disabled={tags.length >= MAX_NUM_TAGS_PER_LINK}
+            fixHelperTextPosition
           />
         </div>
       }

--- a/src/client/user/widgets/TagsAutocomplete.tsx
+++ b/src/client/user/widgets/TagsAutocomplete.tsx
@@ -20,6 +20,12 @@ import FormTag from './FormTag'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
+    fixedHelperText: {
+      position: 'absolute',
+      top: '100%',
+      left: 0,
+      width: 'auto',
+    },
     menuPopper: {
       zIndex: 1301, // To place popper above create link modal with default z-index of 1300
     },
@@ -60,6 +66,7 @@ type TagsAutocompleteProps = {
   tagInput: string
   setTagInput: (tagInput: string) => void
   disabled: boolean
+  fixHelperTextPosition: boolean
 }
 
 export default function TagsAutocomplete({
@@ -68,6 +75,7 @@ export default function TagsAutocomplete({
   tagInput,
   setTagInput,
   disabled,
+  fixHelperTextPosition,
 }: TagsAutocompleteProps) {
   const classes = useStyles()
   const [tagSuggestions, setTagSuggestions] = useState<string[]>([])
@@ -156,6 +164,11 @@ export default function TagsAutocomplete({
                 }
                 return ''
               })()}
+              FormHelperTextProps={
+                fixHelperTextPosition
+                  ? { className: classes.fixedHelperText }
+                  : {}
+              }
             />
           )}
         />


### PR DESCRIPTION
## Problem

See issue description in #2026

Closes #2026 

## Solution

On the edit link form, ensure that the tags field is aligned with the save button, by fixing the helper text's position so that it does not take extra height.

However, we need a way to toggle between making the helper text add extra height on the create link form, and adding no height on the edit link form. This is done through the use of the boolean variable `fixHelperTextPosition`.

## Screenshots

**Before**:

Create link form

https://user-images.githubusercontent.com/41856541/195542387-27999e00-1dae-4a16-aad7-3336e54b5943.mov

Edit link form

https://user-images.githubusercontent.com/41856541/195542566-2cdc6bc8-5fdd-49c8-90c1-7d2de418589a.mov

**After**:

Create link form: unchanged from before

Edit link form

https://user-images.githubusercontent.com/41856541/195543292-f1a3d139-a330-4b32-8e01-e5c4ce326c8c.mov

