### PR TITLE
chore(datadog): add metrics for malicious file or link activity

### DIFF
--- a/src/server/modules/threat/FileCheckController.ts
+++ b/src/server/modules/threat/FileCheckController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import { inject, injectable } from 'inversify'
 
 import fileUpload from 'express-fileupload'
+import dogstatsd, { MALICIOUS_ACTIVITY_FILE } from '../../util/dogstatsd'
 import jsonMessage from '../../util/json'
 import { DependencyIds } from '../../constants'
 import { FileTypeFilterService, VirusScanService } from './interfaces'
@@ -73,6 +74,7 @@ export class FileCheckController {
               user?.email || user?.id
             } tried to upload ${file.name}`,
           )
+          dogstatsd.increment(MALICIOUS_ACTIVITY_FILE, 1, 1)
           res.badRequest(jsonMessage('File is likely to be malicious.'))
           return
         }

--- a/src/server/modules/threat/UrlCheckController.ts
+++ b/src/server/modules/threat/UrlCheckController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 import { inject, injectable } from 'inversify'
 
+import dogstatsd, { MALICIOUS_ACTIVITY_LINK } from '../../util/dogstatsd'
 import jsonMessage from '../../util/json'
 import { UrlCreationRequest } from '../user'
 import { UrlThreatScanService } from './interfaces'
@@ -35,6 +36,7 @@ export class UrlCheckController {
               user?.email || user?.id
             } tried to link ${shortUrl} to ${longUrl}`,
           )
+          dogstatsd.increment(MALICIOUS_ACTIVITY_LINK, 1, 1)
           res.badRequest(
             jsonMessage(
               'Link is likely to be malicious, please contact us for further assistance',

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -10,6 +10,7 @@ import {
 import dogstatsd, {
   SHORTLINK_CREATE,
   SHORTLINK_CREATE_TAG_IS_FILE,
+  SHORTLINK_CREATE_TAG_SOURCE,
 } from '../../../util/dogstatsd'
 import {
   AlreadyExistsError,
@@ -20,6 +21,7 @@ import { UrlRepositoryInterface } from '../../../repositories/interfaces/UrlRepo
 import { addFileExtension, getFileExtension } from '../../../util/fileFormat'
 import { GoUploadedFile, UpdateUrlOptions } from '..'
 import { DependencyIds } from '../../../constants'
+import { BULK, CONSOLE } from '../../../models/types'
 import * as interfaces from '../interfaces'
 
 @injectable()
@@ -77,6 +79,7 @@ export class UrlManagementService implements interfaces.UrlManagementService {
     )
     dogstatsd.increment(SHORTLINK_CREATE, 1, 1, [
       `${SHORTLINK_CREATE_TAG_IS_FILE}:${!!file}`,
+      `${SHORTLINK_CREATE_TAG_SOURCE}:${CONSOLE}`, // TODO: distinguish between console and API sources eventually
     ])
 
     return result
@@ -159,9 +162,10 @@ export class UrlManagementService implements interfaces.UrlManagementService {
       urlMappings,
       tags,
     })
-    dogstatsd.increment('shortlink.create', urlMappings.length, 1, [
-      `isbulk:true`,
-    ]) // TODO: extract metric and tag names
+    dogstatsd.increment(SHORTLINK_CREATE, urlMappings.length, 1, [
+      `${SHORTLINK_CREATE_TAG_IS_FILE}:false`,
+      `${SHORTLINK_CREATE_TAG_SOURCE}:${BULK}`,
+    ])
   }
 }
 

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -1,6 +1,8 @@
 import { StatsD } from 'hot-shots'
 import { DEV_ENV } from '../config'
 
+export const MALICIOUS_ACTIVITY_FILE = 'malicious_activity.file'
+export const MALICIOUS_ACTIVITY_LINK = 'malicious_activity.link'
 export const OTP_GENERATE_FAILURE = 'otp.generate.failure'
 export const OTP_GENERATE_SUCCESS = 'otp.generate.success'
 export const OTP_VERIFY_FAILURE = 'otp.verify.failure'
@@ -8,6 +10,7 @@ export const OTP_VERIFY_SUCCESS = 'otp.verify.success'
 export const SHORTLINK_CLICKS = 'shortlink.clicks'
 export const SHORTLINK_CREATE = 'shortlink.create'
 export const SHORTLINK_CREATE_TAG_IS_FILE = 'isfile'
+export const SHORTLINK_CREATE_TAG_SOURCE = 'source'
 export const USER_NEW = 'user.new'
 
 const dogstatsd = new StatsD({


### PR DESCRIPTION
## Problem

Currently, the metrics for malicious activity are defined under metric filters for CloudWatch log groups. (See [AWS console](https://ap-southeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-1#logsV2:log-groups/log-group/$252Faws$252Felasticbeanstalk$252Fgo-production$252Fvar$252Flog$252Feb-docker$252Fcontainers$252Feb-current-app$252Fstdouterr.log$23metric-filters) for more details, requires AWS permissions to access)

The current approach presents several problems:
1. We cannot distinguish between malicious links and malicious files being uploaded
2. We cannot distinguish between staging/prod and gov/edu/health services without giving each metric a different name
3. The metrics are not defined in the codebase, so it's not under version control, and it adds some 'hidden' technical complexity on AWS infra that's not obvious to developers

## Solution

Add two new malicious activity metrics that will be sent to Datadog: one for malicious files (`go.malicious_activity.file`), and one for malicious links (`go.malicious_activity.link`). The env and service tags for staging/prod and gov/edu/health respectively should be added on Datadog automatically. This will allow us to remove metric filters on CloudWatch in the future as well, if we want to.

**Improvements**:

Resolved a TODO comment from before (https://github.com/opengovsg/GoGovSG/pull/1993#discussion_r984335841) in `UrlManagementService.ts`. For the shortlink creation metric, a new tag was also added to label the source (console or bulk, but not yet API).

## Tests

- [x] Test on staging to make sure that new metrics are being sent with tags

## Deploy notes

Post-deployment: can remove CloudWatch metric filters for malicious activity (optional, but would be nice to do)
