### PR TITLE
feat(tagging): allow backspaces to remove tags

### DIFF
--- a/src/client/user/widgets/TagsAutocomplete.tsx
+++ b/src/client/user/widgets/TagsAutocomplete.tsx
@@ -148,11 +148,19 @@ export default function TagsAutocomplete({
               error={!isValidTag(tagInput, true) || tags.includes(tagInput)}
               className={classes.tagsText}
               onKeyDown={(event) => {
-                // Use enter, comma, or space to create a new tag
-                if (!['Enter', ',', ' '].includes(event.key)) return
-                event.preventDefault() // prevent form from submitting when enter key is pressed
-                event.stopPropagation() // prevent freeSolo from clearing text input
-                addTagInputToTags()
+                if (['Enter', ',', ' '].includes(event.key)) {
+                  // Use enter, comma, or space to create a new tag
+                  event.preventDefault() // prevent form from submitting when enter key is pressed
+                  event.stopPropagation() // prevent freeSolo from clearing text input
+                  addTagInputToTags()
+                } else if (
+                  event.key === 'Backspace' &&
+                  tagInput === '' &&
+                  tags.length > 0
+                ) {
+                  // Use backspace to remove existing tag
+                  setTags(tags.slice(0, -1))
+                }
               }}
               inputProps={params.inputProps}
               InputProps={{


### PR DESCRIPTION
## Problem

Currently, clicking on the 'x' on a tag on the create/edit link forms is the only way to remove the tag. Backspace doesn't do this, which may be unintuitive or non-keyboard friendly.

See [Notion issue](https://www.notion.so/opengov/Update-Delete-should-delete-the-tag-ae73e761415e4ac1874965316a7e7444)

## Solution

Allow backspaces to remove tags.
