### PR TITLE
fix: restrict state to active and inactive in url search

### DIFF
--- a/src/client/user/actions/index.ts
+++ b/src/client/user/actions/index.ts
@@ -366,7 +366,7 @@ const getUrlsForUser =
       offset,
       orderBy,
       sortDirection,
-      state: urlState,
+      ...(urlState && { state: urlState }),
       isFile,
       searchText,
       tags,

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -41,7 +41,7 @@ export const userUrlsQueryConditions = Joi.object({
   orderBy: Joi.string().valid('updatedAt', 'createdAt', 'clicks').optional(),
   sortDirection: Joi.string().valid('desc', 'asc').optional(),
   searchText: Joi.string().allow('').optional(),
-  state: Joi.string().allow('').optional(),
+  state: Joi.string().valid(ACTIVE, INACTIVE, '').optional(),
   isFile: Joi.boolean().optional(),
   tags: tagSchema.max(5),
 })

--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -41,7 +41,7 @@ export const userUrlsQueryConditions = Joi.object({
   orderBy: Joi.string().valid('updatedAt', 'createdAt', 'clicks').optional(),
   sortDirection: Joi.string().valid('desc', 'asc').optional(),
   searchText: Joi.string().allow('').optional(),
-  state: Joi.string().valid(ACTIVE, INACTIVE, '').optional(),
+  state: Joi.string().valid(ACTIVE, INACTIVE).optional(),
   isFile: Joi.boolean().optional(),
   tags: tagSchema.max(5),
 })

--- a/src/server/modules/user/__tests__/UserController.test.ts
+++ b/src/server/modules/user/__tests__/UserController.test.ts
@@ -328,7 +328,7 @@ describe('UserController', () => {
         1,
       )
     })
-    it('call getTagsWithConditions with invalid searchText, less than 3 characters', async () => {
+    it('reports bad request on calling getTagsWithConditions with invalid searchText, less than 3 characters', async () => {
       const searchText = 't'
       const req = httpMocks.createRequest({
         query: { searchText },
@@ -342,7 +342,7 @@ describe('UserController', () => {
       await controller.getTagsWithConditions(req, res)
       expect(res.badRequest).toHaveBeenCalledTimes(1)
     })
-    it('call getTagsWithConditions with invalid searchText, special characters', async () => {
+    it('reports bad request on calling getTagsWithConditions with invalid searchText, special characters', async () => {
       const searchText = '#$%'
       const req = httpMocks.createRequest({
         query: { searchText },
@@ -523,7 +523,7 @@ describe('UserController', () => {
       )
     })
 
-    it('processes query with invalid tags-long', async () => {
+    it('reports bad request on query with invalid tags-long', async () => {
       const req = httpMocks.createRequest({
         body: { userId: 1 },
         query: { isFile: 'false', tags: '01234567890123456789012345;tag2' },
@@ -538,7 +538,7 @@ describe('UserController', () => {
       expect(res.badRequest).toHaveBeenCalledTimes(1)
     })
 
-    it('processes query with invalid tags-special character', async () => {
+    it('reports bad request on query with invalid tags-special character', async () => {
       const req = httpMocks.createRequest({
         body: { userId: 1 },
         query: { isFile: 'false', tags: 'tag1^%^;tag2' },
@@ -553,10 +553,25 @@ describe('UserController', () => {
       expect(res.badRequest).toHaveBeenCalledTimes(1)
     })
 
-    it('processes query with more than 5 tags', async () => {
+    it('reports bad request on query with more than 5 tags', async () => {
       const req = httpMocks.createRequest({
         body: { userId: 1 },
         query: { isFile: 'false', tags: 'tag1;tag2;tag3;tag4;tag5;tag6' },
+      })
+      const res: any = httpMocks.createResponse()
+      res.ok = jest.fn()
+      res.badRequest = jest.fn()
+      const result = { urls: [], count: 0 }
+      urlManagementService.getUrlsWithConditions.mockResolvedValue(result)
+
+      await controller.getUrlsWithConditions(req, res)
+      expect(res.badRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports bad request on query with invalid state', async () => {
+      const req = httpMocks.createRequest({
+        body: { userId: 1 },
+        query: { isFile: 'false', state: 'invalid' },
       })
       const res: any = httpMocks.createResponse()
       res.ok = jest.fn()

--- a/src/server/modules/user/__tests__/UserController.test.ts
+++ b/src/server/modules/user/__tests__/UserController.test.ts
@@ -529,10 +529,7 @@ describe('UserController', () => {
         query: { isFile: 'false', tags: '01234567890123456789012345;tag2' },
       })
       const res: any = httpMocks.createResponse()
-      res.ok = jest.fn()
       res.badRequest = jest.fn()
-      const result = { urls: [], count: 0 }
-      urlManagementService.getUrlsWithConditions.mockResolvedValue(result)
 
       await controller.getUrlsWithConditions(req, res)
       expect(res.badRequest).toHaveBeenCalledTimes(1)
@@ -544,10 +541,7 @@ describe('UserController', () => {
         query: { isFile: 'false', tags: 'tag1^%^;tag2' },
       })
       const res: any = httpMocks.createResponse()
-      res.ok = jest.fn()
       res.badRequest = jest.fn()
-      const result = { urls: [], count: 0 }
-      urlManagementService.getUrlsWithConditions.mockResolvedValue(result)
 
       await controller.getUrlsWithConditions(req, res)
       expect(res.badRequest).toHaveBeenCalledTimes(1)
@@ -559,10 +553,7 @@ describe('UserController', () => {
         query: { isFile: 'false', tags: 'tag1;tag2;tag3;tag4;tag5;tag6' },
       })
       const res: any = httpMocks.createResponse()
-      res.ok = jest.fn()
       res.badRequest = jest.fn()
-      const result = { urls: [], count: 0 }
-      urlManagementService.getUrlsWithConditions.mockResolvedValue(result)
 
       await controller.getUrlsWithConditions(req, res)
       expect(res.badRequest).toHaveBeenCalledTimes(1)
@@ -574,10 +565,19 @@ describe('UserController', () => {
         query: { isFile: 'false', state: 'invalid' },
       })
       const res: any = httpMocks.createResponse()
-      res.ok = jest.fn()
       res.badRequest = jest.fn()
-      const result = { urls: [], count: 0 }
-      urlManagementService.getUrlsWithConditions.mockResolvedValue(result)
+
+      await controller.getUrlsWithConditions(req, res)
+      expect(res.badRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports bad request on query with empty state', async () => {
+      const req = httpMocks.createRequest({
+        body: { userId: 1 },
+        query: { isFile: 'false', state: '' },
+      })
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
 
       await controller.getUrlsWithConditions(req, res)
       expect(res.badRequest).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Problem

The query conditions for `state` when searching for URLs in the user page are overly permissive, and should be restricted to either active or inactive states.

See [Snyk dashboard - Improper Type Validation](https://app.snyk.io/org/gogovsg/project/195ed33d-81b4-40d4-9918-45609ce999fb#issue-dbdfdd86-c468-4c17-aef0-d0c9b0bad893)

## Solution

Use Joi validator to allow the optional `state` field to be only one of `ACTIVE`, `INACTIVE` ~or `''`.~

~I'm perhaps less comfortable with allowing `state` to be `''`, but the frontend inserts `&state=` by default so disallowing it will break the frontend search~ edit: removed `''` from `state` following the comments below!

**Tests**:

- Added tests for an invalid and empty `state` field in `UserController.test.ts`
- (Improvement) Renamed test cases that return a bad request response code to begin with "reports bad request", in line with other test cases in the file that do this
