### PR TITLE
fix: restrict state to active and inactive in directory search

### DIFF
--- a/src/client/directory/actions/index.ts
+++ b/src/client/directory/actions/index.ts
@@ -67,7 +67,7 @@ const getDirectoryResults =
       order,
       limit,
       offset,
-      state,
+      ...(state && { state }),
       isFile,
       isEmail,
     }

--- a/src/server/api/directory.ts
+++ b/src/server/api/directory.ts
@@ -3,6 +3,7 @@ import { createValidator } from 'express-joi-validation'
 import Joi from '@hapi/joi'
 import { container } from '../util/inversify'
 import { DependencyIds } from '../constants'
+import { ACTIVE, INACTIVE } from '../models/types'
 import { DirectoryController } from '../modules/directory'
 import { SearchResultsSortOrder } from '../../shared/search'
 
@@ -14,7 +15,7 @@ const urlSearchRequestSchema = Joi.object({
     .only(),
   limit: Joi.number(),
   offset: Joi.number(),
-  state: Joi.string().allow(''),
+  state: Joi.string().valid(ACTIVE, INACTIVE, ''),
   isFile: Joi.string().allow(''),
   isEmail: Joi.string().required(),
 })

--- a/src/server/api/directory.ts
+++ b/src/server/api/directory.ts
@@ -15,7 +15,7 @@ const urlSearchRequestSchema = Joi.object({
     .only(),
   limit: Joi.number(),
   offset: Joi.number(),
-  state: Joi.string().valid(ACTIVE, INACTIVE, ''),
+  state: Joi.string().valid(ACTIVE, INACTIVE),
   isFile: Joi.string().allow(''),
   isEmail: Joi.string().required(),
 })


### PR DESCRIPTION
## Problem

Similar to #2050, the query conditions for `state` when searching for URLs in the directory page are overly permissive, and should be restricted to either active or inactive states.

See [Snyk dashboard - Improper Type Validation](https://app.snyk.io/org/gogovsg/project/195ed33d-81b4-40d4-9918-45609ce999fb#issue-dbdfdd86-c468-4c17-aef0-d0c9b0bad893)

## Solution

Use Joi validator to allow the optional `state` field to be only one of `ACTIVE`, `INACTIVE`. (updated to remove `''` following comments in the other PR!) (Joi validated fields are optional by default)

No controller tests can be added here - the Joi validation happens in the middleware before hitting the controller level
