### PR TITLE
fix: add second order by shortUrl when searching for links

### DIFF
--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -113,6 +113,7 @@ export class UserRepository implements UserRepositoryInterface {
           conditions.orderBy,
           conditions.sortDirection,
         ],
+        ['shortUrl', 'asc'],
       ],
     })
     if (!urlsAndCount) {


### PR DESCRIPTION
## Problem

Bulk-created links with the same `createdAt` time are not necessarily returned in the same order when sorting links by `createdAt` only. This may cause issues, like the sort order of bulk links suddenly changing when one of the links is updated

See [Notion issue - [Create] Link sort order seems to be changed after adding the tag](https://www.notion.so/opengov/Create-Link-sort-order-seems-to-be-changed-after-adding-the-tag-62912d3cae88455a957e4955d51ca984) and [Notion issue - [Create] [Update] Link status changes after adding or updating the tag](https://www.notion.so/opengov/Create-Update-Link-status-changes-after-adding-or-updating-the-tag-c251902d44754ab08d832e122ff8bff6)

## Solution

Add a second `ORDER BY` condition on `shortUrl`, leading to a deterministic ordering with bulk-created links

- Possible drawback is that the search could take extra time: `shortUrl` doesn't seem to be an indexed field (but then again, we're currently ordering by `createdAt` which doesn't seem to be indexed either)
- But locally at least, searching with 20k links is still super fast
