### PR TITLE
build(deps): bump sharp from 0.30.5 to 0.30.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6304,15 +6304,6 @@
           "requires": {
             "color-name": "~1.1.4"
           }
-        },
-        "color-string": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-          "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
         }
       }
     },
@@ -14065,9 +14056,9 @@
       }
     },
     "node-abi": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.22.0.tgz",
-      "integrity": "sha512-u4uAs/4Zzmp/jjsD9cyFYDXeISfUWaAVWshPmDZOFOv4Xl4SbzTXm53I04C2uRueYJ+0t5PEtLH/owbn2Npf/w==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
+      "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
       "requires": {
         "semver": "^7.3.5"
       }
@@ -15048,9 +15039,9 @@
       }
     },
     "prebuild-install": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
-      "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -15059,7 +15050,6 @@
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^3.3.0",
-        "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
         "simple-get": "^4.0.0",
@@ -16887,14 +16877,14 @@
       }
     },
     "sharp": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.5.tgz",
-      "integrity": "sha512-0T28KxqY4DzUMLSAp1/IhGVeHpPIQyp1xt7esmuXCAfyi/+6tYMUeRhQok+E/+E52Yk5yFjacXp90cQOkmkl4w==",
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
+      "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
       "requires": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",
         "node-addon-api": "^5.0.0",
-        "prebuild-install": "^7.1.0",
+        "prebuild-install": "^7.1.1",
         "semver": "^7.3.7",
         "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
@@ -16912,9 +16902,9 @@
           "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regenerator-runtime": "^0.13.8",
     "sanitize-html": "^2.7.1",
     "sequelize": "^6.21.2",
-    "sharp": "^0.30.5",
+    "sharp": "^0.30.7",
     "ua-parser-js": "^0.7.28",
     "uuid": "^8.3.2",
     "validator": "^13.7.0",


### PR DESCRIPTION
## Problem

`sharp` 0.30.5 is out-of-date: it depends on an old version of an `ansi-regex` that contains a ReDoS vulnerability (see [Snyk dashboard](https://app.snyk.io/org/gogovsg/project/3fa5b914-3f0f-4828-a3ae-5e77446f64c5#issue-SNYK-JS-ANSIREGEX-1583908))

`sharp` is currently used for image resizing for QR codes

## Solution

Update `sharp` to 0.30.7

## Tests

- [x] Test on local and staging to ensure that QR code generation still works