### PR TITLE
build(deps): bump postcss from 8.4.5 to 8.4.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14997,19 +14997,24 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.1.30",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+        },
+        "source-map-js": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+          "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
         }
       }
     },
@@ -17202,11 +17207,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
-    },
-    "source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
     },
     "source-map-resolve": {
       "version": "0.5.3",


### PR DESCRIPTION
## Problem

`postcss` 8.4.5 is out-of-date: it depends on an older version of `nanoid` that has a vulnerability (see [Snyk dashboard](https://app.snyk.io/org/gogovsg/project/3fa5b914-3f0f-4828-a3ae-5e77446f64c5#issue-SNYK-JS-NANOID-2332193))

`postcss` is used by `sanitize-html`, which is used to sanitize HTML inputs in two places: login whitelist phrase, and home page target users phrase

## Solution

Within `package-lock.json`, I deleted the chunk with `postcss` version 8.4.5, then re-ran `npm install`. This generated the new `package-lock.json` as seen in this PR with `postcss` version 8.4.18

## Tests

- [x] Tested on local and staging: ensure that login whitelist phrase and home page target users phrase still works
 