### PR TITLE
chore: paginate directory search

### DIFF
--- a/test/server/api/util.ts
+++ b/test/server/api/util.ts
@@ -216,6 +216,10 @@ export const mockQuery = jest.fn()
 export const mockDefine = jest.fn()
 
 mockQuery.mockImplementation((query: string) => {
+  // For rawDirectorySearch count queries
+  if (query.includes('count(*)')) {
+    return { count: 1 }
+  }
   // For rawDirectorySearch -> email
   if (query.includes('queryFile')) {
     return [
@@ -226,9 +230,6 @@ mockQuery.mockImplementation((query: string) => {
         isFile: false,
       },
     ]
-  }
-  if (query.includes('count(*)')) {
-    return [{ count: 10 }]
   }
   // For rawDirectorySearch -> plain text
   if (query.includes('JOIN')) {


### PR DESCRIPTION
## Problem

Directory searches for links are not paginated at the database level. Instead, the server fetches all of the links from the database at one go (then counts and slices it afterwards). This can potentially create immense server load If there are many links returned from the search query.

## Solution

Paginate directory searches for links (both by keyword and email) at the database level.
- Use `LIMIT` and `OFFSET` for the main query
- Add a separate query to fetch the total count of links

An alternative approach considered was to convert the raw queries to Sequelize and use `findAndCountAll` - but Sequelize  queries aren't powerful enough to support full-text searches, so for consistency I decided to leave them all as raw queries.

For unit tests: I repurposed the `count(*)` mock query result to return `{ count: 1 }`. Seems to not be used anywhere else (probably deprecated), so it's safe to reuse

## Tests

- Tested directory search by email for `@open.gov.sg` emails on staging returning 1.4M links - it still takes quite long (~15s), but the server no longer crashes (good news!). RDS CPU utilisation still increases, but EC2 CPU utilisation does not