### PR TITLE
build(deps): bump @sentry/webpack-plugin from 1.16.0 to 1.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3206,24 +3206,30 @@
       }
     },
     "@sentry/cli": {
-      "version": "1.67.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.67.2.tgz",
-      "integrity": "sha512-lPn0Sffbjg2UmCkHl2iw8pKlqpPhy85mW0za5kz3LEqC9JGUXHo9eSyyCkiRktlemMXKk+DeS/nyFy/LTRUG2Q==",
+      "version": "1.74.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.74.6.tgz",
+      "integrity": "sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==",
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "npmlog": "^4.1.2",
         "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+        },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         }
       }
@@ -3372,11 +3378,12 @@
       }
     },
     "@sentry/webpack-plugin": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.16.0.tgz",
-      "integrity": "sha512-Ax0QZ3a+LFYU876Si2HElPYSj+mX3vinvzH+o9F1g/5T2Z3HqITnX6gg+zVfLFsE819PN9KeLpmoHtO352dlmQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.20.0.tgz",
+      "integrity": "sha512-Ssj1mJVFsfU6vMCOM2d+h+KQR7QHSfeIP16t4l20Uq/neqWXZUQ2yvQfe4S3BjdbJXz/X4Rw8Hfy1Sd0ocunYw==",
       "requires": {
-        "@sentry/cli": "^1.67.1"
+        "@sentry/cli": "^1.74.6",
+        "webpack-sources": "^2.0.0 || ^3.0.0"
       }
     },
     "@sinonjs/commons": {
@@ -11134,8 +11141,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -20162,7 +20168,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@sentry/react": "^6.11.0",
     "@sentry/tracing": "^6.8.0",
-    "@sentry/webpack-plugin": "^1.15.1",
+    "@sentry/webpack-plugin": "^1.20.0",
     "@types/express-rate-limit": "^5.1.3",
     "@types/papaparse": "^5.3.5",
     "aws-sdk": "^2.1101.0",


### PR DESCRIPTION
## Problem

`@sentry/webpack-plugin` 1.16.0 is out-of-date: it depends on an older version of `minimist` that has a vulnerability (see [Snyk dashboard](https://app.snyk.io/org/gogovsg/project/3fa5b914-3f0f-4828-a3ae-5e77446f64c5#issue-SNYK-JS-MINIMIST-2429795))

## Solution

Update `@sentry/webpack-plugin` to 1.20.0

## Tests

- [x] Test on local and staging to ensure everything still works
- [ ] Test that sentry still works (not sure how to do this)
