### PR TITLE
feat: allow html for announcement modal message

### DIFF
--- a/src/client/app/util/format.ts
+++ b/src/client/app/util/format.ts
@@ -66,7 +66,7 @@ export function formatBytes(bytes: number) {
   return `${parseFloat((bytes / k ** i).toFixed(1))}${sizes[i]}`
 }
 
-export function hmtlSanitizer(dirtyHtmlString: string) {
+export function htmlSanitizer(dirtyHtmlString: string) {
   return sanitizeHtml(dirtyHtmlString, {
     allowedTags: ['b', 'i', 'em', 'strong', 'a'],
     allowedAttributes: {

--- a/src/client/home/components/FeatureListSliver.tsx
+++ b/src/client/home/components/FeatureListSliver.tsx
@@ -15,7 +15,7 @@ import antiPhishingIcon from '@assets/components/home/feature-list-sliver/home-p
 import customisedIcon from '@assets/components/home/feature-list-sliver/home-page-customised-icon.svg'
 import analyticsIcon from '@assets/components/home/feature-list-sliver/home-page-analytics-icon.svg'
 import fileSharingIcon from '@assets/components/home/feature-list-sliver/home-page-file-sharing-icon.svg'
-import { hmtlSanitizer } from '../../app/util/format'
+import { htmlSanitizer } from '../../app/util/format'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -120,7 +120,7 @@ const FeatureListSliver = () => {
         display="inline"
         gutterBottom
         dangerouslySetInnerHTML={{
-          __html: hmtlSanitizer(i18next.t('homePage.targetUsersPhrase')),
+          __html: htmlSanitizer(i18next.t('homePage.targetUsersPhrase')),
         }}
       >
         {/* <text ></text> NOTE: dangerouslySetInnerHTML is used as copy includes <a href></a> tag */}

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -17,7 +17,7 @@ import assetVariant from '../../shared/util/asset-variant'
 import { GoGovReduxState } from '../app/reducers/types'
 import loginActions from './actions'
 import rootActions from '../app/components/pages/RootPage/actions'
-import { hmtlSanitizer } from '../app/util/format'
+import { htmlSanitizer } from '../app/util/format'
 import { USER_PAGE, VariantType, loginFormVariants } from '../app/util/types'
 import { get } from '../app/util/requests'
 import LoginForm from './components/LoginForm'
@@ -240,7 +240,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
                       className={classes.loginHeader}
                       variant="body1"
                       dangerouslySetInnerHTML={{
-                        __html: hmtlSanitizer(
+                        __html: htmlSanitizer(
                           i18next.t('login.whitelistPhrase'),
                         ),
                       }}

--- a/src/client/user/components/AnnouncementModal/index.tsx
+++ b/src/client/user/components/AnnouncementModal/index.tsx
@@ -14,6 +14,7 @@ import userActions from '../../actions'
 import useFullScreenDialog from '../../helpers/fullScreenDialog'
 import CloseIcon from '../../../app/components/widgets/CloseIcon'
 import { GAEvent } from '../../../app/util/ga'
+import { htmlSanitizer } from '../../../app/util/format'
 
 type StyleProps = {
   isFullScreenDialog: boolean
@@ -66,7 +67,8 @@ const useStyles = makeStyles((theme) =>
         width: '100%',
       },
     },
-    messagePadding: {
+    message: {
+      display: 'block',
       paddingLeft: theme.spacing(4),
       paddingRight: theme.spacing(4),
       whiteSpace: 'pre-line',
@@ -215,12 +217,12 @@ const AnnouncementModal = () => {
       ) : null}
       {announcement?.message ? (
         <Typography
-          className={`${classes.justifyCenter} ${classes.messagePadding}`}
+          className={classes.message}
           variant="body2"
-        >
-          {/* Enable line break */}
-          {announcement.message.replace(/\\n/g, '\n')}
-        </Typography>
+          dangerouslySetInnerHTML={{
+            __html: htmlSanitizer(announcement.message.replace(/\\n/g, '\n')),
+          }}
+        />
       ) : null}
       <div className={`${classes.justifyCenter} ${classes.modalBottom}`}>
         {announcement?.url ? (

--- a/src/client/user/components/AnnouncementModal/index.tsx
+++ b/src/client/user/components/AnnouncementModal/index.tsx
@@ -220,6 +220,7 @@ const AnnouncementModal = () => {
           className={classes.message}
           variant="body2"
           dangerouslySetInnerHTML={{
+            // Enable line break
             __html: htmlSanitizer(announcement.message.replace(/\\n/g, '\n')),
           }}
         />


### PR DESCRIPTION
## Problem

The announcement modal currently does not allow HTML inside its message, preventing us from using clickable hyperlinks.

## Solution

Allow HTML for the announcement modal message. Since we control the announcement message (through the `ANNOUNCEMENT_MESSAGE` env variable), this should be safe.
- Sanitize message before setting it in inner HTML
- Changed from `display: flex` to `display: block` to avoid new HTML elements from being added in new columns
- Fixed small typo by renaming `hmtlSanitizer` to `htmlSanitizer`

## Before & After Screenshots


**AFTER**:

`ANNOUNCEMENT_MESSAGE` here is set to `You can now tag your links and manage your dashboards effectively. Learn more about this on <a href="https://guide.go.gov.sg/guide-1/link-tagging">our guide</a>.\nFurthermore, our team is constantly looking for new problems to solve for our users. If you would like us to build a solution for you, please provide your thoughts <a href="https://go.gov.sg/go-pain-point-survey">here</a>!`

![Screenshot 2022-11-01 at 6 59 01 PM](https://user-images.githubusercontent.com/41856541/199218571-954044f3-8da6-4c27-a2fa-2e85e669fd84.png)