### PR TITLE
fix(tagging): fix filtering for no results when searching by tags

### DIFF
--- a/src/client/user/components/EmptyState/isFiltered.ts
+++ b/src/client/user/components/EmptyState/isFiltered.ts
@@ -5,7 +5,7 @@ export default function useIsFiltered() {
   const tableConfig = useSelector(
     (state: GoGovReduxState) => state.user.tableConfig,
   )
-  const { searchText } = tableConfig
+  const { searchText, tags } = tableConfig
   const filtered = Object.values(tableConfig.filter).some((value) => !!value)
-  return !!searchText || filtered
+  return !!searchText || !!tags || filtered
 }

--- a/test/end-to-end/UserPage.test.ts
+++ b/test/end-to-end/UserPage.test.ts
@@ -20,6 +20,9 @@ import {
   generateUrlImage,
   longUrl,
   longUrlTextField,
+  noResultsFoundText,
+  searchBarLinkButton,
+  searchBarLinksInput,
   searchBarTagButton,
   searchBarTagsInput,
   shortUrlTextField,
@@ -160,6 +163,19 @@ test('User page test on filter search by link', async (t) => {
     .click(clickAway)
     .expect(filterSortPanel.getStyleProperty('height'))
     .eql('0px')
+
+  // Searching for a non-existent link should show that no results are found
+  await t
+    .typeText(searchBarLinksInput, 'this-link-does-not-exist')
+    .wait(1000)
+    // Should display no results found
+    .expect(noResultsFoundText.exists)
+    .ok()
+    // Links input and dropdown should still exist
+    .expect(searchBarLinkButton.exists)
+    .ok()
+    .expect(searchBarLinksInput.exists)
+    .ok()
 })
 
 test('User page test on filter search by tags', async (t) => {
@@ -208,7 +224,7 @@ test('User page test on filter search by tags', async (t) => {
   // Click on tag 1 from url 1
   await t
     .click(linkTableRow1.find('span').withExactText(tagText1))
-    .wait(3000)
+    .wait(2000)
     // Link table should show urls 2 and 1 on top
     .expect(urlTableRowUrlText(0))
     .eql(`/${generatedUrl2}`)
@@ -224,7 +240,7 @@ test('User page test on filter search by tags', async (t) => {
   // Click on tag 2 from url 2
   await t
     .click(linkTableRow2.find('span').withExactText(tagText2))
-    .wait(3000)
+    .wait(2000)
     // Link table should show urls 3, 2, and 1 on top
     .expect(urlTableRowUrlText(0))
     .eql(`/${generatedUrl3}`)
@@ -242,7 +258,7 @@ test('User page test on filter search by tags', async (t) => {
   // Add semicolon and non-existent tag to search input
   await t
     .typeText(searchBarTagsInput, `${TAG_SEPARATOR}zzzzzzzzzzzzzzzzzzzz`)
-    .wait(3000)
+    .wait(2000)
     // Link table should still show urls 3, 2, and 1 on top (because of OR condition between search tags)
     .expect(urlTableRowUrlText(0))
     .eql(`/${generatedUrl3}`)
@@ -255,7 +271,7 @@ test('User page test on filter search by tags', async (t) => {
   await t
     .click(searchBarTagsInput)
     .pressKey('ctrl+a delete')
-    .wait(3000)
+    .wait(2000)
     // Link table should show urls 3, 2, and 1 on top
     .expect(urlTableRowUrlText(0))
     .eql(`/${generatedUrl3}`)
@@ -272,4 +288,19 @@ test('User page test on filter search by tags', async (t) => {
     .eql(`/${generatedUrl2}`)
     .expect(urlTableRowUrlText(1))
     .eql(`/${generatedUrl1}`)
+
+  // Change search input to a single non-existent tag
+  await t
+    .click(searchBarTagsInput)
+    .pressKey('ctrl+a delete')
+    .typeText(searchBarTagsInput, 'this-tag-does-not-exist')
+    .wait(2000)
+    // Should display no results found
+    .expect(noResultsFoundText.exists)
+    .ok()
+    // Tag input and dropdown should still exist
+    .expect(searchBarTagButton.exists)
+    .ok()
+    .expect(searchBarTagsInput.exists)
+    .ok()
 })

--- a/test/end-to-end/util/helpers.ts
+++ b/test/end-to-end/util/helpers.ts
@@ -103,6 +103,9 @@ export const tag3 = Selector('p').withExactText(tagText3).parent()
 export const tagCloseButton1 = tag1.child('button')
 export const tagCloseButton2 = tag2.child('button')
 export const tagCloseButton3 = tag3.child('button')
+export const noResultsFoundText = Selector('p').withExactText(
+  'No results found, try expanding your search terms.',
+)
 
 // User Page - filter search
 export const userFilterSortPanelButton = Selector(


### PR DESCRIPTION
## Problem

To reproduce:
- Login and go to the user page, ensure that you have some links
- Search for a non-existent tag
- Search bar disappears and page says that you have no short links

Regression likely introduced by #2037, by separating `searchText` out into `searchText` and `tags`

Closes [Notion issue](https://www.notion.so/opengov/Address-bug-when-searching-for-tag-that-does-not-exist-b6c77f13eac149d796881c93f45921c0)

## Solution

Change the condition for determining if the user has searched/filtered for URLs, by also checking for the existence of `tags` in `tableConfig`

## Before & After Screenshots

**BEFORE**:
When searching for a non-existent tag:
![Screenshot 2022-11-03 at 2 54 39 PM](https://user-images.githubusercontent.com/41856541/199662401-96e88532-2636-462d-be68-8218ea3c2fc5.png)

**AFTER**:
When searching for a non-existent tag:
![Screenshot 2022-11-03 at 2 55 31 PM](https://user-images.githubusercontent.com/41856541/199662499-9c4984b0-4cbd-40fa-869f-920dd6b3efe2.png)

## Tests

- [x] Add E2E test for searching for non-existent tag
- [x] Add E2E test for searching for non-existent link

Also shortened the wait time for searching for tags from 3s -> 2s, which still seems more than long enough. Wait time for searching for links remains at 1s
