### PR TITLE
fix: add return after making server response

### DIFF
--- a/src/server/modules/audit/LinkAuditController.ts
+++ b/src/server/modules/audit/LinkAuditController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { inject, injectable } from 'inversify'
 import { LinkAuditService } from './interfaces'
 import { DependencyIds } from '../../constants'
+import { NotFoundError } from '../../util/error'
 import jsonMessage from '../../util/json'
 
 @injectable()
@@ -40,10 +41,11 @@ export class LinkAuditController {
       res.status(200).json(linkStats)
       return
     } catch (error) {
-      if (error instanceof Error) {
-        res.status(400).send(jsonMessage(error.message))
+      if (error instanceof NotFoundError) {
+        res.status(404).send(jsonMessage(error.message))
+        return
       }
-      res.status(404).send(jsonMessage(error.message))
+      res.status(400).send(jsonMessage(error.message))
       return
     }
   }

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -96,6 +96,7 @@ export class UserController {
       }
       if (error instanceof Sequelize.ValidationError) {
         res.badRequest(jsonMessage(error.message))
+        return
       }
       logger.error(`Error creating short URL:\t${error}`)
       res.badRequest(jsonMessage('Server Error.'))


### PR DESCRIPTION
## Problem

In two places in the codebase, the server does not return immediately after making a response, leading to `res.send()` being called _twice_, which causes an unhandled promise rejection. This is still okay for node <14 because it just gives a warning, but not from node 15 onwards (see [node 15 release docs](https://nodejs.org/en/blog/release/v15.0.0/#throw-on-unhandled-rejections-33021)) as it throws an error and terminates the entire node process, which is very scary.

Example error message:
![Screenshot 2022-11-10 at 6 26 35 PM](https://user-images.githubusercontent.com/41856541/201066808-9cde9705-e735-44a1-9611-9b129b38e4ce.png)

## Solution

- In `UserController`: simply add `return`
- In `LinkAuditController`: had to invert the logic a little to do the same functionality without calling `res.send()` twice

