### PR TITLE
Feat/bulk/all create job

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ After these have been set up, set the environment variables according to the tab
 |COOKIE_MAX_AGE|Yes|Session duration of cookie|
 |BULK_UPLOAD_MAX_NUM|No|Maximum number of links that can be bulk uploaded at once. Defaults to 1000|
 |BULK_UPLOAD_RANDOM_STR_LENGTH|No|String length of randomly generated shortUrl in bulk upload. Defaults to 8|
-|BULK_QR_CODE_BATCH_SIZE|No|Maximum number of links that can be bulk uploaded at once. Defaults to 100|
+|BULK_QR_CODE_BATCH_SIZE|No|Maximum batch size of QR codes to generate in a single Lambda run. Defaults to 1000|
 |REPLICA_URI|Yes|The postgres connection string, e.g. `postgres://postgres:postgres@postgres:5432/postgres`|
-|SQS_BULK_QRCODE_GENERATE_START_URL|Yes|The SQS queue for starting QR code bulk generation Lambda|
+|SQS_BULK_QRCODE_GENERATE_START_URL|No|The SQS queue for starting QR code bulk generation Lambda|
 |SQS_TIMEOUT|No|Duration of time in ms for sending to SQS queue before timeout. Defaults to 10000ms (10s)|
-|SQS_REGION|Yes|AWS Region of SQS queue for starting QR code bulk generation Lambda|
+|SQS_REGION|No|AWS Region of SQS queue for starting QR code bulk generation Lambda|
 
 
 #### Serverless functions for link migration

--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ After these have been set up, set the environment variables according to the tab
 |COOKIE_MAX_AGE|Yes|Session duration of cookie|
 |BULK_UPLOAD_MAX_NUM|No|Maximum number of links that can be bulk uploaded at once. Defaults to 1000|
 |BULK_UPLOAD_RANDOM_STR_LENGTH|No|String length of randomly generated shortUrl in bulk upload. Defaults to 8|
+|BULK_QR_CODE_BATCH_SIZE|No|Maximum number of links that can be bulk uploaded at once. Defaults to 100|
 |REPLICA_URI|Yes|The postgres connection string, e.g. `postgres://postgres:postgres@postgres:5432/postgres`|
+|SQS_BULK_QRCODE_GENERATE_START_URL|Yes|The SQS queue for starting QR code bulk generation Lambda|
+|SQS_TIMEOUT|No|Duration of time in ms for sending to SQS queue before timeout. Defaults to 10000ms (10s)|
+|SQS_REGION|Yes|AWS Region of SQS queue for starting QR code bulk generation Lambda|
+
 
 #### Serverless functions for link migration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - SQS_BULK_QRCODE_GENERATE_START_URL=
       - SQS_TIMEOUT=10000
       - SQS_REGION=
-      - BULK_QR_CODE_BATCH_SIZE=100
+      - BULK_QR_CODE_BATCH_SIZE=1000
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - BULK_UPLOAD_MAX_NUM=1000
       - BULK_UPLOAD_RANDOM_STR_LENGTH=8
       - AWS_SQS_BULK_QRCODE_GENERATE_START_URL=
+      - AWS_SQS_TIMEOUT=10000
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - ACTIVATE_POSTMAN_FALLBACK=
       - BULK_UPLOAD_MAX_NUM=1000
       - BULK_UPLOAD_RANDOM_STR_LENGTH=8
+      - AWS_SQS_BULK_QRCODE_GENERATE_START_URL=
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,10 @@ services:
       - ACTIVATE_POSTMAN_FALLBACK=
       - BULK_UPLOAD_MAX_NUM=1000
       - BULK_UPLOAD_RANDOM_STR_LENGTH=8
-      - AWS_SQS_BULK_QRCODE_GENERATE_START_URL=
-      - AWS_SQS_TIMEOUT=10000
+      - SQS_BULK_QRCODE_GENERATE_START_URL=
+      - SQS_TIMEOUT=10000
+      - SQS_REGION=
+      - BULK_QR_CODE_BATCH_SIZE=100
     volumes:
       - ./public:/usr/src/gogovsg/public
       - ./src:/usr/src/gogovsg/src

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -19,6 +19,7 @@ import {
 import { UserController } from '../../modules/user'
 import { BulkController } from '../../modules/bulk'
 import { FileCheckController, UrlCheckController } from '../../modules/threat'
+import { JobController } from '../../modules/job'
 
 const router = Express.Router()
 
@@ -37,6 +38,8 @@ const urlCheckController = container.get<UrlCheckController>(
 const bulkController = container.get<BulkController>(
   DependencyIds.bulkController,
 )
+
+const jobController = container.get<JobController>(DependencyIds.jobController)
 
 const fileUploadMiddleware = fileUpload({
   limits: {
@@ -117,6 +120,7 @@ router.post(
   bulkController.validateAndParseCsv,
   urlCheckController.bulkUrlCheck,
   bulkController.bulkCreate,
+  jobController.createAndStartJob,
 )
 
 router.patch(

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -173,9 +173,10 @@ export const userAnnouncement = {
 
 export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
+export const sqsRegion = process.env.SQS_REGION as string
 export const sqsBulkQRCodeStartUrl =
-  (process.env.AWS_SQS_BULK_QRCODE_GENERATE_START_URL as string) || ''
-export const sqsTimeout = Number(process.env.AWS_SQS_TIMEOUT) || 10000
+  (process.env.SQS_BULK_QRCODE_GENERATE_START_URL as string) || ''
+export const sqsTimeout = Number(process.env.SQS_TIMEOUT) || 10000
 
 const parseDbUri = (uri: string): ConnectionOptions => {
   const { host, user, password, database, port } = parseUri(uri)
@@ -248,3 +249,5 @@ export const bulkUploadMaxNum: number =
   Number(process.env.BULK_UPLOAD_MAX_NUM) || 1000
 export const bulkUploadRandomStrLength: number =
   Number(process.env.BULK_UPLOAD_RANDOM_STR_LENGTH) || 8
+export const qrCodeJobBatchSize: number =
+  Number(process.env.BULK_QR_CODE_BATCH_SIZE) || 100

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -173,7 +173,7 @@ export const userAnnouncement = {
 
 export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
-export const sqsRegion = process.env.SQS_REGION as string
+export const sqsRegion = (process.env.SQS_REGION as string) || ''
 export const sqsBulkQRCodeStartUrl =
   (process.env.SQS_BULK_QRCODE_GENERATE_START_URL as string) || ''
 export const sqsTimeout = Number(process.env.SQS_TIMEOUT) || 10000
@@ -250,4 +250,4 @@ export const bulkUploadMaxNum: number =
 export const bulkUploadRandomStrLength: number =
   Number(process.env.BULK_UPLOAD_RANDOM_STR_LENGTH) || 8
 export const qrCodeJobBatchSize: number =
-  Number(process.env.BULK_QR_CODE_BATCH_SIZE) || 100
+  Number(process.env.BULK_QR_CODE_BATCH_SIZE) || 1000

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -174,7 +174,7 @@ export const userAnnouncement = {
 export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
 export const sqsBulkQRCodeStartUrl =
-  process.env.AWS_SQS_BULK_QRCODE_GENERATE_START_URL || ''
+  (process.env.AWS_SQS_BULK_QRCODE_GENERATE_START_URL as string) || ''
 
 const parseDbUri = (uri: string): ConnectionOptions => {
   const { host, user, password, database, port } = parseUri(uri)

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -175,6 +175,7 @@ export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
 export const sqsBulkQRCodeStartUrl =
   (process.env.AWS_SQS_BULK_QRCODE_GENERATE_START_URL as string) || ''
+export const sqsTimeout = Number(process.env.AWS_SQS_TIMEOUT) || 10000
 
 const parseDbUri = (uri: string): ConnectionOptions => {
   const { host, user, password, database, port } = parseUri(uri)

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -173,6 +173,8 @@ export const userAnnouncement = {
 
 export const s3Bucket = process.env.AWS_S3_BUCKET as string
 export const linksToRotate = process.env.ROTATED_LINKS
+export const sqsBulkQRCodeStartUrl =
+  process.env.AWS_SQS_BULK_QRCODE_GENERATE_START_URL || ''
 
 const parseDbUri = (uri: string): ConnectionOptions => {
   const { host, user, password, database, port } = parseUri(uri)

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -13,6 +13,7 @@ export const DependencyIds = {
   tagRepository: Symbol.for('tagRepository'),
   jobRepository: Symbol.for('jobRepository'),
   jobItemRepository: Symbol.for('jobItemRepository'),
+  jobController: Symbol.for('jobController'),
   otpRepository: Symbol.for('otpRepository'),
   mailer: Symbol.for('mailer'),
   cryptography: Symbol.for('cryptography'),

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -19,6 +19,8 @@ export const DependencyIds = {
   s3: Symbol.for('s3'),
   s3Bucket: Symbol.for('s3Bucket'),
   s3Client: Symbol.for('s3Client'),
+  sqsClient: Symbol.for('sqsClient'),
+  sqsService: Symbol.for('sqsService'),
   fileURLPrefix: Symbol.for('fileURLPrefix'),
   redirectService: Symbol.for('redirectService'),
   crawlerCheckService: Symbol.for('crawlerCheckService'),

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -194,6 +194,7 @@ export default () => {
 
     container.bind(DependencyIds.sqsClient).toConstantValue(
       new AWS.SQS({
+        region: 'ap-southeast-1',
         httpOptions: {
           timeout: sqsTimeout,
         },
@@ -204,6 +205,7 @@ export default () => {
     container.bind(DependencyIds.s3Client).toConstantValue(new AWS.S3())
     container.bind(DependencyIds.sqsClient).toConstantValue(
       new AWS.SQS({
+        region: 'ap-southeast-1',
         httpOptions: {
           timeout: sqsTimeout,
         },

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -11,6 +11,7 @@ import {
   linksToRotate,
   ogUrl,
   s3Bucket,
+  sqsRegion,
   sqsTimeout,
   userAnnouncement,
   userMessage,
@@ -194,7 +195,7 @@ export default () => {
 
     container.bind(DependencyIds.sqsClient).toConstantValue(
       new AWS.SQS({
-        region: 'ap-southeast-1',
+        region: sqsRegion,
         httpOptions: {
           timeout: sqsTimeout,
         },
@@ -205,7 +206,7 @@ export default () => {
     container.bind(DependencyIds.s3Client).toConstantValue(new AWS.S3())
     container.bind(DependencyIds.sqsClient).toConstantValue(
       new AWS.SQS({
-        region: 'ap-southeast-1',
+        region: sqsRegion,
         httpOptions: {
           timeout: sqsTimeout,
         },

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -78,6 +78,7 @@ import JobManagementService from './modules/job/services/JobManagementService'
 import { BulkService } from './modules/bulk/services'
 import { BulkController } from './modules/bulk'
 import { SQSService } from './services/sqs'
+import { JobController } from './modules/job'
 
 function bindIfUnbound<T>(
   dependencyId: symbol,
@@ -109,6 +110,7 @@ export default () => {
   bindIfUnbound(DependencyIds.tagRepository, TagRepository)
   bindIfUnbound(DependencyIds.jobRepository, JobRepository)
   bindIfUnbound(DependencyIds.jobItemRepository, JobItemRepository)
+  bindIfUnbound(DependencyIds.jobController, JobController)
   bindIfUnbound(DependencyIds.cryptography, CryptographyBcrypt)
   bindIfUnbound(DependencyIds.redirectController, RedirectController)
   bindIfUnbound(DependencyIds.gaController, GaController)

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -188,6 +188,10 @@ export default () => {
       .bind(DependencyIds.fileURLPrefix)
       .toConstantValue(`${accessEndpoint}/`)
     container.bind(DependencyIds.s3Client).toConstantValue(s3Client)
+
+    container
+      .bind(DependencyIds.sqsClient)
+      .toConstantValue(new AWS.SQS({ apiVersion: '2012-11-05' }))
   } else {
     container.bind(DependencyIds.fileURLPrefix).toConstantValue('https://')
     container.bind(DependencyIds.s3Client).toConstantValue(new AWS.S3())

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -11,6 +11,7 @@ import {
   linksToRotate,
   ogUrl,
   s3Bucket,
+  sqsTimeout,
   userAnnouncement,
   userMessage,
 } from './config'
@@ -191,15 +192,23 @@ export default () => {
       .toConstantValue(`${accessEndpoint}/`)
     container.bind(DependencyIds.s3Client).toConstantValue(s3Client)
 
-    container
-      .bind(DependencyIds.sqsClient)
-      .toConstantValue(new AWS.SQS({ apiVersion: '2012-11-05' }))
+    container.bind(DependencyIds.sqsClient).toConstantValue(
+      new AWS.SQS({
+        httpOptions: {
+          timeout: sqsTimeout,
+        },
+      }),
+    )
   } else {
     container.bind(DependencyIds.fileURLPrefix).toConstantValue('https://')
     container.bind(DependencyIds.s3Client).toConstantValue(new AWS.S3())
-    container
-      .bind(DependencyIds.sqsClient)
-      .toConstantValue(new AWS.SQS({ apiVersion: '2012-11-05' }))
+    container.bind(DependencyIds.sqsClient).toConstantValue(
+      new AWS.SQS({
+        httpOptions: {
+          timeout: sqsTimeout,
+        },
+      }),
+    )
   }
 
   bindIfUnbound(DependencyIds.s3, S3ServerSide)

--- a/src/server/inversify.config.ts
+++ b/src/server/inversify.config.ts
@@ -77,6 +77,7 @@ import TagManagementService from './modules/user/services/TagManagementService'
 import JobManagementService from './modules/job/services/JobManagementService'
 import { BulkService } from './modules/bulk/services'
 import { BulkController } from './modules/bulk'
+import { SQSService } from './services/sqs'
 
 function bindIfUnbound<T>(
   dependencyId: symbol,
@@ -190,7 +191,11 @@ export default () => {
   } else {
     container.bind(DependencyIds.fileURLPrefix).toConstantValue('https://')
     container.bind(DependencyIds.s3Client).toConstantValue(new AWS.S3())
+    container
+      .bind(DependencyIds.sqsClient)
+      .toConstantValue(new AWS.SQS({ apiVersion: '2012-11-05' }))
   }
 
   bindIfUnbound(DependencyIds.s3, S3ServerSide)
+  bindIfUnbound(DependencyIds.sqsService, SQSService)
 }

--- a/src/server/models/job.ts
+++ b/src/server/models/job.ts
@@ -34,7 +34,7 @@ export interface JobItemType extends IdType, Sequelize.Model {
   readonly status: JobItemStatusEnum
   readonly message: string
   readonly params: JSON
-  readonly jobId: Number
+  readonly jobId: number
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -1,16 +1,11 @@
 import { NextFunction, Request, Response } from 'express'
 import { inject, injectable } from 'inversify'
 import { UploadedFile } from 'express-fileupload'
-import { JobItemStatusEnum } from '../../repositories/enums'
 import jsonMessage from '../../util/json'
 import { DependencyIds } from '../../constants'
 import { BulkService } from './interfaces'
 import { UrlManagementService } from '../user/interfaces'
 import dogstatsd from '../../util/dogstatsd'
-import { SQSServiceInterface } from '../../services/sqs'
-import JobManagementServiceInterface from '../job/interfaces/JobManagementService'
-
-const QR_CODE_BATCH_SIZE = 5
 
 @injectable()
 export class BulkController {
@@ -18,24 +13,14 @@ export class BulkController {
 
   private bulkService: BulkService
 
-  private sqsService: SQSServiceInterface
-
-  private jobManagementService: JobManagementServiceInterface
-
   public constructor(
     @inject(DependencyIds.bulkService)
     bulkService: BulkService,
     @inject(DependencyIds.urlManagementService)
     urlManagementService: UrlManagementService,
-    @inject(DependencyIds.jobManagementService)
-    jobManagementService: JobManagementServiceInterface,
-    @inject(DependencyIds.sqsService)
-    sqsService: SQSServiceInterface,
   ) {
     this.bulkService = bulkService
     this.urlManagementService = urlManagementService
-    this.sqsService = sqsService
-    this.jobManagementService = jobManagementService
   }
 
   public validateAndParseCsv: (
@@ -59,13 +44,15 @@ export class BulkController {
     next()
   }
 
-  public bulkCreate: (req: Request, res: Response) => Promise<void> = async (
-    req,
-    res,
-  ) => {
+  public bulkCreate: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<void> = async (req, res, next) => {
     const { userId, longUrls, tags } = req.body
     // generate url mappings
     const urlMappings = await this.bulkService.generateUrlMappings(longUrls)
+
     // bulk create
     try {
       await this.urlManagementService.bulkCreate(userId, urlMappings, tags)
@@ -75,32 +62,12 @@ export class BulkController {
       return
     }
 
+    // put jobParamsList on the req body so that it can be used by JobController
+    req.body.jobParamsList = urlMappings
+
     dogstatsd.increment('bulk.hash.success', 1, 1)
-
-    console.log('creating job')
-
-    const job = await this.jobManagementService.createJob(userId)
-
-    console.log('job created')
-
-    for (let i = 0; i < urlMappings.length; i += QR_CODE_BATCH_SIZE) {
-      const urlMapping = urlMappings.slice(i, i + QR_CODE_BATCH_SIZE)
-      const sqsBody = { filePath: `${job.uuid}/${1}`, mappings: urlMapping }
-      // eslint-disable-next-line no-await-in-loop
-      await this.jobManagementService.createJobItem({
-        status: JobItemStatusEnum.InProgress,
-        message: '',
-        params: <JSON>(<unknown>sqsBody),
-        jobId: job.id,
-      })
-
-      // validate jobItem -> what happens if jobItem wasn't created?
-
-      // eslint-disable-next-line no-await-in-loop
-      await this.sqsService.sendMessage(sqsBody.filePath, sqsBody.mappings)
-    }
-
     res.ok(jsonMessage(`${urlMappings.length} links created`))
+    next()
   }
 }
 

--- a/src/server/modules/bulk/__tests__/BulkController.test.ts
+++ b/src/server/modules/bulk/__tests__/BulkController.test.ts
@@ -15,7 +15,25 @@ const mockUrlManagementService = {
   getUrlsWithConditions: jest.fn(),
   bulkCreate: jest.fn(),
 }
-const controller = new BulkController(mockBulkService, mockUrlManagementService)
+
+const jobManagementService = {
+  createJob: jest.fn(),
+  findJobById: jest.fn(),
+  createJobItem: jest.fn(),
+  updateJobItem: jest.fn(),
+  findJobItemsByJobId: jest.fn(),
+  getJobStatus: jest.fn(),
+}
+const sqsService = {
+  sendMessage: jest.fn(),
+}
+
+const controller = new BulkController(
+  mockBulkService,
+  mockUrlManagementService,
+  jobManagementService,
+  sqsService,
+)
 
 describe('BulkController unit test', () => {
   describe('validateAndParseCsv tests', () => {
@@ -104,6 +122,9 @@ describe('BulkController unit test', () => {
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockResolvedValue({})
+      jobManagementService.createJob.mockResolvedValue({})
+      jobManagementService.createJobItem.mockResolvedValue({})
+      sqsService.sendMessage.mockResolvedValue({})
 
       await controller.bulkCreate(req, res)
 
@@ -167,6 +188,10 @@ describe('BulkController unit test', () => {
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockResolvedValue({})
+
+      jobManagementService.createJob.mockResolvedValue({})
+      jobManagementService.createJobItem.mockResolvedValue({})
+      sqsService.sendMessage.mockResolvedValue({})
 
       await controller.bulkCreate(req, res)
 

--- a/src/server/modules/bulk/__tests__/BulkController.test.ts
+++ b/src/server/modules/bulk/__tests__/BulkController.test.ts
@@ -16,24 +16,7 @@ const mockUrlManagementService = {
   bulkCreate: jest.fn(),
 }
 
-const jobManagementService = {
-  createJob: jest.fn(),
-  findJobById: jest.fn(),
-  createJobItem: jest.fn(),
-  updateJobItem: jest.fn(),
-  findJobItemsByJobId: jest.fn(),
-  getJobStatus: jest.fn(),
-}
-const sqsService = {
-  sendMessage: jest.fn(),
-}
-
-const controller = new BulkController(
-  mockBulkService,
-  mockUrlManagementService,
-  jobManagementService,
-  sqsService,
-)
+const controller = new BulkController(mockBulkService, mockUrlManagementService)
 
 describe('BulkController unit test', () => {
   describe('validateAndParseCsv tests', () => {
@@ -117,16 +100,14 @@ describe('BulkController unit test', () => {
         body: { userId, longUrls: [longUrl] },
       })
       const res = httpMocks.createResponse() as any
+      const next = jest.fn() as unknown as express.NextFunction
 
       res.badRequest = badRequest
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockResolvedValue({})
-      jobManagementService.createJob.mockResolvedValue({})
-      jobManagementService.createJobItem.mockResolvedValue({})
-      sqsService.sendMessage.mockResolvedValue({})
 
-      await controller.bulkCreate(req, res)
+      await controller.bulkCreate(req, res, next)
 
       expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
@@ -136,6 +117,7 @@ describe('BulkController unit test', () => {
       )
       expect(res.badRequest).not.toHaveBeenCalled()
       expect(res.ok).toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
 
     it('bulkCreate without tags responds with error if urls are not created', async () => {
@@ -150,13 +132,14 @@ describe('BulkController unit test', () => {
 
       const req = httpMocks.createRequest({ body: { userId, longUrls } })
       const res = httpMocks.createResponse() as any
+      const next = jest.fn() as unknown as express.NextFunction
 
       res.badRequest = badRequest
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockRejectedValue({})
 
-      await controller.bulkCreate(req, res)
+      await controller.bulkCreate(req, res, next)
 
       expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
@@ -166,6 +149,7 @@ describe('BulkController unit test', () => {
       )
       expect(res.badRequest).toHaveBeenCalled()
       expect(res.ok).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
     })
 
     it('bulkCreate with tags should return success if urls are created', async () => {
@@ -183,17 +167,14 @@ describe('BulkController unit test', () => {
         body: { userId, longUrls: [longUrl], tags },
       })
       const res = httpMocks.createResponse() as any
+      const next = jest.fn() as unknown as express.NextFunction
 
       res.badRequest = badRequest
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockResolvedValue({})
 
-      jobManagementService.createJob.mockResolvedValue({})
-      jobManagementService.createJobItem.mockResolvedValue({})
-      sqsService.sendMessage.mockResolvedValue({})
-
-      await controller.bulkCreate(req, res)
+      await controller.bulkCreate(req, res, next)
 
       expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
@@ -203,6 +184,7 @@ describe('BulkController unit test', () => {
       )
       expect(res.badRequest).not.toHaveBeenCalled()
       expect(res.ok).toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
 
     it('bulkCreate with tags responds with error if urls are not created', async () => {
@@ -218,13 +200,14 @@ describe('BulkController unit test', () => {
 
       const req = httpMocks.createRequest({ body: { userId, longUrls, tags } })
       const res = httpMocks.createResponse() as any
+      const next = jest.fn() as unknown as express.NextFunction
 
       res.badRequest = badRequest
       res.ok = ok
       mockBulkService.generateUrlMappings.mockResolvedValue(urlMappings)
       mockUrlManagementService.bulkCreate.mockRejectedValue({})
 
-      await controller.bulkCreate(req, res)
+      await controller.bulkCreate(req, res, next)
 
       expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
@@ -234,6 +217,7 @@ describe('BulkController unit test', () => {
       )
       expect(res.badRequest).toHaveBeenCalled()
       expect(res.ok).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/server/modules/job/JobController.ts
+++ b/src/server/modules/job/JobController.ts
@@ -1,0 +1,53 @@
+import { Request } from 'express'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import { DependencyIds } from '../../constants'
+import dogstatsd from '../../util/dogstatsd'
+import { SQSServiceInterface } from '../../services/sqs'
+import { JobManagementService } from './interfaces'
+
+@injectable()
+export class JobController {
+  private sqsService: SQSServiceInterface
+
+  private jobManagementService: JobManagementService
+
+  public constructor(
+    @inject(DependencyIds.jobManagementService)
+    jobManagementService: JobManagementService,
+    @inject(DependencyIds.sqsService)
+    sqsService: SQSServiceInterface,
+  ) {
+    this.sqsService = sqsService
+    this.jobManagementService = jobManagementService
+  }
+
+  public createAndStartJob: (req: Request) => Promise<void> = async (req) => {
+    const jobBatchSize = 5 // temp
+    const { userId, jobParamsList } = req.body
+    const jobBatches = _.chunk(jobParamsList, jobBatchSize)
+    try {
+      const job = await this.jobManagementService.createJob(userId)
+
+      await Promise.all(
+        jobBatches.map(async (jobBatch, idx) => {
+          const messageParams = {
+            jobItemId: `${job.uuid}/${idx}`,
+            mappings: jobBatch,
+          }
+          await this.jobManagementService.createJobItem({
+            params: <JSON>(<unknown>messageParams),
+            jobId: job.id,
+          })
+          await this.sqsService.sendMessage(messageParams)
+          return
+        }),
+      )
+      dogstatsd.increment('job.start.success', 1, 1)
+    } catch (e) {
+      dogstatsd.increment('job.start.failure', 1, 1)
+    }
+  }
+}
+
+export default JobController

--- a/src/server/modules/job/JobController.ts
+++ b/src/server/modules/job/JobController.ts
@@ -5,7 +5,7 @@ import { DependencyIds } from '../../constants'
 import dogstatsd from '../../util/dogstatsd'
 import { SQSServiceInterface } from '../../services/sqs'
 import { JobManagementService } from './interfaces'
-import { qrCodeJobBatchSize } from '../../config'
+import { logger, qrCodeJobBatchSize } from '../../config'
 
 @injectable()
 export class JobController {
@@ -49,6 +49,7 @@ export class JobController {
       )
       dogstatsd.increment('job.start.success', 1, 1)
     } catch (e) {
+      logger.error(`error creating and starting job: ${e}`)
       dogstatsd.increment('job.start.failure', 1, 1)
     }
   }

--- a/src/server/modules/job/JobController.ts
+++ b/src/server/modules/job/JobController.ts
@@ -5,6 +5,7 @@ import { DependencyIds } from '../../constants'
 import dogstatsd from '../../util/dogstatsd'
 import { SQSServiceInterface } from '../../services/sqs'
 import { JobManagementService } from './interfaces'
+import { qrCodeJobBatchSize } from '../../config'
 
 @injectable()
 export class JobController {
@@ -23,9 +24,12 @@ export class JobController {
   }
 
   public createAndStartJob: (req: Request) => Promise<void> = async (req) => {
-    const jobBatchSize = 5 // temp
     const { userId, jobParamsList } = req.body
-    const jobBatches = _.chunk(jobParamsList, jobBatchSize)
+    if (!jobParamsList || jobParamsList.length === 0) {
+      return
+    }
+
+    const jobBatches = _.chunk(jobParamsList, qrCodeJobBatchSize)
     try {
       const job = await this.jobManagementService.createJob(userId)
 

--- a/src/server/modules/job/index.ts
+++ b/src/server/modules/job/index.ts
@@ -1,0 +1,1 @@
+export { JobController, JobController as default } from './JobController'

--- a/src/server/services/sqs.ts
+++ b/src/server/services/sqs.ts
@@ -1,0 +1,35 @@
+import { inject, injectable } from 'inversify'
+import { SQS } from 'aws-sdk'
+import { DependencyIds } from '../constants'
+import { sqsBulkQRCodeStartUrl } from '../config'
+import { BulkUrlMapping } from '../repositories/types'
+
+export interface SQSServiceInterface {
+  sendMessage(filePath: string, mappings: BulkUrlMapping[]): Promise<void>
+}
+
+@injectable()
+export class SQSService implements SQSServiceInterface {
+  private sqsClient: SQS
+
+  constructor(@inject(DependencyIds.sqsClient) sqsClient: SQS) {
+    this.sqsClient = sqsClient
+  }
+
+  sendMessage: (filePath: string, mappings: BulkUrlMapping[]) => Promise<void> =
+    async (filePath, mappings) => {
+      await this.sqsClient.sendMessage(
+        {
+          MessageBody: JSON.stringify({ filePath, mappings }),
+          QueueUrl: sqsBulkQRCodeStartUrl,
+        },
+        (err, data) => {
+          if (err) {
+            console.log(`SQS sendMessage error: ${err}`)
+          } else {
+            console.log(`SQS sendMessage success, messageId: ${data.MessageId}`)
+          }
+        },
+      )
+    }
+}


### PR DESCRIPTION
## Context

This PR adds logic to create and send out jobs to the QR code generation Lambda via SQS. 

The logic is as follows:
- After the url mappings have been created, url mappings are sent to the JobController
- JobController creates a Job,
- Job Controller batches the url mappings into several JobItems belonging to that Job 
  - for batch size of 100, 919 mappings will be split into 10 JobItems belonging to 1 Job, 9 JobItems with 100 mappings each and 1 JobItem with 19
- JobController will start these JobItems by sending it via SQS to QR code generation Lambda 

## Details

### SQS authentication
We have added security rules on the SQS queue so that only the EB IAM role is able to send incoming messages to the queue.

We experimented with VPC endpoints to secure the traffic between EB and SQS, but the VPC endpoint caused the EB deployments to fail. See https://stackoverflow.com/questions/55458492/create-aws-vpc-endpoint-for-sqs. After debugging for hours, we realised it was simpler to use the NAT gateway already attached to our private VPC security group to allow for outbound internet connections to the SQS queue. 

### Local development
Currently this feature does not work locally as there's no local stack set up yet. This is a lower priority task and will be tackled at the end.

## Tests

_What tests should be run to confirm functionality?_

- Deploy to staging,
- On Health staging (not configured on Edu and Go yet), create a bulk upload via Postman API
- You should be able to see the following
  - New job and job items should be created on health-staging DB jobs table and job_items table. (Check the job uuid, you'll need it for later)
  - SQS health-staging-bulk-qrcode-generate-start should receive the job item messages
  - Lambda health-staging-bulk-qrcode-generation should be triggered (can see invocations via Cloudwatch)
  - S3 bucket should have the newly generated files stored under job uuid from the DB table

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:
- `SQS_BULK_QRCODE_GENERATE_START_URL`
- `SQS_TIMEOUT`
- `SQS_REGION`
- `BULK_QR_CODE_BATCH_SIZE`