### PR TITLE
fix: disallow updating files for links and links for files

### DIFF
--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -5,7 +5,11 @@ import Sequelize from 'sequelize'
 import { logger } from '../../../config'
 import { DependencyIds } from '../../../constants'
 import jsonMessage from '../../../util/json'
-import { AlreadyExistsError, NotFoundError } from '../../../util/error'
+import {
+  AlreadyExistsError,
+  InvalidUrlUpdateError,
+  NotFoundError,
+} from '../../../util/error'
 
 import { UrlManagementService } from '../../user/interfaces'
 import { MessageType } from '../../../../shared/util/messages'
@@ -90,6 +94,10 @@ export class ApiV1Controller {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.forbidden(jsonMessage(error.message))
+        return
+      }
+      if (error instanceof InvalidUrlUpdateError) {
+        res.badRequest(jsonMessage(error.message))
         return
       }
       logger.error(`Error editing URL:\t${error}`)

--- a/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
+++ b/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
@@ -3,7 +3,11 @@ import httpMocks from 'node-mocks-http'
 import { ValidationError } from 'sequelize'
 import { createRequestWithUser } from '../../../../../../test/server/api/util'
 import { UrlV1Mapper } from '../../../../mappers/UrlV1Mapper'
-import { AlreadyExistsError, NotFoundError } from '../../../../util/error'
+import {
+  AlreadyExistsError,
+  InvalidUrlUpdateError,
+  NotFoundError,
+} from '../../../../util/error'
 import { ApiV1Controller } from '../ApiV1Controller'
 
 const urlManagementService = {
@@ -228,6 +232,21 @@ describe('ApiV1Controller', () => {
       res.badRequest = jest.fn()
 
       urlManagementService.updateUrl.mockRejectedValue(new Error())
+
+      await controller.updateUrl(req, res)
+      expect(res.badRequest).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
+    })
+
+    it('reports bad request on InvalidUrlUpdateError', async () => {
+      const req = createRequestWithUser(undefined)
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
+
+      urlManagementService.updateUrl.mockRejectedValue(
+        new InvalidUrlUpdateError(''),
+      )
 
       await controller.updateUrl(req, res)
       expect(res.badRequest).toHaveBeenCalledWith({

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -8,6 +8,7 @@ import { DependencyIds } from '../../constants'
 import {
   AlreadyExistsError,
   AlreadyOwnLinkError,
+  InvalidUrlUpdateError,
   NotFoundError,
 } from '../../util/error'
 import { MessageType } from '../../../shared/util/messages'
@@ -153,6 +154,10 @@ export class UserController {
     } catch (error) {
       if (error instanceof NotFoundError) {
         res.forbidden(jsonMessage(error.message))
+        return
+      }
+      if (error instanceof InvalidUrlUpdateError) {
+        res.badRequest(jsonMessage(error.message))
         return
       }
       logger.error(`Error editing URL:\t${error}`)

--- a/src/server/modules/user/__tests__/UserController.test.ts
+++ b/src/server/modules/user/__tests__/UserController.test.ts
@@ -11,7 +11,11 @@ import {
 } from '../../../../../test/server/api/util'
 
 import { UserController } from '../UserController'
-import { AlreadyExistsError, NotFoundError } from '../../../util/error'
+import {
+  AlreadyExistsError,
+  InvalidUrlUpdateError,
+  NotFoundError,
+} from '../../../util/error'
 
 const urlManagementService = {
   createUrl: jest.fn(),
@@ -268,6 +272,21 @@ describe('UserController', () => {
           description,
         },
       )
+    })
+
+    it('reports bad request on InvalidUrlUpdateError', async () => {
+      const req = createRequestWithUser(undefined)
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
+
+      urlManagementService.updateUrl.mockRejectedValue(
+        new InvalidUrlUpdateError(''),
+      )
+
+      await controller.updateUrl(req, res)
+      expect(res.badRequest).toHaveBeenCalledWith({
+        message: expect.any(String),
+      })
     })
 
     it('reports bad request on Error', async () => {

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -16,6 +16,7 @@ import dogstatsd, {
 import {
   AlreadyExistsError,
   AlreadyOwnLinkError,
+  InvalidUrlUpdateError,
   NotFoundError,
 } from '../../../util/error'
 import { StorableUrlSource } from '../../../repositories/enums'
@@ -118,6 +119,10 @@ export class UrlManagementService implements interfaces.UrlManagementService {
 
     if (!url) {
       throw new NotFoundError(`Short link "${shortUrl}" not found for user.`)
+    } else if (url.isFile && options.longUrl) {
+      throw new InvalidUrlUpdateError(`Cannot update longUrl for file.`)
+    } else if (!url.isFile && options.file) {
+      throw new InvalidUrlUpdateError(`Cannot update file for link.`)
     }
 
     const storableFile: StorableFile | undefined = file

--- a/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
+++ b/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
@@ -141,12 +141,18 @@ describe('UrlManagementService', () => {
 
   describe('updateUrl', () => {
     const userId = 2
-    const url = { shortUrl: 'abcdef' }
+    const linkUrl = { shortUrl: 'abcdef', isFile: false }
+    const fileUrl = { shortUrl: 'abcdef', isFile: true }
     const options = {
       longUrl: 'https://www.agency.gov.sg',
       state: undefined,
       description: 'An agency',
       contactEmail: 'contact-us@agency.gov.sg',
+    }
+    const file = {
+      data: Buffer.from(''),
+      name: 'file.json',
+      mimetype: 'application/json',
     }
 
     beforeEach(() => {
@@ -157,54 +163,82 @@ describe('UrlManagementService', () => {
     it('throws NotFoundError on no url', async () => {
       userRepository.findOneUrlForUser.mockResolvedValue(null)
       await expect(
-        service.updateUrl(userId, url.shortUrl, options),
+        service.updateUrl(userId, linkUrl.shortUrl, options),
       ).rejects.toBeInstanceOf(NotFoundError)
       expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
         userId,
-        url.shortUrl,
+        linkUrl.shortUrl,
+      )
+      expect(urlRepository.update).not.toHaveBeenCalled()
+    })
+
+    it('throws Error when updating file with longUrl', async () => {
+      userRepository.findOneUrlForUser.mockResolvedValue(fileUrl)
+      await expect(
+        service.updateUrl(userId, fileUrl.shortUrl, {
+          longUrl: 'https://example.com',
+        }),
+      ).rejects.toBeInstanceOf(Error)
+      expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
+        userId,
+        fileUrl.shortUrl,
+      )
+      expect(urlRepository.update).not.toHaveBeenCalled()
+    })
+
+    it('throws Error when updating link with file', async () => {
+      userRepository.findOneUrlForUser.mockResolvedValue(linkUrl)
+      await expect(
+        service.updateUrl(userId, linkUrl.shortUrl, { file }),
+      ).rejects.toBeInstanceOf(Error)
+      expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
+        userId,
+        linkUrl.shortUrl,
       )
       expect(urlRepository.update).not.toHaveBeenCalled()
     })
 
     it('updates a non-file url', async () => {
-      userRepository.findOneUrlForUser.mockResolvedValue(url)
-      urlRepository.update.mockResolvedValue(url)
+      userRepository.findOneUrlForUser.mockResolvedValue(linkUrl)
+      urlRepository.update.mockResolvedValue(linkUrl)
       await expect(
-        service.updateUrl(userId, url.shortUrl, {
+        service.updateUrl(userId, linkUrl.shortUrl, {
           ...options,
           file: undefined,
         }),
-      ).resolves.toStrictEqual(url)
+      ).resolves.toStrictEqual(linkUrl)
       expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
         userId,
-        url.shortUrl,
+        linkUrl.shortUrl,
       )
-      expect(urlRepository.update).toHaveBeenCalledWith(url, options, undefined)
+      expect(urlRepository.update).toHaveBeenCalledWith(
+        linkUrl,
+        options,
+        undefined,
+      )
     })
 
     it('updates a file url', async () => {
-      const file = {
-        data: Buffer.from(''),
-        name: 'file.json',
-        mimetype: 'application/json',
-      }
-      userRepository.findOneUrlForUser.mockResolvedValue(url)
-      urlRepository.update.mockResolvedValue(url)
+      userRepository.findOneUrlForUser.mockResolvedValue(fileUrl)
+      urlRepository.update.mockResolvedValue(fileUrl)
       await expect(
-        service.updateUrl(userId, url.shortUrl, {
-          ...options,
+        service.updateUrl(userId, fileUrl.shortUrl, {
           file,
         }),
-      ).resolves.toStrictEqual(url)
+      ).resolves.toStrictEqual(fileUrl)
       expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
         userId,
-        url.shortUrl,
+        fileUrl.shortUrl,
       )
-      expect(urlRepository.update).toHaveBeenCalledWith(url, options, {
-        data: file.data,
-        key: `${url.shortUrl}.json`,
-        mimetype: file.mimetype,
-      })
+      expect(urlRepository.update).toHaveBeenCalledWith(
+        fileUrl,
+        {},
+        {
+          data: file.data,
+          key: `${fileUrl.shortUrl}.json`,
+          mimetype: file.mimetype,
+        },
+      )
     })
   })
 

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -8,6 +8,14 @@ export class NotFoundError extends Error {
   }
 }
 
+export class InvalidUrlUpdateError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidUrlUpdateError'
+    Object.setPrototypeOf(this, InvalidUrlUpdateError.prototype)
+  }
+}
+
 export class InvalidOtpError extends Error {
   public retries: number
 


### PR DESCRIPTION
## Problem

One can manually submit a request (`PATCH /api/user/url`) to update the `longUrl` for a file, or the `file` for a link. This should not be allowed.

<img width="930" alt="Screenshot 2022-11-16 at 11 25 32 AM" src="https://user-images.githubusercontent.com/41856541/202076169-eabe0423-1ce9-4d08-9281-59aa18b5d929.png">


## Solution

Disallow updating files for links and links for files at the service layer, depending on the `isFile` field of the URL.
- Return a 400 bad request on the user and API controller when encountering this error
- Created a new error type `InvalidUrlUpdateError` for this, because it didn't seem to fall under any existing error type - not sure of my approach though, happy to modify where necessary
