### PR TITLE
chore: change default session cookie max age to 1 day

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ After these have been set up, set the environment variables according to the tab
 |SAFE_BROWSING_KEY|No|API key for access to Google Safe Browsing.|
 |SAFE_BROWSING_LOG_ONLY|No|Boolean, whether to log only, or throw error if unsafe link is found by Google SafeBrowsing. Defaults to false|
 |ASSET_VARIANT|Yes|Asset variant specifying environment for deployment, one of `gov`, `edu`, `health`|
-|COOKIE_MAX_AGE|Yes|Session duration of cookie|
+|COOKIE_MAX_AGE|No|Session duration of cookie in milliseconds. Defaults to 86400000 (1 day)|
 |BULK_UPLOAD_MAX_NUM|No|Maximum number of links that can be bulk uploaded at once. Defaults to 1000|
 |BULK_UPLOAD_RANDOM_STR_LENGTH|No|String length of randomly generated shortUrl in bulk upload. Defaults to 8|
 |API_LINK_RANDOM_STR_LENGTH|No|String length of randomly generated shortUrl in API created links. Defaults to 8|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - GA_TRACKING_ID=UA-139330318-1
       - OG_URL=https://go.gov.sg
       - VALID_EMAIL_GLOB_EXPRESSION=*.gov.sg
+      - COOKIE_MAX_AGE=86400000
       - LOGIN_MESSAGE=Your OTP might take awhile to get to you.
       - USER_MESSAGE=User message test
       - ANNOUNCEMENT_MESSAGE=Search by email to find link owners, or by keyword to discover other links! \n PRO TIP! Search your email domain to find out all the links made by your agency.

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -111,12 +111,14 @@ transporterOpts = {
   maxConnections: 20,
 }
 
+const maxAge = Number(process.env.COOKIE_MAX_AGE) || 86400000 // milliseconds = 1 day
+
 if (DEV_ENV) {
   // Only configure things particular to development here
   logger.warn('Deploying in development mode.')
   cookieConfig = {
     secure: false, // do not set domain for localhost
-    maxAge: 1800000, // milliseconds = 30 min
+    maxAge,
   }
   proxy = false
   otpLimit = 10
@@ -126,10 +128,9 @@ if (DEV_ENV) {
 } else {
   logger.info('Deploying in production mode.')
 
-  const maxAge = Number(process.env.COOKIE_MAX_AGE)
   cookieConfig = {
     secure: true,
-    maxAge: Number.isNaN(maxAge) ? 1800000 : maxAge,
+    maxAge,
   }
   exitIfAnyMissing(sesVars)
 


### PR DESCRIPTION
## Problem

It's really tiring for devs to have to log in again every 30 mins

## Solution

Change the default `COOKIE_MAX_AGE` from 1800000 (30 mins) to 86400000 (1 day) in `docker-compose.yml`.
- `COOKIE_MAX_AGE` is already set to 86400000 on gov/edu/health prod, so there will be no change at all to production
- I could not find any history as to why `COOKIE_MAX_AGE` was set at 30 mins 3 years ago, but since prod already overrides this to 1 day anyway, I figure that bumping everything to 1 day by default is fine
