### PR TITLE
feat(api): disable closing api modal on click out

### DIFF
--- a/src/client/apiintegration/components/ApiKeyModal/index.tsx
+++ b/src/client/apiintegration/components/ApiKeyModal/index.tsx
@@ -82,7 +82,6 @@ const ApiKeyModal: FunctionComponent = () => {
       fullScreen={false}
       fullWidth
       maxWidth="sm"
-      onClose={closeApiKeyModal}
       open={apiKeyModal}
     >
       <div className={classes.modalWrapper}>
@@ -128,9 +127,7 @@ const ApiKeyModal: FunctionComponent = () => {
         />
         <Button
           className={classes.copyApiKeyButton}
-          onClick={() => {
-            dispatch(apiActions.closeApiKeyModal())
-          }}
+          onClick={closeApiKeyModal}
           variant="contained"
           fullWidth={false}
         >


### PR DESCRIPTION
## Problem

The user may accidentally click out of the API key modal, which closes it before they have confirmed saving the API key. See notion issue description [here](https://www.notion.so/opengov/Bug-Staging-key-starts-with-live-fba9622a73cd49e687363e383c9a637a)

## Solution

Disable closing the API key modal when the user clicks out from the modal.
