### PR TITLE
feat(api): amend header spacing on api integration page

### DIFF
--- a/src/client/apiintegration/components/ApiKeyGraphic/index.tsx
+++ b/src/client/apiintegration/components/ApiKeyGraphic/index.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) =>
       flexDirection: 'column',
       marginTop: theme.spacing(3),
       [theme.breakpoints.up('md')]: {
-        marginTop: theme.spacing(6),
+        marginTop: theme.spacing(4),
       },
     },
     configOptionWrapper: {

--- a/src/client/apiintegration/index.tsx
+++ b/src/client/apiintegration/index.tsx
@@ -16,8 +16,8 @@ const useStyles = makeStyles((theme) =>
     apiIntegrationHeader: {
       flexGrow: 1,
       flexShrink: 0,
-      alignSelf: 'left',
       marginRight: 20,
+      marginTop: theme.spacing(4),
       whiteSpace: 'nowrap',
       [theme.breakpoints.down('sm')]: {
         order: 10,


### PR DESCRIPTION
## Problem

The header spacing on the API integration page is a little bit wonky, see [Notion issue](https://www.notion.so/opengov/Bug-API-Key-title-spacing-e724ea917f95408e8ff05ed2d1830571)

## Solution

**Features**:

- Adjusted the header spacing so it looks a little better

**Improvements**:

- Removed the `align-self` property, which does not affect the layout (devtools also says that `left` is not a valid value)

## Before & After Screenshots

**BEFORE**:

Desktop:
![Screenshot 2022-11-22 at 11 47 59 AM](https://user-images.githubusercontent.com/41856541/203216581-d7121e82-6dbc-4f75-a962-6dd471dc5c32.png)

Mobile:
![Screenshot 2022-11-22 at 11 47 12 AM](https://user-images.githubusercontent.com/41856541/203216479-c062d5b3-18db-4a07-9486-41786894ffc8.png)

**AFTER**:

Desktop:
![Screenshot 2022-11-22 at 11 46 40 AM](https://user-images.githubusercontent.com/41856541/203216393-632cfd96-e435-48ca-b592-5d5b840fba3a.png)

Mobile view remains entirely unchanged