### PR TITLE
fix: set apiEnv according to DD_ENV instead of NODE_ENV

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -249,7 +249,7 @@ export const bulkUploadRandomStrLength: number =
 
 export const apiKeyVersion: string = process.env.API_KEY_VERSION || 'v1'
 export const apiEnv: string =
-  process.env.NODE_ENV === 'production' ? 'live' : 'test'
+  process.env.DD_ENV === 'production' ? 'live' : 'test'
 export const apiKeySalt = process.env.API_KEY_SALT as string
 export const apiLinkRandomStrLength: number =
   Number(process.env.API_LINK_RANDOM_STR_LENGTH) || 8


### PR DESCRIPTION
## Problem

NODE_ENV is set to production in both Staging and Production environment, causing apiEnv to have `live_` prefix in both staging and prd


## Solution

To make apiEnv to rely DD_ENV instead.