### PR TITLE
test(api): add integration tests for external api urls

### DIFF
--- a/test/integration/api/external-v1/Urls.test.ts
+++ b/test/integration/api/external-v1/Urls.test.ts
@@ -1,0 +1,273 @@
+import FormData from 'form-data'
+import { API_EXTERNAL_V1_URLS, SMALL_TEXT_FILE_PATH } from '../../config'
+import {
+  DATETIME_REGEX,
+  createIntegrationTestUser,
+  deleteIntegrationTestUser,
+  generateRandomString,
+  readFile,
+} from '../../util/helpers'
+import { get, patch, postFormData, postJson } from '../../util/requests'
+
+async function createLinkUrl(
+  link: {
+    shortUrl?: string
+    longUrl?: string
+  },
+  apiKey: string,
+) {
+  const res = await postJson(API_EXTERNAL_V1_URLS, link, undefined, apiKey)
+  return res
+}
+
+async function createFileUrl(shortUrl: string, apiKey: string) {
+  const formData = new FormData()
+  const smallTextFile = readFile(SMALL_TEXT_FILE_PATH)
+  formData.append('file', smallTextFile)
+  formData.append('shortUrl', shortUrl)
+  const res = await postFormData(
+    API_EXTERNAL_V1_URLS,
+    formData,
+    undefined,
+    apiKey,
+  )
+  return res
+}
+
+async function updateLinkUrl(
+  link: { shortUrl: string; longUrl?: string; state?: string },
+  apiKey: string,
+) {
+  const { shortUrl, longUrl, state } = link
+  const res = await patch(
+    `${API_EXTERNAL_V1_URLS}/${shortUrl}`,
+    {
+      longUrl,
+      state,
+    },
+    undefined,
+    apiKey,
+  )
+  return res
+}
+
+/**
+ * Integration tests for URLs.
+ */
+describe('Url integration tests', () => {
+  let email: string
+  let apiKey: string
+  const longUrl = 'https://example.com'
+
+  beforeEach(async () => {
+    ;({ email, apiKey } = await createIntegrationTestUser())
+  })
+
+  afterEach(async () => {
+    await deleteIntegrationTestUser(email)
+  })
+
+  it('should be able to get urls', async () => {
+    const res = await get(API_EXTERNAL_V1_URLS, undefined, apiKey)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toBeTruthy()
+    expect(json).toEqual({
+      urls: [],
+      count: 0,
+    })
+  })
+
+  it('should not be able to get urls without API key header', async () => {
+    const res = await get(API_EXTERNAL_V1_URLS)
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json).toBeTruthy()
+    expect(json).toEqual({
+      message: 'Authorization header is missing',
+    })
+  })
+
+  it('should not be able to get urls with invalid API key', async () => {
+    const res = await get(
+      API_EXTERNAL_V1_URLS,
+      undefined,
+      'this-is-an-invalid-api-key',
+    )
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json).toBeTruthy()
+    expect(json).toEqual({
+      message: 'Invalid API Key',
+    })
+  })
+
+  it('should be able to create link url with shortUrl and longUrl', async () => {
+    const shortUrl = await generateRandomString(6)
+    const res = await createLinkUrl({ shortUrl, longUrl }, apiKey)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      shortUrl,
+      longUrl,
+      clicks: 0,
+      state: 'ACTIVE',
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+  })
+
+  it('should be able to create link url with longUrl but not shortUrl', async () => {
+    const res = await createLinkUrl({ longUrl }, apiKey)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      shortUrl: expect.stringMatching(/^[a-z0-9]{8}$/),
+      longUrl,
+      clicks: 0,
+      state: 'ACTIVE',
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+  })
+
+  it('should not be able to create link url with neither longUrl nor shortUrl', async () => {
+    const res = await createLinkUrl({}, apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({
+      message: 'ValidationError: "longUrl" is required',
+    })
+  })
+
+  it('should not be able to create link url with invalid longUrl', async () => {
+    const invalidLongUrl = 'this-is-an-invalid-url'
+    const res = await createLinkUrl({ longUrl: invalidLongUrl }, apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({
+      message: 'ValidationError: Long url must start with https://',
+    })
+  })
+
+  it('should not be able to create link url with invalid shortUrl', async () => {
+    const invalidShortUrl = 'foo%bar'
+    const res = await createLinkUrl(
+      { shortUrl: invalidShortUrl, longUrl },
+      apiKey,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({
+      message: 'ValidationError: Short url format is invalid.',
+    })
+  })
+
+  it('should not be able to create file url', async () => {
+    const shortUrl = await generateRandomString(6)
+    const res = await createFileUrl(shortUrl, apiKey)
+    expect(res.status).toBe(400)
+  })
+
+  it('should be able to update link url with new longUrl and state', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const newLongUrl = 'https://myspace.com'
+    const newState = 'INACTIVE'
+    const res = await updateLinkUrl(
+      { shortUrl, longUrl: newLongUrl, state: newState },
+      apiKey,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      shortUrl,
+      longUrl: newLongUrl,
+      clicks: 0,
+      state: newState,
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+
+    // Should be able to get updated link URL
+    const newRes = await get(API_EXTERNAL_V1_URLS, undefined, apiKey)
+    expect(newRes.status).toBe(200)
+    const newBody = await newRes.json()
+    expect(newBody).toEqual({
+      urls: [
+        {
+          shortUrl,
+          longUrl: newLongUrl,
+          state: newState,
+          clicks: 0,
+          createdAt: expect.stringMatching(DATETIME_REGEX),
+          updatedAt: expect.stringMatching(DATETIME_REGEX),
+        },
+      ],
+      count: 1,
+    })
+  })
+
+  it('should be able to update link url with new longUrl', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const newLongUrl = 'https://myspace.com'
+    const res = await updateLinkUrl({ shortUrl, longUrl: newLongUrl }, apiKey)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      shortUrl,
+      longUrl: newLongUrl,
+      clicks: 0,
+      state: 'ACTIVE',
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+  })
+
+  it('should be able to update link url with new state', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const newState = 'INACTIVE'
+    const res = await updateLinkUrl({ shortUrl, state: newState }, apiKey)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      shortUrl,
+      longUrl,
+      clicks: 0,
+      state: newState,
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+  })
+
+  it('should not be able to update link url with invalid new longUrl', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const newLongUrl = 'this-is-an-invalid-url'
+    const res = await updateLinkUrl({ shortUrl, longUrl: newLongUrl }, apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({
+      message: 'ValidationError: Long url must start with https://',
+    })
+  })
+
+  it('should not be able to update link url with invalid new state', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const newState = 'inACTIVE'
+    const res = await updateLinkUrl({ shortUrl, state: newState }, apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({
+      message: 'ValidationError: "state" must be one of [ACTIVE, INACTIVE]',
+    })
+  })
+})

--- a/test/integration/api/external-v1/Urls.test.ts
+++ b/test/integration/api/external-v1/Urls.test.ts
@@ -146,7 +146,7 @@ describe('Url integration tests', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body).toEqual({
-      message: 'ValidationError: Long url must start with https://',
+      message: 'ValidationError: Only HTTPS URLs are allowed.',
     })
   })
 
@@ -159,7 +159,7 @@ describe('Url integration tests', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body).toEqual({
-      message: 'ValidationError: Short url format is invalid.',
+      message: 'ValidationError: Short URL format is invalid.',
     })
   })
 
@@ -254,7 +254,7 @@ describe('Url integration tests', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body).toEqual({
-      message: 'ValidationError: Long url must start with https://',
+      message: 'ValidationError: Only HTTPS URLs are allowed.',
     })
   })
 

--- a/test/integration/api/user/Urls.test.ts
+++ b/test/integration/api/user/Urls.test.ts
@@ -4,7 +4,7 @@ import {
   IMAGE_FILE_PATH,
   LOCAL_BUCKET_URL,
   SMALL_TEXT_FILE_PATH,
-} from './config'
+} from '../../config'
 import {
   DATETIME_REGEX,
   createIntegrationTestUser,
@@ -12,14 +12,14 @@ import {
   generateRandomString,
   getAuthCookie,
   readFile,
-} from './util/helpers'
+} from '../../util/helpers'
 import {
   get,
   patch,
   patchFormData,
   postFormData,
   postJson,
-} from './util/requests'
+} from '../../util/requests'
 
 async function createLinkUrl(
   shortUrl: string,
@@ -48,7 +48,7 @@ describe('Url integration tests', () => {
   const longUrl = 'https://example.com'
 
   beforeEach(async () => {
-    email = await createIntegrationTestUser()
+    ;({ email } = await createIntegrationTestUser())
     authCookie = await getAuthCookie(email)
   })
 

--- a/test/integration/config.ts
+++ b/test/integration/config.ts
@@ -7,9 +7,12 @@ export const LARGE_TEXT_FILE_PATH = './test/integration/assets/large-file.txt'
 export const IMAGE_FILE_PATH = './test/integration/assets/go-logo.png'
 
 export const API_USER_URL = 'http://localhost:8080/api/user/url'
+export const API_EXTERNAL_V1_URLS = 'http://localhost:8080/api/v1/urls'
 export const API_LOGIN_OTP = 'http://localhost:8080/api/login/otp'
 export const API_LOGIN_VERIFY = 'http://localhost:8080/api/login/verify'
 
 export const LOCAL_EMAIL_URL = 'http://localhost:1080/email'
 
 export const LOCAL_BUCKET_URL = 'http://localhost:4566/local-bucket'
+
+export const API_KEY_SALT = '$2b$10$9rBKuE4Gb5ravnvP4xjoPu'

--- a/test/integration/util/db.ts
+++ b/test/integration/util/db.ts
@@ -6,15 +6,18 @@ const sequelize = new Sequelize.Sequelize(DB_URI, {
   timezone: '+08:00',
 })
 
-export const createDbUser = async (email: string): Promise<void> => {
+export const createDbUser = async (
+  email: string,
+  apiKeyHash: string,
+): Promise<void> => {
   try {
-    // Create integration test user with given email
+    // Create integration test user with given email and apiKeyHash
     await sequelize.query(
       `
-      INSERT INTO users ("email", "createdAt", "updatedAt") SELECT :email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      INSERT INTO users ("email", "createdAt", "updatedAt", "apiKeyHash") SELECT :email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, :apiKeyHash
       WHERE NOT EXISTS (SELECT * FROM users WHERE "email"=:email);
     `,
-      { replacements: { email } },
+      { replacements: { email, apiKeyHash } },
     )
   } catch (e) {
     throw new Error(

--- a/test/integration/util/requests.ts
+++ b/test/integration/util/requests.ts
@@ -1,7 +1,12 @@
 import fetch from 'cross-fetch'
 import FormData from 'form-data'
 
-export const postJson = (url: string, data: object, authCookie?: string) => {
+export const postJson = (
+  url: string,
+  data: object,
+  authCookie?: string,
+  apiKey?: string,
+) => {
   const opts: RequestInit = {
     method: 'POST',
     mode: 'same-origin',
@@ -10,6 +15,7 @@ export const postJson = (url: string, data: object, authCookie?: string) => {
     headers: {
       'Content-Type': 'application/json',
       ...(authCookie && { Cookie: authCookie }),
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     },
     body: JSON.stringify(data),
   }
@@ -20,6 +26,7 @@ export const postFormData = (
   url: string,
   data: FormData,
   authCookie?: string,
+  apiKey?: string,
 ) => {
   const opts: RequestInit = {
     method: 'POST',
@@ -28,13 +35,19 @@ export const postFormData = (
     credentials: 'include',
     headers: {
       ...(authCookie && { Cookie: authCookie }),
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     },
     body: data as any, // Circumvent typescript error where form-data cannot be used as request body
   }
   return fetch(url, opts)
 }
 
-export const patch = (url: string, data: object, authCookie?: string) => {
+export const patch = (
+  url: string,
+  data: object,
+  authCookie?: string,
+  apiKey?: string,
+) => {
   const opts: RequestInit = {
     method: 'PATCH',
     mode: 'same-origin',
@@ -43,6 +56,7 @@ export const patch = (url: string, data: object, authCookie?: string) => {
     headers: {
       'Content-Type': 'application/json',
       ...(authCookie && { Cookie: authCookie }),
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     },
     body: JSON.stringify(data),
   }
@@ -53,6 +67,7 @@ export const patchFormData = (
   url: string,
   data: FormData,
   authCookie?: string,
+  apiKey?: string,
 ) => {
   const opts: RequestInit = {
     method: 'PATCH',
@@ -61,13 +76,14 @@ export const patchFormData = (
     credentials: 'include',
     headers: {
       ...(authCookie && { Cookie: authCookie }),
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     },
     body: data as any, // Circumvent typescript error where form-data cannot be used as request body
   }
   return fetch(url, opts)
 }
 
-export const get = (url: string, authCookie?: string) => {
+export const get = (url: string, authCookie?: string, apiKey?: string) => {
   const opts: RequestInit = {
     method: 'GET',
     mode: 'same-origin',
@@ -75,6 +91,7 @@ export const get = (url: string, authCookie?: string) => {
     credentials: 'include',
     headers: {
       ...(authCookie && { Cookie: authCookie }),
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     },
   }
   return fetch(url, opts)


### PR DESCRIPTION
## Problem

We'd like to add integration tests for our external API URLs

## Solution

Add integration tests for our external API to create, get, and update URLs at the `/api/v1/urls` endpoint.
-  The strange `;( ... )` syntax in e.g. `;({ email, apiKey } = await createIntegrationTestUser())` was enforced by prettier, see   [this comment](https://prettier.io/docs/en/rationale.html#semicolons) in their docs
- There's some duplication in logic for creating the API key, which seems unavoidable because the test environment is set up differently from the server
- ~inb4: I hope GitGuardian doesn't complain loudly about the `API_KEY_SALT` variable, it's used in local dev only~ surpisingly it looks like we're in the clear!

