### PR TITLE
fix: updated api-doc urls

### DIFF
--- a/public/locales/edu/en/translation.json
+++ b/public/locales/edu/en/translation.json
@@ -27,7 +27,7 @@
       "builtBy": "https://open.gov.sg",
       "linkedin": "https://sg.linkedin.com/company/open-government-products",
       "facebook": "https://www.facebook.com/opengovsg",
-      "apiDoc": "https://guide.for.edu.sg/guide/api-doc"
+      "apiDoc": "https://guide.for.edu.sg/developer-guide/api-documentation"
     },
     "builtBy": "Built by Open Government Products"
   },

--- a/public/locales/gov/en/translation.json
+++ b/public/locales/gov/en/translation.json
@@ -27,7 +27,7 @@
       "builtBy": "https://open.gov.sg",
       "linkedin": "https://sg.linkedin.com/company/open-government-products",
       "facebook": "https://www.facebook.com/opengovsg",
-      "apiDoc": "https://guide.go.gov.sg/guide/api-doc"
+      "apiDoc": "https://guide.go.gov.sg/developer-guide/api-documentation"
     },
     "builtBy": "Built by Open Government Products"
   },

--- a/public/locales/health/en/translation.json
+++ b/public/locales/health/en/translation.json
@@ -27,7 +27,7 @@
       "builtBy": "https://open.gov.sg",
       "linkedin": "https://sg.linkedin.com/company/open-government-products",
       "facebook": "https://www.facebook.com/opengovsg",
-      "apiDoc": "https://guide.for.sg/guide/api-doc"
+      "apiDoc": "https://guide.for.sg/developer-guide/api-documentation"
     },
     "builtBy": "Built by Open Government Products"
   },


### PR DESCRIPTION
## Problem
api documentation is pointing to the wrong URL

Closes [insert issue #]
updated translation.json files in 3 envs to point to the correct API doc URL. E.g: https://guide.go.gov.sg/developer-guide/api-documentation

