### PR TITLE
fix: update safe browsing error messages

### DIFF
--- a/src/server/modules/threat/UrlCheckController.ts
+++ b/src/server/modules/threat/UrlCheckController.ts
@@ -45,7 +45,7 @@ export class UrlCheckController {
           return
         }
       } catch (error) {
-        logger.error(error)
+        logger.error(error.message)
         res.serverError(jsonMessage(error.message))
         return
       }
@@ -78,7 +78,7 @@ export class UrlCheckController {
           return
         }
       } catch (error) {
-        logger.error(error)
+        logger.error(error.message)
         res.serverError(jsonMessage(error.message))
         return
       }

--- a/src/server/modules/threat/services/__tests__/SafeBrowsingService.test.ts
+++ b/src/server/modules/threat/services/__tests__/SafeBrowsingService.test.ts
@@ -79,13 +79,12 @@ describe('SafeBrowsingService', () => {
 
     it('only returns false when response is not ok', async () => {
       const json = jest.fn()
-      json.mockResolvedValue(null)
+      json.mockResolvedValue({ error: { message: '' } })
       mockFetch.mockResolvedValue({ ok: false, json })
 
       await expect(service.isThreat(url)).resolves.toBeFalsy()
       expect(get).toHaveBeenCalledWith(url)
       expect(set).not.toHaveBeenCalled()
-      expect(json).not.toHaveBeenCalled()
       expect(mockFetch).toHaveBeenCalled()
     })
 
@@ -160,7 +159,6 @@ describe('SafeBrowsingService', () => {
       await expect(service.isThreat(url)).rejects.toBeDefined()
       expect(get).toHaveBeenCalledWith(url)
       expect(set).not.toHaveBeenCalled()
-      expect(json).not.toHaveBeenCalled()
       expect(mockFetch).toHaveBeenCalled()
     })
 
@@ -245,7 +243,7 @@ describe('SafeBrowsingService', () => {
 
     it('returns false when any response is not ok', async () => {
       const json = jest.fn()
-      json.mockResolvedValue(null)
+      json.mockResolvedValue({ error: { message: '' } })
       mockFetch
         .mockResolvedValueOnce({ ok: true, json })
         .mockResolvedValueOnce({ ok: false, json })
@@ -322,7 +320,6 @@ describe('SafeBrowsingService', () => {
         .mockResolvedValueOnce({ ok: false, json })
 
       await expect(service.isThreatBulk(urls, batchSize)).rejects.toBeDefined()
-      expect(json).toHaveBeenCalledTimes(1)
       expect(mockFetch).toHaveBeenCalledTimes(numBatches)
       expect(spy).toHaveBeenCalledTimes(numBatches)
     })


### PR DESCRIPTION
## Problem

Safe browsing errors are not being logged and returned properly. 

The returned error message looks like this, because `response` and `response.body` are objects:
![Screenshot 2022-11-28 at 4 52 10 PM](https://user-images.githubusercontent.com/41856541/204234426-82721ddf-34a3-453f-9dc1-f053b36437b7.png)

The logged error message looks like this, because it's trying to log `error` instead of `error.message`:
![Screenshot 2022-11-28 at 3 25 04 PM](https://user-images.githubusercontent.com/41856541/204218026-b3c51003-9d1f-4934-8f15-09137deca29c.png)

## Solution

- Change the error message contents from `response` and `response.body` to `body.error.message`
- Change the logged error message from `error` to `error.message`

Now, both the logged and returned error messages look like this:
![Screenshot 2022-11-28 at 5 18 28 PM](https://user-images.githubusercontent.com/41856541/204239825-6caccaab-4e27-4ad6-8c30-ed7a73ab634a.png)

For context, when calling the Safe Browsing API, the reponse JSON `body` looks something like this when there's an error:
![Screenshot 2022-11-28 at 3 23 54 PM](https://user-images.githubusercontent.com/41856541/204217840-3bbe06fb-a553-422d-8575-0fd0602b43c0.png)

The indentation changes from line 83/84 onwards in this PR are caused by prettier

Also, apologies to the team for unintentionally exposing the now-removed API key 🙇
