### PR TITLE
chore(datadog): add metric for generating API keys

### DIFF
--- a/src/server/modules/user/services/__tests__/ApiKeyAuthService.test.ts
+++ b/src/server/modules/user/services/__tests__/ApiKeyAuthService.test.ts
@@ -18,6 +18,8 @@ const baseUserId = 1
 describe('ApiKeyAuthService', () => {
   beforeEach(() => {
     userRepository.saveApiKeyHash.mockReset()
+    userRepository.findUserByApiKey.mockReset()
+    userRepository.hasApiKey.mockReset()
   })
   it('createApiKey should call userRepository.saveApiKeyHash', async () => {
     await apiAuthService.upsertApiKey(baseUserId)

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -1,6 +1,8 @@
 import { StatsD } from 'hot-shots'
 import { DEV_ENV } from '../config'
 
+export const API_KEY_GENERATE = 'apikey.generate'
+export const API_KEY_GENERATE_TAG_IS_NEW = 'isnew'
 export const MALICIOUS_ACTIVITY_FILE = 'malicious_activity.file'
 export const MALICIOUS_ACTIVITY_LINK = 'malicious_activity.link'
 export const OTP_GENERATE_FAILURE = 'otp.generate.failure'


### PR DESCRIPTION
## Problem

We want metrics to track API key generation

## Solution

Add datadog metrics to track API key generation, and whether these API keys are new or not. This will incur an extra database read, but the cost is probably quite small in the grand scheme of things

