### PR TITLE
chore: refactor validations for getting urls

### DIFF
--- a/src/server/api/user/validators.ts
+++ b/src/server/api/user/validators.ts
@@ -43,15 +43,16 @@ const tagSchema = Joi.array()
 
 export const userUrlsQueryConditions = Joi.object({
   userId: Joi.number().required(),
-  limit: Joi.number().required(),
-  offset: Joi.number().optional(),
-  orderBy: Joi.string().valid('updatedAt', 'createdAt', 'clicks').optional(),
+  // eslint-disable-next-line newline-per-chained-call
+  limit: Joi.number().integer().min(0).max(1000).required(),
+  offset: Joi.number().integer().min(0).optional(),
+  orderBy: Joi.string().valid('createdAt', 'clicks').optional(),
   sortDirection: Joi.string().valid('desc', 'asc').optional(),
-  searchText: Joi.string().allow('').optional(),
+  searchText: Joi.string().lowercase().allow('').optional(),
   state: Joi.string().valid(ACTIVE, INACTIVE).optional(),
   isFile: Joi.boolean().optional(),
   tags: tagSchema.max(5),
-})
+}).oxor('searchText', 'tags')
 
 export const userTagsQueryConditions = Joi.object({
   userId: Joi.number().required(),

--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -17,6 +17,7 @@ import {
   StorableUrlSource,
   StorableUrlState,
 } from '../../../repositories/enums'
+import { UserUrlsQueryConditions } from '../../../repositories/types'
 
 import { UrlCreationRequest, UrlEditRequest } from '.'
 import { UrlV1Mapper } from '../../../mappers/UrlV1Mapper'
@@ -93,7 +94,9 @@ export class ApiV1Controller {
     }
   }
 
-  private static extractUrlQueryConditions(req: Express.Request) {
+  private static extractUrlQueryConditions(
+    req: Express.Request,
+  ): UserUrlsQueryConditions {
     const { userId } = req.body
     const {
       limit = 1000,

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -26,6 +26,7 @@ import dogstatsd, {
 } from '../../util/dogstatsd'
 import TagManagementServiceInterface from './interfaces/TagManagementService'
 import ApiKeyAuthServiceInterface from './interfaces/ApiKeyAuthServiceInterface'
+import { UserUrlsQueryConditions } from '../../repositories/types'
 
 type AnnouncementResponse = {
   message?: string
@@ -216,7 +217,7 @@ export class UserController {
       const { urls, count } =
         await this.urlManagementService.getUrlsWithConditions(queryConditions)
       dogstatsd.increment(SEARCH_USER_URL, 1, 1, [
-        `${SEARCH_USER_URL_TAG_IS_TAG}:${queryConditions.tags.length > 0}`,
+        `${SEARCH_USER_URL_TAG_IS_TAG}:${!!queryConditions.tags}`,
       ])
       res.ok({ urls, count })
       return
@@ -230,14 +231,15 @@ export class UserController {
     }
   }
 
-  private static extractUrlQueryConditions(req: Express.Request) {
+  private static extractUrlQueryConditions(
+    req: Express.Request,
+  ): UserUrlsQueryConditions {
     const { userId } = req.body
-    let { limit = 1000, searchText = '' } = req.query
-    limit = Math.min(1000, Number(limit))
-    searchText = searchText.toString().toLowerCase()
     const {
+      limit = 1000,
       offset = 0,
-      orderBy = 'updatedAt',
+      searchText = '',
+      orderBy = 'createdAt',
       sortDirection = 'desc',
       isFile,
       state,
@@ -245,15 +247,15 @@ export class UserController {
     } = req.query
     const tagList = tags ? tags.toString().toLowerCase().split(';') : []
     const queryConditions = {
-      limit,
+      userId,
+      limit: Number(limit),
       offset: Number(offset),
       orderBy: orderBy.toString(),
       sortDirection: sortDirection.toString(),
-      searchText,
-      userId,
       state: state?.toString(),
       isFile: undefined as boolean | undefined,
-      tags: tagList,
+      ...(searchText && { searchText: searchText.toString().toLowerCase() }),
+      ...(tags && { tags: tagList }),
     }
     if (isFile === 'true') {
       queryConditions.isFile = true

--- a/src/server/modules/user/__tests__/UserController.test.ts
+++ b/src/server/modules/user/__tests__/UserController.test.ts
@@ -435,13 +435,11 @@ describe('UserController', () => {
       expect(urlManagementService.getUrlsWithConditions).toHaveBeenCalledWith({
         limit: 1000,
         offset: 0,
-        orderBy: 'updatedAt',
+        orderBy: 'createdAt',
         sortDirection: 'desc',
-        searchText: '',
         userId: 1,
         state: undefined,
         isFile: undefined,
-        tags: [],
       })
     })
 
@@ -481,7 +479,6 @@ describe('UserController', () => {
         userId,
         state,
         isFile: undefined,
-        tags: [],
       })
     })
 
@@ -532,7 +529,7 @@ describe('UserController', () => {
       await controller.getUrlsWithConditions(req, res)
       expect(res.ok).toHaveBeenCalledWith(result)
       expect(urlManagementService.getUrlsWithConditions).toHaveBeenCalledWith(
-        expect.objectContaining({ isFile: false, tags: [] }),
+        expect.objectContaining({ isFile: false }),
       )
     })
 

--- a/src/server/repositories/UserRepository.ts
+++ b/src/server/repositories/UserRepository.ts
@@ -131,22 +131,22 @@ export class UserRepository implements UserRepositoryInterface {
   }
 
   private static buildQueryConditions(conditions: UserUrlsQueryConditions) {
-    const searchTextCondition = {
-      [Op.or]: [
-        {
-          shortUrl: {
-            [Op.substring]: conditions.searchText,
-          },
-        },
-        {
-          longUrl: {
-            [Op.substring]: conditions.searchText,
-          },
-        },
-      ],
-    }
     let whereConditions: any = { userId: conditions.userId }
-    if (conditions.searchText.length > 0) {
+    if (conditions.searchText && conditions.searchText.length > 0) {
+      const searchTextCondition = {
+        [Op.or]: [
+          {
+            shortUrl: {
+              [Op.substring]: conditions.searchText,
+            },
+          },
+          {
+            longUrl: {
+              [Op.substring]: conditions.searchText,
+            },
+          },
+        ],
+      }
       whereConditions = { ...whereConditions, ...searchTextCondition }
     }
 

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -37,14 +37,14 @@ export type StorableUser = {
 export type BulkUrlMapping = Pick<StorableUrl, 'shortUrl' | 'longUrl'>
 
 export type UserUrlsQueryConditions = {
+  userId: number
   limit: number
   offset: number
   orderBy: string
   sortDirection: string
-  searchText: string
-  userId: number
   state?: string
   isFile?: boolean
+  searchText?: string
   tags?: string[]
 }
 


### PR DESCRIPTION
## Problem

We want to clean up validations for getting URLs on the internal API, as noted in #2073 

## Solution

Improved the validations for getting URLs on the internal API (user controller).

**Improvements**:

Validations
- Joi validations are clearer in terms of what they expect from each of the params
- Removed `updatedAt` as an option for `orderBy`, since it's unused
- Added optional XOR between `searchText` and `tags` to ensure that both are not used at the same time
- Add `lowercase()` to `searchText`, since we want to convert it to lowercase anyway

User controller
- Set default `orderBy` option to `createdAt` rather than the unused `updatedAt`
- Make `searchText` and `tags` optional params to pass down to the URL management service and URL repository



