### PR TITLE
build: fix localstack version in docker-compose to 1.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     ports:
       - '6379:6379'
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:1.2
     container_name: gogovsg-localstack
     ports:
       - '4566:4566'


### PR DESCRIPTION
## Problem

`docker-compose.yml` is using `localstack:latest`, which has recently bumped its latest version from v1.2.0 to v1.3.0. Apparently the local AWS bucket somehow does not work the same way in `localstack` v1.3.0, and hence file uploads and E2E tests are failing.

## Solution

Fix the version of `localstack` to 1.2 in `docker-compose.yml`.

(If we want to upgrade to `localstack` v1.3.0 eventually, we'll have to figure out how to make local S3 work with it.)

Other notes:
- Integration tests are helpful for debugging!
- Try pinning down specific versions of images instead of using `latest`, because it makes the project vulnerable to package upgrades which may suddenly and inexplicably break things
- Curiously I still can't replicate this problem locally, despite killing all docker containers and restarting them - does anyone have any ideas why?
