### PR TITLE
chore: disable otp rate limit on local dev

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -121,7 +121,7 @@ if (DEV_ENV) {
     maxAge,
   }
   proxy = false
-  otpLimit = 10
+  otpLimit = 0 // disable OTP rate limit on development to allow faster logins for integration tests
 
   // Configure maildev specific options
   transporterOpts.ignoreTLS = true


### PR DESCRIPTION
## Problem

Integration tests on local dev (e.g. #2091) can make many user logins within a short time period, and if the OTP rate limit is too low, the logins will fail

## Solution

Disable OTP rate limiting on local dev. Setting the max rate limit to 0 disables it entirely (see [`express-rate-limit` documentation](https://www.npmjs.com/package/express-rate-limit#configuration))
