### PR TITLE
Feat/bulk/all metrics

### DIFF
--- a/src/client/user/components/UserLinkTable/DownloadBulkButton/index.tsx
+++ b/src/client/user/components/UserLinkTable/DownloadBulkButton/index.tsx
@@ -14,7 +14,9 @@ function downloadFileFromS3(
 ) {
   bulkCsvIds.forEach((bulkCsvId) => {
     try {
-      window.open(`${bulkCsvId}/${BULK_QR_DOWNLOAD_MAPPINGS[format]}`)
+      window.open(
+        `${bulkCsvId}/${BULK_QR_DOWNLOAD_MAPPINGS[format]}?x-source=console`,
+      )
       GAEvent(`qr code bulk download`, format, 'successful')
     } catch (e) {
       Sentry.captureMessage(`qr code bulk download for ${format} unsuccessful`)

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -6,7 +6,6 @@ import { DependencyIds } from '../../constants'
 import { BulkService } from './interfaces'
 import { UrlManagementService } from '../user/interfaces'
 import dogstatsd, {
-  BULK_CREATE_COUNT,
   BULK_CREATE_FAILURE,
   BULK_CREATE_SUCCESS,
 } from '../../util/dogstatsd'
@@ -67,7 +66,6 @@ export class BulkController {
       res.badRequest(jsonMessage('Something went wrong, please try again.'))
       return
     }
-    dogstatsd.increment(BULK_CREATE_COUNT, urlMappings.length)
     dogstatsd.increment(BULK_CREATE_SUCCESS, 1, 1)
     if (shouldGenerateQRCodes) {
       logger.info('shouldGenerateQRCodes true, triggering QR code generation')

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -5,7 +5,11 @@ import jsonMessage from '../../util/json'
 import { DependencyIds } from '../../constants'
 import { BulkService } from './interfaces'
 import { UrlManagementService } from '../user/interfaces'
-import dogstatsd from '../../util/dogstatsd'
+import dogstatsd, {
+  BULK_CREATE_COUNT,
+  BULK_CREATE_FAILURE,
+  BULK_CREATE_SUCCESS,
+} from '../../util/dogstatsd'
 import { logger, shouldGenerateQRCodes } from '../../config'
 import { MessageType } from '../../../shared/util/messages'
 
@@ -59,12 +63,12 @@ export class BulkController {
     try {
       await this.urlManagementService.bulkCreate(userId, urlMappings, tags)
     } catch (e) {
-      dogstatsd.increment('bulk.hash.failure', 1, 1)
+      dogstatsd.increment(BULK_CREATE_FAILURE, 1, 1)
       res.badRequest(jsonMessage('Something went wrong, please try again.'))
       return
     }
-
-    dogstatsd.increment('bulk.hash.success', 1, 1)
+    dogstatsd.increment(BULK_CREATE_COUNT, urlMappings.length)
+    dogstatsd.increment(BULK_CREATE_SUCCESS, 1, 1)
     if (shouldGenerateQRCodes) {
       logger.info('shouldGenerateQRCodes true, triggering QR code generation')
       // put jobParamsList on the req body so that it can be used by JobController

--- a/src/server/modules/bulk/services/BulkService.ts
+++ b/src/server/modules/bulk/services/BulkService.ts
@@ -12,6 +12,10 @@ import { BULK_UPLOAD_HEADER } from '../../../../shared/constants'
 import { BulkUrlMapping } from '../../../repositories/types'
 import * as validators from '../../../../shared/util/validation'
 import generateShortUrl from '../../../util/url'
+import dogstatsd, {
+  BULK_VALIDATION_ERROR,
+  BULK_VALIDATION_ERROR_TAGS,
+} from '../../../util/dogstatsd'
 
 const BULK_UPLOAD_RANDOM_STR_LENGTH = bulkUploadRandomStrLength
 const BULK_UPLOAD_MAX_NUM = bulkUploadMaxNum
@@ -36,6 +40,9 @@ export class BulkService implements interfaces.BulkService {
         complete: () => {
           // check for empty file
           if (longUrls.length === 0) {
+            dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+              `${BULK_VALIDATION_ERROR_TAGS.hasUrls}`,
+            ])
             reject(new Error('csv file is empty'))
           }
           resolve(longUrls)
@@ -49,6 +56,9 @@ export class BulkService implements interfaces.BulkService {
 
           if (counter === 0) {
             if (stringData !== BULK_UPLOAD_HEADER) {
+              dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                `${BULK_VALIDATION_ERROR_TAGS.validHeader}`,
+              ])
               throw new Error(
                 `Row ${counter + 1}: bulk upload header is invalid`,
               )
@@ -67,32 +77,53 @@ export class BulkService implements interfaces.BulkService {
 
             switch (true) {
               case !acceptableLinkCount:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.acceptableLinkCount}`,
+                ])
                 throw new Error(
                   `File exceeded ${BULK_UPLOAD_MAX_NUM} original URLs to shorten`,
                 )
               case !onlyOneColumn:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.onlyOneColumn}`,
+                ])
                 throw new Error(
                   `Row ${
                     counter + 1
                   }: ${rowData} contains more than one column of data`,
                 )
               case !isNotEmpty:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isNotEmpty}`,
+                ])
                 throw new Error(`Row ${counter + 1} is empty`)
               case !isValidUrl:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isValidUrl}`,
+                ])
                 throw new Error(
                   `Row ${counter + 1}: ${stringData} is not valid`,
                 )
               case !isNotBlacklisted:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isNotBlacklisted}`,
+                ])
                 throw new Error(
                   `Row ${counter + 1}: ${stringData} is blacklisted`,
                 )
               case !isNotCircularRedirect:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isNotCircularRedirect}`,
+                ])
                 throw new Error(
                   `Row ${
                     counter + 1
                   }: ${stringData} redirects back to ${ogHostname}`,
                 )
               case !noParsingError:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.noParsingError}`,
+                ])
                 throw new Error('Parsing error')
               default:
               // no error, do nothing

--- a/src/server/services/__tests__/email.test.ts
+++ b/src/server/services/__tests__/email.test.ts
@@ -216,13 +216,13 @@ describe('Mailer tests', () => {
           (downloadLink) =>
             `<a href="${downloadLink}/${
               BULK_QR_DOWNLOAD_MAPPINGS[BULK_QR_DOWNLOAD_FORMATS.PNG]
-            }" target="_blank">here </a>`,
+            }?x-source=email" target="_blank">here </a>`,
         )}</p>
         <p>Download QR codes for your links (SVG): ${downloadLinks.map(
           (downloadLink) =>
             `<a href="${downloadLink}/${
               BULK_QR_DOWNLOAD_MAPPINGS[BULK_QR_DOWNLOAD_FORMATS.SVG]
-            }" target="_blank">here </a>`,
+            }?x-source=email" target="_blank">here </a>`,
         )}</p>
       `
 

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -156,13 +156,13 @@ export class MailerNode implements Mailer {
           (downloadLink) =>
             `<a href="${downloadLink}/${
               BULK_QR_DOWNLOAD_MAPPINGS[BULK_QR_DOWNLOAD_FORMATS.PNG]
-            }" target="_blank">here </a>`,
+            }?x-source=email" target="_blank">here </a>`,
         )}</p>
         <p>Download QR codes for your links (SVG): ${downloadLinks.map(
           (downloadLink) =>
             `<a href="${downloadLink}/${
               BULK_QR_DOWNLOAD_MAPPINGS[BULK_QR_DOWNLOAD_FORMATS.SVG]
-            }" target="_blank">here </a>`,
+            }?x-source=email" target="_blank">here </a>`,
         )}</p>
       `
 

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -20,15 +20,15 @@ export const USER_NEW = 'user.new'
 
 export const BULK_VALIDATION_ERROR = 'bulk.validation.error'
 export const BULK_VALIDATION_ERROR_TAGS = {
-  hasUrls: 'errorType:emptyCsv',
-  validHeader: 'errorType: invalidHeader',
-  acceptableLinkCount: 'errorType:exceededLinkCount',
-  onlyOneColumn: 'errorType:moreThanOneColumn',
-  isNotEmpty: 'errorType:emptyRow',
-  isValidUrl: 'errorType:invalidUrl',
-  isNotBlacklisted: 'errorType:blacklistedUrl',
-  isNotCircularRedirect: 'errorType:circularRedirect',
-  noParsingError: 'errorType:parsingError',
+  hasUrls: 'error_type:has_urls',
+  validHeader: 'error_type:valid_header',
+  acceptableLinkCount: 'error_type:acceptable_link_count',
+  onlyOneColumn: 'error_type:only_one_column',
+  isNotEmpty: 'error_type:is_not_empty',
+  isValidUrl: 'error_type:is_valid_url',
+  isNotBlacklisted: 'error_type:is_not_blacklisted',
+  isNotCircularRedirect: 'error_type:is_not_circular_redirect',
+  noParsingError: 'error_type:no_parsing_error',
 }
 export const BULK_CREATE_SUCCESS = 'bulk.hash.success'
 export const BULK_CREATE_FAILURE = 'bulk.hash.failure'

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -18,6 +18,10 @@ export const SHORTLINK_CREATE_TAG_IS_FILE = 'isfile'
 export const SHORTLINK_CREATE_TAG_SOURCE = 'source'
 export const USER_NEW = 'user.new'
 
+export const BULK_CREATE_SUCCESS = 'bulk.hash.success'
+export const BULK_CREATE_FAILURE = 'bulk.hash.failure'
+export const BULK_CREATE_COUNT = 'bulk.urls.count'
+
 export const JOB_START_SUCCESS = 'job.start.success'
 export const JOB_START_FAILURE = 'job.start.failure'
 export const JOB_ITEM_UPDATE_SUCCESS = 'jobItem.update.success'

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -32,7 +32,6 @@ export const BULK_VALIDATION_ERROR_TAGS = {
 }
 export const BULK_CREATE_SUCCESS = 'bulk.hash.success'
 export const BULK_CREATE_FAILURE = 'bulk.hash.failure'
-export const BULK_CREATE_COUNT = 'bulk.urls.count'
 
 export const JOB_START_SUCCESS = 'job.start.success'
 export const JOB_START_FAILURE = 'job.start.failure'

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -18,6 +18,18 @@ export const SHORTLINK_CREATE_TAG_IS_FILE = 'isfile'
 export const SHORTLINK_CREATE_TAG_SOURCE = 'source'
 export const USER_NEW = 'user.new'
 
+export const BULK_VALIDATION_ERROR = 'bulk.validation.error'
+export const BULK_VALIDATION_ERROR_TAGS = {
+  hasUrls: 'errorType:emptyCsv',
+  validHeader: 'errorType: invalidHeader',
+  acceptableLinkCount: 'errorType:exceededLinkCount',
+  onlyOneColumn: 'errorType:moreThanOneColumn',
+  isNotEmpty: 'errorType:emptyRow',
+  isValidUrl: 'errorType:invalidUrl',
+  isNotBlacklisted: 'errorType:blacklistedUrl',
+  isNotCircularRedirect: 'errorType:circularRedirect',
+  noParsingError: 'errorType:parsingError',
+}
 export const BULK_CREATE_SUCCESS = 'bulk.hash.success'
 export const BULK_CREATE_FAILURE = 'bulk.hash.failure'
 export const BULK_CREATE_COUNT = 'bulk.urls.count'


### PR DESCRIPTION
Adds the following metrics for bulk QR code generation and bulk link creation:
- [x] bulk create count
- [x] bulk validation error (and error types tags)
- [x] custom query strings to track source for s3 bucket download


After release, to add S3 bucket logs and DD streaming for the 3 environments