### PR TITLE
fix(LoginForm): validate email on initial blur, then on change

### DIFF
--- a/src/client/login/components/LoginForm.tsx
+++ b/src/client/login/components/LoginForm.tsx
@@ -10,8 +10,9 @@ type LoginFormProps = {
   variant: VariantType
   autoComplete: string
   onChange: (email: string) => void
-  textError: () => boolean
-  textErrorMessage: () => string
+  onBlur?: () => void
+  isError: boolean
+  textErrorMessage: string
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
   value: string
 }
@@ -46,7 +47,8 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
   variant,
   autoComplete,
   onChange,
-  textError,
+  onBlur,
+  isError,
   textErrorMessage,
   onSubmit,
   children,
@@ -63,6 +65,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
         variant="outlined"
         placeholder={placeholder}
         onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
         InputProps={{
           classes: {
             input: classes.loginInputText,
@@ -73,8 +76,8 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
         id={id}
         name={id}
         disabled={!variantMap.inputEnabled}
-        error={textError()}
-        helperText={textErrorMessage()}
+        error={isError}
+        helperText={isError ? textErrorMessage : ''}
         value={value}
       />
       <section className={classes.buttonRow}>
@@ -83,7 +86,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({
           type="submit"
           variant="contained"
           color="primary"
-          disabled={!variantMap.submitEnabled || !!textError()}
+          disabled={!variantMap.submitEnabled || isError}
           size="large"
         >
           {buttonMessage}

--- a/test/end-to-end/LoginPageSessions.test.ts
+++ b/test/end-to-end/LoginPageSessions.test.ts
@@ -17,6 +17,7 @@ test('Invalid Email that does not end with .gov.sg and should not allow submissi
   await t
     .click(loginButton)
     .typeText('#email', `${incorrectEmail}`)
+    .click(signInButton)
     // It should respond with invalid email when email does not end with .gov.sg
     .expect(emailHelperText.innerText)
     .eql("This doesn't look like a valid gov.sg email.")


### PR DESCRIPTION
## Problem
On the login page, the error message for the email input appears the moment you start typing. This is quite jarring:


https://user-images.githubusercontent.com/29480346/219290831-ca3deb77-2cd8-4146-aa03-cbbf23f66085.mov

## Solution

Use an `onTouched` strategy, as offered by [`react-hook-form`](https://react-hook-form.com/api/useform); in other words, validate on blur initially, then on change subsequently.


https://user-images.githubusercontent.com/29480346/219291002-0ef82e74-1154-4e88-9dd2-ff6fb17561dd.mov

