### PR TITLE
fix: identify google page renderer user agent as a bot

### DIFF
--- a/src/server/modules/analytics/services/DeviceCheckService.ts
+++ b/src/server/modules/analytics/services/DeviceCheckService.ts
@@ -5,7 +5,7 @@ import * as interfaces from '../interfaces'
 import { DeviceType } from '../interfaces'
 
 const BOTS_USER_AGENTS =
-  /bot|facebookexternalhit|Facebot|Slackbot|TelegramBot|WhatsApp|Twitterbot|Pinterest|Postman|url/
+  /bot|facebookexternalhit|Facebot|Slackbot|TelegramBot|WhatsApp|Twitterbot|Pinterest|Postman|url|Google-PageRenderer/
 
 @injectable()
 export class DeviceCheckService implements interfaces.DeviceCheckService {

--- a/src/server/modules/analytics/services/__tests__/DeviceCheckService.test.ts
+++ b/src/server/modules/analytics/services/__tests__/DeviceCheckService.test.ts
@@ -17,6 +17,14 @@ describe('DeviceCheckService tests', () => {
       ).toStrictEqual('others')
     })
 
+    test('should correctly identify google page renderer bots', () => {
+      expect(
+        service.getDeviceType(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google-PageRenderer Google (+https://developers.google.com/+/web/snippet/)',
+        ),
+      ).toStrictEqual('others')
+    })
+
     test('empty user agent are classified as others', () => {
       expect(service.getDeviceType('')).toStrictEqual('others')
     })


### PR DESCRIPTION
## Problem

tldr; our server is wrongly classifying google's page renderer bot as a user on "Desktop", when it should be classified under "Others" instead. full story:
- Recently, a user sent out a Go link to many users via SMS. Unexpectedly, they saw that in their link statistics section, there were many more hits than expected and 90% of them were coming from desktop, when all their actual human users should be coming from mobile instead (since they're opening the link from SMS). 
- Upon investigating our logs, we can see from the user-agent string that these requests are being made by the "Google-PageRenderer" bot, whose purpose is presumably to automatically render pages from links sent out by SMS. Due to incomplete bot-handling logic on Go, these hits were wrongly categorised under "Desktop", when they actually should be categorised under "Others" instead. 

## Solution

Change the `BOTS_USER_AGENTS` expression to include `Google-PageRenderer`.

Doing this might not work for the long-term though. The current solution to check for bots was implemented in #209, a custom-written `BOTS_USER_AGENTS` expression is used to determine if a user-agent is a bot or not. But naturally, the expression cannot exhaustively cover all possible bots, leading to many other bots falling through the cracks (like this google page renderer bot).

In the future, we may want to opt for a more comprehensive solution from using a library like [isbot](https://github.com/omrilotan/isbot)
