### PR TITLE
feat(link-transfer): add request ownership button to directory table

### DIFF
--- a/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
+++ b/src/client/directory/components/DirectoryResults/DirectoryTable/DirectoryTableRow/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import copy from 'copy-to-clipboard'
 import {
   Hidden,
+  Link,
   TableCell,
   TableRow,
   Typography,
@@ -12,6 +13,7 @@ import {
   useTheme,
 } from '@material-ui/core'
 import personIcon from '@assets/components/directory/directory-results/person-icon.svg'
+import i18next from 'i18next'
 import { UrlTypePublic } from '../../../../reducers/types'
 import useAppMargins from '../../../../../app/components/AppMargins/appMargins'
 import { SetSuccessMessageAction } from '../../../../../app/components/pages/RootPage/actions/types'
@@ -46,7 +48,6 @@ const useStyles = makeStyles((theme) =>
       [theme.breakpoints.up('md')]: {
         width: '40%',
         paddingTop: theme.spacing(7.5),
-        paddingRight: () => '10%',
         marginLeft: () => 0,
       },
     },
@@ -87,6 +88,9 @@ const useStyles = makeStyles((theme) =>
         textDecoration: 'underline',
       },
     },
+    requestOwnershipText: {
+      color: 'inherit',
+    },
     domainTextInactive: {
       color: '#BBBBBB',
       [theme.breakpoints.up('md')]: {
@@ -104,10 +108,6 @@ const useStyles = makeStyles((theme) =>
         width: 'calc(100% - 32px)',
       },
     },
-    urlInformationCell: {
-      width: '100%',
-      marginRight: 0,
-    },
     contactEmailCell: {
       display: 'inline-flex',
       margin: 0,
@@ -123,7 +123,22 @@ const useStyles = makeStyles((theme) =>
         flexDirection: 'column',
       },
     },
-    IconCell: {
+    requestOwnershipCell: {
+      display: 'inline-flex',
+      margin: 0,
+      width: '100%',
+      border: 'none',
+      paddingLeft: (props: DirectoryTableRowStyleProps) => props.appMargins,
+      paddingBottom: theme.spacing(4),
+      [theme.breakpoints.up('md')]: {
+        paddingTop: theme.spacing(7.5),
+        paddingBottom: theme.spacing(0.5),
+        paddingLeft: () => 0,
+        width: 'fit-content',
+        flexDirection: 'column',
+      },
+    },
+    linkIconCell: {
       display: 'inline-flex',
       verticalAlign: 'middle',
       [theme.breakpoints.up('md')]: {
@@ -131,13 +146,12 @@ const useStyles = makeStyles((theme) =>
         marginLeft: (props: DirectoryTableRowStyleProps) => props.appMargins,
       },
     },
-    mailIconCell: {
+    personIconCell: {
+      display: 'inline-flex',
+      verticalAlign: 'middle',
       [theme.breakpoints.up('md')]: {
-        paddingTop: theme.spacing(5.0),
-        paddingLeft: 0,
-        paddingRight: theme.spacing(1),
-        marginLeft: 0,
-        marginRight: 0,
+        paddingRight: theme.spacing(1.5),
+        marginLeft: theme.spacing(4),
       },
     },
     personIcon: {
@@ -154,7 +168,7 @@ const useStyles = makeStyles((theme) =>
     stateCell: {
       [theme.breakpoints.up('md')]: {
         paddingTop: theme.spacing(7.5),
-        minWidth: '100px',
+        minWidth: '75px',
       },
       [theme.breakpoints.down('sm')]: {
         display: 'inline-flex',
@@ -219,6 +233,20 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
     }
   }
 
+  const onClickRequestOwnership = (
+    e: React.MouseEvent<HTMLSpanElement, MouseEvent>,
+  ) => {
+    GAEvent(
+      'directory result',
+      `${query}`,
+      'request ownership',
+      parseInt(`${index}`, 10),
+    )
+    if (!isMobileView) {
+      e.stopPropagation()
+    }
+  }
+
   return (
     <TableRow
       className={classes.tableRow}
@@ -227,7 +255,7 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
     >
       <TableCell className={classes.shortLinkCell} key="shortUrlCell">
         <Typography variant="body2" className={classes.shortLinkText}>
-          <div className={classes.IconCell}>
+          <div className={classes.linkIconCell}>
             {url?.isFile ? (
               <DirectoryFileIcon
                 color={
@@ -284,7 +312,7 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
           className={classes.emailText}
           onClick={(e) => onClickEmail(e)}
         >
-          <div className={classes.IconCell}>
+          <div className={classes.personIconCell}>
             <img
               className={classes.personIcon}
               src={personIcon}
@@ -294,6 +322,24 @@ const DirectoryTableRow: FunctionComponent<DirectoryTableRowProps> = ({
           {String(url.email)}
         </Typography>
       </TableCell>
+
+      <Hidden smDown>
+        <TableCell
+          className={classes.requestOwnershipCell}
+          key="requestOwnershipCell"
+        >
+          <Link
+            variant="body2"
+            className={classes.requestOwnershipText}
+            onClick={(e) => onClickRequestOwnership(e)}
+            href={i18next.t('general.links.contact')}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Request ownership
+          </Link>
+        </TableCell>
+      </Hidden>
     </TableRow>
   )
 }

--- a/src/client/directory/components/DirectoryResults/MobilePanel/index.tsx
+++ b/src/client/directory/components/DirectoryResults/MobilePanel/index.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import copy from 'copy-to-clipboard'
 import { useDispatch } from 'react-redux'
 import {
+  Button,
   Divider,
   Drawer,
   Paper,
@@ -11,6 +12,7 @@ import {
 } from '@material-ui/core'
 import personIcon from '@assets/components/directory/directory-results/person-icon.svg'
 import copyEmailIcon from '@assets/components/directory/directory-results/copy-email-icon.svg'
+import i18next from 'i18next'
 import { SetSuccessMessageAction } from '../../../../app/components/pages/RootPage/actions/types'
 import rootActions from '../../../../app/components/pages/RootPage/actions'
 import useAppMargins from '../../../../app/components/AppMargins/appMargins'
@@ -45,11 +47,14 @@ const useStyles = makeStyles((theme) =>
       right: '10%',
     },
     row: {
-      padding: theme.spacing(3),
+      paddingTop: theme.spacing(1.5),
+      paddingBottom: theme.spacing(1.5),
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3),
     },
     divider: {
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(3),
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
     },
     shortUrlRow: {
       display: 'box',
@@ -92,7 +97,7 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
   const classes = useStyles({ appMargins })
   const dispatch = useDispatch()
 
-  const onClickEvent = () => {
+  const onCopyEmail = () => {
     copy(url.email)
     dispatch<SetSuccessMessageAction>(
       rootActions.setSuccessMessage('Email has been copied'),
@@ -190,10 +195,20 @@ const MobilePanel: FunctionComponent<MobilePanelProps> = ({
           <input
             type="image"
             src={copyEmailIcon}
-            onClick={() => onClickEvent()}
+            onClick={onCopyEmail}
             className={classes.copyIcon}
             alt="email icon"
           />
+        </Typography>
+        <Divider className={classes.divider} />
+        <Typography className={classes.row} variant="body2">
+          <Button
+            href={i18next.t('general.links.contact')}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Request ownership
+          </Button>
         </Typography>
       </Paper>
     </Drawer>


### PR DESCRIPTION
## Problem

Part of the link transfer feature (see [Notion doc](https://www.notion.so/opengov/20230309-Link-Transfers-4450fc62cba84a91862b130055d5abeb?pvs=4))

## Solution

This PR adds a "Request ownership" button to the directory table. On mobile, the button will not be shown on the table but only appears in the bottom panel (after the user clicks on the table row).

Clicking on "Request ownership" will take the user to Go's [Contact Us form](https://form.gov.sg/62f0747c7da3e1001240f8bb). In the future, clicking it should instead create an actual link transfer request and send an email out to the link owner, but as a first step we've agreed with product-side to redirect them to the contact form first.

**Notes**:

Ideally, the "Request ownership" button should be an actual `Button` component instead of a `Link`, but the CSS on the directory table is such a mess that it's a bit difficult to figure out a proper styling -- it should still be alright to have it as a link though, as that would be consistent with the other clickable links on the table too (e.g. contact email).

On the mobile panel though, the "Request ownership" button is actually a `Button`.

**Improvements**:

- Removed some unused CSS
- Removed some unnecessary padding/whitespace (to also make room for the "Request ownership" link)

## Before & After Screenshots

**BEFORE**:
![Screenshot 2023-03-14 at 5 52 28 PM](https://user-images.githubusercontent.com/41856541/224963236-3977326d-a368-4d48-b5d6-76759ba23a09.png)
![Screenshot 2023-03-14 at 5 52 58 PM](https://user-images.githubusercontent.com/41856541/224963374-4c4e7c4e-5d32-43d0-be22-4ac8bc96fe27.png)

**AFTER**:
![Screenshot 2023-03-14 at 5 53 22 PM](https://user-images.githubusercontent.com/41856541/224963463-70039411-bce3-418e-b968-ddbb1c118a92.png)
![Screenshot 2023-03-14 at 5 53 46 PM](https://user-images.githubusercontent.com/41856541/224963563-4b69e9a7-82b0-4f18-9974-0a99db378018.png)

https://user-images.githubusercontent.com/41856541/224963954-5dade8bc-a7b4-4df8-997b-b29ade2c057a.mov
