### PR TITLE
chore: redirect user to existing link in directory

### DIFF
--- a/src/client/directory/index.tsx
+++ b/src/client/directory/index.tsx
@@ -48,39 +48,6 @@ const useStyles = makeStyles(() =>
 type SearchPageProps = {}
 
 /**
- * Search query default parameters.
- */
-const defaultParams: GoSearchParams = {
-  query: '',
-  sortOrder: defaultSortOption,
-  rowsPerPage: 10,
-  currentPage: 0,
-  state: '',
-  isFile: '',
-  isEmail: 'false',
-}
-
-/**
- * Redirect back to directory page with parameters that are different from default parameters.
- */
-const redirectWithParams = (newParams: GoSearchParams, history: History) => {
-  const queryObject: any = { query: newParams.query }
-  Object.entries(newParams).map(([key, value], _) => {
-    if (value && value !== (defaultParams as any)[key]) {
-      queryObject[key] = value
-    }
-    return
-  })
-  const newPath = {
-    pathname: DIRECTORY_PAGE,
-    search: `${querystring.stringify(queryObject)}`,
-  }
-  history.push(newPath)
-}
-
-const updateQueryDebounced = debounce(redirectWithParams, 500)
-
-/**
  * @component Directory page root component.
  */
 const SearchPage: FunctionComponent<SearchPageProps> = () => {
@@ -90,13 +57,27 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
   const history = useHistory()
   const location = useLocation()
   const [pendingQuery, setPendingQuery] = useState('')
-  const [queryFile, setQueryFile] = useState<string>(defaultParams.isFile)
-  const [querystate, setQueryState] = useState<string>(defaultParams.state)
-  const [queryEmail, setQueryEmail] = useState<string>(defaultParams.isEmail)
+  const [disablePagination, setDisablePagination] = useState<boolean>(false)
+
+  /**
+   * Search query default parameters.
+   */
+  const defaultParams: GoSearchParams = {
+    query: new URLSearchParams(location.search).get('query') || '',
+    sortOrder: defaultSortOption,
+    rowsPerPage: 10,
+    currentPage: 0,
+    state: '',
+    isFile: '',
+    isEmail: 'false',
+  }
+
   const [queryOrder, setQueryOrder] = useState<SearchResultsSortOrder>(
     defaultParams.sortOrder,
   )
-  const [disablePagination, setDisablePagination] = useState<boolean>(false)
+  const [queryFile, setQueryFile] = useState<string>(defaultParams.isFile)
+  const [querystate, setQueryState] = useState<string>(defaultParams.state)
+  const [queryEmail, setQueryEmail] = useState<string>(defaultParams.isEmail)
 
   /**
    * Search parameters that includes the latest changes and retain default values for the others.
@@ -112,6 +93,28 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
   const rowsPerPage = Number(params.rowsPerPage)
   const currentPage = Number(params.currentPage)
   const rankOffset = rowsPerPage * currentPage
+  console.log(location)
+
+  /**
+   * Redirect back to directory page with parameters that are different from default parameters.
+   */
+  const redirectWithParams = (newParams: GoSearchParams, history: History) => {
+    const queryObject: any = { query: newParams.query }
+    Object.entries(newParams).map(([key, value], _) => {
+      if (value && value !== (defaultParams as any)[key]) {
+        queryObject[key] = value
+      }
+      return
+    })
+    const newPath = {
+      pathname: DIRECTORY_PAGE,
+      search: `${querystring.stringify(queryObject)}`,
+    }
+    history.push(newPath)
+  }
+
+  const updateQueryDebounced = debounce(redirectWithParams, 500)
+
   /** Dispatch action to get new results. */
   const getResults = () =>
     dispatch(
@@ -196,6 +199,7 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
       )
     }
   }
+
   // Google Analytics
   useEffect(() => {
     GAEvent('directory page', 'main')

--- a/src/client/directory/index.tsx
+++ b/src/client/directory/index.tsx
@@ -48,6 +48,39 @@ const useStyles = makeStyles(() =>
 type SearchPageProps = {}
 
 /**
+ * Search query default parameters.
+ */
+const defaultParams: GoSearchParams = {
+  query: '',
+  sortOrder: defaultSortOption,
+  rowsPerPage: 10,
+  currentPage: 0,
+  state: '',
+  isFile: '',
+  isEmail: 'false',
+}
+
+/**
+ * Redirect back to directory page with parameters that are different from default parameters.
+ */
+const redirectWithParams = (newParams: GoSearchParams, history: History) => {
+  const queryObject: any = { query: newParams.query }
+  Object.entries(newParams).map(([key, value], _) => {
+    if (value && value !== (defaultParams as any)[key]) {
+      queryObject[key] = value
+    }
+    return
+  })
+  const newPath = {
+    pathname: DIRECTORY_PAGE,
+    search: `${querystring.stringify(queryObject)}`,
+  }
+  history.push(newPath)
+}
+
+const updateQueryDebounced = debounce(redirectWithParams, 500)
+
+/**
  * @component Directory page root component.
  */
 const SearchPage: FunctionComponent<SearchPageProps> = () => {
@@ -57,27 +90,13 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
   const history = useHistory()
   const location = useLocation()
   const [pendingQuery, setPendingQuery] = useState('')
-  const [disablePagination, setDisablePagination] = useState<boolean>(false)
-
-  /**
-   * Search query default parameters.
-   */
-  const defaultParams: GoSearchParams = {
-    query: new URLSearchParams(location.search).get('query') || '',
-    sortOrder: defaultSortOption,
-    rowsPerPage: 10,
-    currentPage: 0,
-    state: '',
-    isFile: '',
-    isEmail: 'false',
-  }
-
-  const [queryOrder, setQueryOrder] = useState<SearchResultsSortOrder>(
-    defaultParams.sortOrder,
-  )
   const [queryFile, setQueryFile] = useState<string>(defaultParams.isFile)
   const [querystate, setQueryState] = useState<string>(defaultParams.state)
   const [queryEmail, setQueryEmail] = useState<string>(defaultParams.isEmail)
+  const [queryOrder, setQueryOrder] = useState<SearchResultsSortOrder>(
+    defaultParams.sortOrder,
+  )
+  const [disablePagination, setDisablePagination] = useState<boolean>(false)
 
   /**
    * Search parameters that includes the latest changes and retain default values for the others.
@@ -93,28 +112,6 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
   const rowsPerPage = Number(params.rowsPerPage)
   const currentPage = Number(params.currentPage)
   const rankOffset = rowsPerPage * currentPage
-  console.log(location)
-
-  /**
-   * Redirect back to directory page with parameters that are different from default parameters.
-   */
-  const redirectWithParams = (newParams: GoSearchParams, history: History) => {
-    const queryObject: any = { query: newParams.query }
-    Object.entries(newParams).map(([key, value], _) => {
-      if (value && value !== (defaultParams as any)[key]) {
-        queryObject[key] = value
-      }
-      return
-    })
-    const newPath = {
-      pathname: DIRECTORY_PAGE,
-      search: `${querystring.stringify(queryObject)}`,
-    }
-    history.push(newPath)
-  }
-
-  const updateQueryDebounced = debounce(redirectWithParams, 500)
-
   /** Dispatch action to get new results. */
   const getResults = () =>
     dispatch(
@@ -199,7 +196,6 @@ const SearchPage: FunctionComponent<SearchPageProps> = () => {
       )
     }
   }
-
   // Google Analytics
   useEffect(() => {
     GAEvent('directory page', 'main')

--- a/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
+++ b/src/client/user/components/CreateUrlModal/CreateLinkForm.tsx
@@ -315,7 +315,10 @@ const CreateLinkForm: FunctionComponent<CreateLinkFormProps> = ({
                   visible={!!createShortLinkError}
                   type={CollapsibleMessageType.Error}
                 >
-                  <a className={classes.shortLinkError} href="/#/directory">
+                  <a
+                    className={classes.shortLinkError}
+                    href={`/#/directory?query=${shortUrl}`}
+                  >
                     {createShortLinkError}
                   </a>
                 </CollapsibleMessage>

--- a/src/server/modules/user/UserController.ts
+++ b/src/server/modules/user/UserController.ts
@@ -98,7 +98,7 @@ export class UserController {
         return
       }
       if (error instanceof AlreadyExistsError) {
-        const newErrorMessage = `${error.message} Click here to find out more`
+        const newErrorMessage = `${error.message} Click here to find out who is the link owner & request for ownership.`
         res.badRequest(jsonMessage(newErrorMessage, MessageType.ShortUrlError))
         return
       }


### PR DESCRIPTION
## Problem

User Story 1 of [Link Transfer Feature](https://github.com/opengovsg/GoGovSG/pull/2179#:~:text=transfer%20feature%20(see-,Notion%20doc,-))

## Solution

This PR changes the following:

1. Changed `CreateLinkForm` component's error message for short URLs to redirect to `/#/directory?query=${shortUrl}` to query the short URL that already exists
2. Updated error message if short link already exists

**Note:**
With the change, the address bar will not reflect the query as the `useEffect` hook in `SearchPage` component for Directory (which handles the keyword/email search) would set the query to empty as the logic is run once upon initialisation - to be worked on a separate refactoring effort.

**Improvements**:

- When user attempts to create a short link that already exists, and clicks on the error message, they will be redirected to the directory page with the existing short link queried to show the owner of the link

## Before & After Screenshots

**BEFORE**:
![before_link_redir](https://user-images.githubusercontent.com/119388168/225196335-94214667-ed65-4d85-8827-dcad1e523118.gif)

**AFTER**:
![after_link_redir](https://user-images.githubusercontent.com/119388168/225196357-975b98e8-d963-41bd-88dd-78fce5e670a2.gif)