### PR TITLE
chore: fix error messages

### DIFF
--- a/src/server/serverless/bulk-qrcode-generation/index.js
+++ b/src/server/serverless/bulk-qrcode-generation/index.js
@@ -58,7 +58,7 @@ async function handler(event) {
     // cleanup
     await fsUtils.fsRmdirRecursiveSync(`/tmp/${jobItemId}`)
 
-    await httpService.sendHttpMessage(false, jobItemId, error)
+    await httpService.sendHttpMessage(false, jobItemId, error.message)
     throw new Error(`Failed to generate files, Error: ${error} `)
   }
 

--- a/src/server/serverless/bulk-qrcode-generation/s3.js
+++ b/src/server/serverless/bulk-qrcode-generation/s3.js
@@ -61,12 +61,14 @@ async function archiverZipStreamToS3(systemPath, s3Path) {
       })
       .catch((err) => {
         // upload error
-        reject(err)
+        reject(
+          new Error(`Error uploading from ${systemPath} to ${s3Path}: ${err}`),
+        )
       })
 
     archive.on('error', (err) => {
       // stream error
-      reject(err)
+      reject(new Error(`Error opening stream to s3: ${err}`))
     })
 
     // where archiver stream writes to


### PR DESCRIPTION
The error messages on the Lambda were not sending successfully to the server as the error object was in the wrong shape (object instead of string).

This PR is a quick fix to change the shape of the error object.