### PR TITLE
build: update ubuntu to 22 in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - run: npm run test:e2e-headless
   integration:
     name: Integration Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js


### PR DESCRIPTION
## Problem

GitHub action for integration tests is not running because it's using Ubuntu 18.04, which is [deprecated as of April 2023](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

This is blocking for any deployment/release because the build and deployment steps cannot happen before integration tests pass

Apologies, when merging in the integration tests PR #2091 (which was first opened before the ubuntu upgrade PR #2133), I didn't realise that the GitHub action was outdated

## Solution

Bump Ubuntu version from 18.04 to 22.04
