### PR TITLE
feat: allow zip files and block password-protected files

### DIFF
--- a/src/server/modules/threat/interfaces/FileTypeFilterService.ts
+++ b/src/server/modules/threat/interfaces/FileTypeFilterService.ts
@@ -1,4 +1,9 @@
 export interface FileTypeFilterService {
+  getExtension: (file: {
+    name: string
+    data: Buffer
+  }) => Promise<string | undefined>
+
   hasAllowedType: (
     file: {
       name: string

--- a/src/server/modules/threat/interfaces/VirusScanService.ts
+++ b/src/server/modules/threat/interfaces/VirusScanService.ts
@@ -1,5 +1,7 @@
 import fileUpload from 'express-fileupload'
 
 export interface VirusScanService {
-  hasVirus(file: fileUpload.UploadedFile): Promise<boolean>
+  scanFile(
+    file: fileUpload.UploadedFile,
+  ): Promise<{ hasVirus: boolean; isPasswordProtected: boolean }>
 }

--- a/src/server/modules/threat/services/FileTypeFilterService.ts
+++ b/src/server/modules/threat/services/FileTypeFilterService.ts
@@ -25,6 +25,7 @@ export const DEFAULT_ALLOWED_FILE_EXTENSIONS = [
   'tiff',
   'txt',
   'xlsx',
+  'zip',
 ]
 
 @injectable()
@@ -38,15 +39,22 @@ export class FileTypeFilterService implements interfaces.FileTypeFilterService {
     this.allowedFileExtensions = allowedFileExtensions
   }
 
+  getExtension: (file: {
+    name: string
+    data: Buffer
+  }) => Promise<string | undefined> = async ({ name, data }) => {
+    const fileType = await FileType.fromBuffer(data)
+    return fileType?.ext || name.split('.').pop()
+  }
+
   hasAllowedType: (
     file: {
       name: string
       data: Buffer
     },
     allowedExtensions?: string[],
-  ) => Promise<boolean> = async ({ name, data }, allowedExtensions) => {
-    const fileType = await FileType.fromBuffer(data)
-    const extension = fileType?.ext || name.split('.').pop()
+  ) => Promise<boolean> = async (file, allowedExtensions) => {
+    const extension = await this.getExtension(file)
     if (!extension) return false
 
     if (allowedExtensions && allowedExtensions.length > 0) {


### PR DESCRIPTION
## Problem

We want to allow users to upload zip files, but block users from uploading password-protected files (zip, pdf or otherwise) as Cloudmersive cannot properly scan them for viruses.

## Solution

1. Allow zip files to be uploaded
2. Switch from using basic file scanning to advanced file scanning on Cloudmersive. This gives us additional options to tell if the file is password protected or not, and block it from being uploaded if it is.

## Tests

On staging, we should test the following:
- [x] Regular non-password-protected files are allowed to be uploaded, including zip files
- [x] Password-protected files (zip, pdf) are blocked from being uploaded
- [x] 20mb files can still be scanned and uploaded within a reasonable amount of time

Should also update the tests on the release checklist to include password-protected zip/pdf files, if applicable?

## Deploy Notes

Unfortunately, this change doesn't do anything to address the already existing password-protected pdf files on Go, which have not been properly scanned for viruses :(
