### PR TITLE
fix: validate email before passing through glob expression

### DIFF
--- a/src/client/login/actions/index.ts
+++ b/src/client/login/actions/index.ts
@@ -115,8 +115,8 @@ const getEmailValidationGlobExpression =
           dispatch<SetEmailValidatorAction>(
             setEmailValidator((email: string) => {
               return (
-                globValidator.match(email) &&
-                validator.isEmail(email, { allow_utf8_local_part: false })
+                validator.isEmail(email, { allow_utf8_local_part: false }) &&
+                globValidator.match(email)
               )
             }),
           )


### PR DESCRIPTION
## Problem

Possible ReDoS vulnerability on the frontend from glob email validations. Very low severity as it does not affect the backend

Closes [Snyk issue](https://app.snyk.io/org/gogovsg/project/195ed33d-81b4-40d4-9918-45609ce999fb#issue-dce6fcc9-c1da-41db-a4a4-fd17f05ec812)

## Solution

Ensure that the email is validated to be an actual email, before passing it into the glob expression matcher.

## Tests

- [x] Tested manually locally, OTP logins still work
