### PR TITLE
build: bump alpine to 3.18 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.16
+FROM node:16-alpine3.18
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 
@@ -20,10 +20,10 @@ EXPOSE 8080
 # For dev webpack server only, proxies to localhost:8080
 EXPOSE 3000
 
-RUN apk update && apk add ttf-freefont && rm -rf /var/cache/apk/*
+RUN apk update && apk add font-freefont && rm -rf /var/cache/apk/*
 
-# Installs IBMPlexSans-Regular.ttf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/TTF/IBMPlexSans-Regular.ttf
+# Installs IBMPlexSans-Regular.otf for QRCodeService.
+RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
 RUN fc-cache -f
 
 # Install libraries

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=amd64 node:16-alpine3.16
+FROM --platform=amd64 node:16-alpine3.18
 
 LABEL maintainer="Open Government Products" email="go@open.gov.sg"
 
@@ -10,10 +10,10 @@ EXPOSE 8080
 # For dev webpack server only, proxies to localhost:8080
 EXPOSE 3000
 
-RUN apk update && apk add ttf-freefont && rm -rf /var/cache/apk/*
+RUN apk update && apk add font-freefont && rm -rf /var/cache/apk/*
 
-# Installs IBMPlexSans-Regular.ttf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/TTF/IBMPlexSans-Regular.ttf
+# Installs IBMPlexSans-Regular.otf for QRCodeService.
+RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
 RUN fc-cache -f
 
 # Install libraries


### PR DESCRIPTION
## Problem

Closes [Snyk issues](https://app.snyk.io/org/gogovsg/project/a466db86-e13b-4dd1-8b90-2eae048e51da)

## Solution

Upgraded the Dockerfile's node 16 alpine version from 3.16 to 3.18.

Unfortunately, the upgrade broke the font installation steps later on in the Dockerfile. Investigating this further, I found that in alpine 3.18, running `apk add ttf-freefont` actually installs the package `font-freefont` (`font-freefont-20120503-r4`), instead of `ttf-freefont` (`ttf-freefont-20120503-r2`) in alpine 3.16. Hence the resulting directory for fonts is no longer `/usr/share/fonts/TTF` (containing `.ttf` files), but `/usr/share/fonts/freefont` (containing `.otf` files). This PR fixes the font installation by downloading the `.otf` file into the `freefont` directory.

I couldn't find any documentation for this alpine change online... 💀💀

See #1317 and #170 for previous context on Go for including `ttf-freefont`

## Tests

- [x] Tested locally to ensure that QR code png/svg still works with the downloaded font
- [x] Tested on staging to ensure that QR code png/svg still works with the downloaded font
