### PR TITLE
build(deps): bump import-in-the-middle from 1.4.1 to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14323,9 +14323,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
-      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -38391,9 +38391,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
-      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "requires": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",


### PR DESCRIPTION
## Problem

Closes [Snyk issue](https://app.snyk.io/org/gogovsg/project/fecd1c42-72ac-477a-ac85-e757deb4f77a#issue-SNYK-JS-IMPORTINTHEMIDDLE-5826054)

## Solution

Upgrade `import-in-the-middle` from 1.4.1 to 1.4.2
