### PR TITLE
chore: fix serverless plugin include dependencies to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,8 @@ jobs:
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v3.0.0
         with:
-          args: -c "serverless plugin install --name serverless-plugin-include-dependencies && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
+          # serverless-plugin-include-dependencies v6 onwards requires node 18
+          args: -c "serverless plugin install --name serverless-plugin-include-dependencies@5.0.0 && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
           entrypoint: /bin/bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -422,7 +423,8 @@ jobs:
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v3.0.0
         with:
-          args: -c "serverless plugin install --name serverless-plugin-include-dependencies && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
+          # serverless-plugin-include-dependencies v6 onwards requires node 18
+          args: -c "serverless plugin install --name serverless-plugin-include-dependencies@5.0.0 && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
           entrypoint: /bin/bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -548,7 +550,8 @@ jobs:
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v3.0.0
         with:
-          args: -c "serverless plugin install --name serverless-plugin-include-dependencies && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
+          # serverless-plugin-include-dependencies v6 onwards requires node 18
+          args: -c "serverless plugin install --name serverless-plugin-include-dependencies@5.0.0 && serverless deploy --stage=$BRANCH_ENV --conceal --verbose"
           entrypoint: /bin/bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Problem

Serverless deployment is failing recently, because we're using the most recent version of the `serverless-plugin-include-dependencies` plugin (v6.0.0, released 2 weeks ago). This version requires node >=18, but serverless is currently on node 14.

## Solution

Fix `serverless-plugin-include-dependencies` at v5.0.0, which is its one and only v5 release. v5 is compatible with node 14.
