### PR TITLE
Chore/fix user query

### DIFF
--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -76,8 +76,10 @@ export class UrlManagementService implements interfaces.UrlManagementService {
       shortUrl = await generateShortUrl(API_LINK_RANDOM_STR_LENGTH)
     }
 
-    const owner = await this.userRepository.findUserByUrl(shortUrl)
-    if (owner) {
+    const isShortUrlAvailable = await this.urlRepository.isShortUrlAvailable(
+      shortUrl,
+    )
+    if (!isShortUrlAvailable) {
       throw new AlreadyExistsError(`Short link "${shortUrl}" is already used.`)
     }
 

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -184,9 +184,10 @@ export class UrlRepository implements UrlRepositoryInterface {
   ) => {
     try {
       // Cache lookup
+      await this.getLongUrlFromCache(shortUrl)
       // if long url does not exist, throws error
-      const longUrl = await this.getLongUrlFromCache(shortUrl)
-      return !longUrl
+      // return false if no error since long url exists
+      return false
     } catch {
       // Cache failed, look in database
       const url = await Url.findOne({

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -175,6 +175,27 @@ export class UrlRepository implements UrlRepositoryInterface {
     return this.urlMapper.persistenceToDto(newUrl)
   }
 
+  /**
+   * @param  {string} shortUrl Short url.
+   * @returns {Promise<boolean>} Returns true if shortUrl is available and false otherwise.
+   */
+  public isShortUrlAvailable: (shortUrl: string) => Promise<boolean> = async (
+    shortUrl,
+  ) => {
+    try {
+      // Cache lookup
+      // if long url does not exist, throws error
+      const longUrl = await this.getLongUrlFromCache(shortUrl)
+      return !longUrl
+    } catch {
+      // Cache failed, look in database
+      const url = await Url.findOne({
+        where: { shortUrl },
+      })
+      return !url
+    }
+  }
+
   public getLongUrl: (shortUrl: string) => Promise<string> = async (
     shortUrl,
   ) => {

--- a/src/server/repositories/interfaces/UrlRepositoryInterface.ts
+++ b/src/server/repositories/interfaces/UrlRepositoryInterface.ts
@@ -44,6 +44,12 @@ export interface UrlRepositoryInterface {
   ): Promise<StorableUrl>
 
   /**
+   * Returns true if shortUrl is available, otherwise false.
+   * @param {string} shortUrl The shortUrl.
+   */
+  isShortUrlAvailable: (shortUrl: string) => Promise<boolean>
+
+  /**
    * Looks up the longUrl given a shortUrl from the cache, falling back
    * to the database. The cache is re-populated if the database lookup is
    * performed successfully.

--- a/test/server/mocks/repositories/UrlRepository.ts
+++ b/test/server/mocks/repositories/UrlRepository.ts
@@ -39,6 +39,10 @@ export class UrlRepositoryMock implements UrlRepositoryInterface {
     throw new Error('Not implemented')
   }
 
+  isShortUrlAvailable: (shortUrl: string) => Promise<boolean> = () => {
+    throw new Error('Not implemented')
+  }
+
   getLongUrl: (shortUrl: string) => Promise<string> = () => {
     throw new Error('Not implemented')
   }


### PR DESCRIPTION
## Problem
Optimising our current query to check if short link exists. Previous query was doing an unnecessary join on the users table, causing the query duration to spike.

![Screenshot 2024-03-18 at 5 34 26 PM](https://github.com/opengovsg/GoGovSG/assets/39231249/5d60a650-6e92-4fac-bf95-e8074df7821f)


## Solution
Replaced query to only check in urls table instead of joining urls with user table.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2024-03-18 at 5 44 04 PM](https://github.com/opengovsg/GoGovSG/assets/39231249/3c1f5c1d-786f-4c42-b5e2-859eb46d60ca)

**AFTER**:
![Screenshot 2024-03-18 at 5 35 38 PM](https://github.com/opengovsg/GoGovSG/assets/39231249/ee5b523c-86ab-4cfe-9974-f83e3a984a12)


## Tests
- [x] Ran load tests on staging to check if query duration reduced.

**E2E Manual tests**
- [x] If short link is already used, should not be able to create short link
- [x] When creating new links via APIs, should be able to create shortened link without specifying short link
- [x] When creating new links via APIs, if short link is already used, should not be able to create short link