### PR TITLE
chore: replace safe browsing with web risk

### DIFF
--- a/src/server/modules/threat/interfaces/SafeBrowsingRepository.ts
+++ b/src/server/modules/threat/interfaces/SafeBrowsingRepository.ts
@@ -1,17 +1,17 @@
-import { HasCacheDuration } from '../../../repositories/types'
+import { WebRiskThreat } from '../../../repositories/types'
 
 export interface SafeBrowsingRepository {
   /**
    * Sets or replaces the Safe Browsing threat matches associated with a URL.
    * @param  {string} url The URL.
-   * @param  {Array<HasCacheDuration>} matches The threat matches returned by Safe Browsing for the URL.
+   * @param  {WebRiskThreat} threat The threat match returned by Safe Browsing for the URL.
    */
-  set(url: string, matches: HasCacheDuration[]): Promise<void>
+  set(url: string, threat: WebRiskThreat): Promise<void>
 
   /**
    * Retrieves Safe Browsing threat matches for a URL, if any.
    * @param  {string} url The URL.
-   * @returns {Promise<Array<HasCacheDuration> | null>} An array of threat matches, or null if none.
+   * @returns {Promise<WebRiskThreat | null>} Threat match or null if none.
    */
-  get(url: string): Promise<HasCacheDuration[] | null>
+  get(url: string): Promise<WebRiskThreat | null>
 }

--- a/src/server/modules/threat/mappers/SafeBrowsingMapper.ts
+++ b/src/server/modules/threat/mappers/SafeBrowsingMapper.ts
@@ -1,27 +1,25 @@
 /* eslint-disable class-methods-use-this, lines-between-class-members, no-dupe-class-members */
 import { injectable } from 'inversify'
 import { TwoWayMapper } from '../../../mappers/TwoWayMapper'
-import { HasCacheDuration } from '../../../repositories/types'
+import { WebRiskThreat } from '../../../repositories/types'
 
 @injectable()
-export class SafeBrowsingMapper
-  implements TwoWayMapper<HasCacheDuration[], string>
-{
-  persistenceToDto(matches: string): HasCacheDuration[]
-  persistenceToDto(matches: string | null): HasCacheDuration[] | null {
-    if (!matches) {
+export class SafeBrowsingMapper implements TwoWayMapper<WebRiskThreat, string> {
+  persistenceToDto(threat: string): WebRiskThreat
+  persistenceToDto(threat: string | null): WebRiskThreat | null {
+    if (!threat) {
       return null
     }
-    return JSON.parse(matches)
+    return JSON.parse(threat)
   }
 
-  dtoToPersistence(matches: HasCacheDuration[]): string
-  dtoToPersistence(matches: HasCacheDuration[] | null): string | null {
-    if (!matches) {
+  dtoToPersistence(threat: WebRiskThreat): string
+  dtoToPersistence(threat: WebRiskThreat | null): string | null {
+    if (!threat) {
       return null
     }
 
-    return JSON.stringify(matches)
+    return JSON.stringify(threat)
   }
 }
 

--- a/src/server/modules/threat/repositories/__tests__/SafeBrowsingRepository.test.ts
+++ b/src/server/modules/threat/repositories/__tests__/SafeBrowsingRepository.test.ts
@@ -14,15 +14,14 @@ const { SafeBrowsingRepository } = require('..')
 
 const repository = new SafeBrowsingRepository(new SafeBrowsingMapper())
 
-const durationInSeconds = 1
+const durationInSeconds = 300
 const url = 'https://example.com'
-const matches = [
-  {
-    cacheDuration: `${durationInSeconds}s`,
-  },
-]
+const threat = {
+  threatTypes: ['MALWARE'],
+  expireTime: '2024-03-20T05:29:41.898456500Z',
+}
 
-describe('otp repository redis test', () => {
+describe('safe browsing repository redis test', () => {
   beforeEach(async () => {
     await new Promise<void>((resolve) => {
       redisMockClient.flushall(() => resolve())
@@ -32,8 +31,8 @@ describe('otp repository redis test', () => {
   })
 
   it('returns a value if present', async () => {
-    redisMockClient.set(url, JSON.stringify(matches))
-    await expect(repository.get(url)).resolves.toStrictEqual(matches)
+    redisMockClient.set(url, JSON.stringify(threat))
+    await expect(repository.get(url)).resolves.toStrictEqual(threat)
     expect(redisMockClient.get).toBeCalledWith(url, expect.any(Function))
   })
 
@@ -43,10 +42,10 @@ describe('otp repository redis test', () => {
   })
 
   it('sets a value if specified', async () => {
-    await repository.set(url, matches)
+    await repository.set(url, threat)
     expect(redisMockClient.set).toBeCalledWith(
       url,
-      JSON.stringify(matches),
+      JSON.stringify(threat),
       'EX',
       durationInSeconds,
       expect.any(Function),

--- a/src/server/modules/threat/services/SafeBrowsingService.ts
+++ b/src/server/modules/threat/services/SafeBrowsingService.ts
@@ -5,9 +5,14 @@ import { UrlThreatScanService } from '../interfaces'
 import { logger, safeBrowsingKey, safeBrowsingLogOnly } from '../../../config'
 import { SafeBrowsingRepository } from '../interfaces/SafeBrowsingRepository'
 import { DependencyIds } from '../../../constants'
+import { WebRiskThreat } from '../../../repositories/types'
 
-const ENDPOINT = `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${safeBrowsingKey}`
-const SAFE_BROWSING_LIMIT = 500
+const ENDPOINT = `https://webrisk.googleapis.com/v1/uris:search?key=${safeBrowsingKey}`
+const WEB_RISK_THREAT_TYPES = [
+  'SOCIAL_ENGINEERING',
+  'MALWARE',
+  'UNWANTED_SOFTWARE',
+]
 
 @injectable()
 export class SafeBrowsingService implements UrlThreatScanService {
@@ -22,117 +27,82 @@ export class SafeBrowsingService implements UrlThreatScanService {
     this.safeBrowsingRepository = safeBrowsingRepository
   }
 
-  /**
-   * Request template for Safe Browsing. Threat lists found
-   * at /v4/threatLists and are keyed by type, platform and entry.
-   * Both ANY_PLATFORM and all the platforms are specified, the latter
-   * so that we can look up the IP_RANGE lists, which are not keyed by
-   * ANY_PLATFORM.
-   */
-  private requestTemplate = Object.freeze({
-    client: {
-      clientId: 'GoGovSG',
-      clientVersion: '1.0.0',
-    },
-    threatInfo: {
-      threatTypes: [
-        'POTENTIALLY_HARMFUL_APPLICATION',
-        'UNWANTED_SOFTWARE',
-        'MALWARE',
-        'SOCIAL_ENGINEERING',
-      ],
-      platformTypes: ['ANY_PLATFORM', 'WINDOWS', 'LINUX', 'OSX'],
-      threatEntryTypes: ['URL', 'EXECUTABLE', 'IP_RANGE'],
-    },
-  })
-
   public isThreat: (url: string) => Promise<boolean> = async (url) => {
     if (!safeBrowsingKey) {
       logger.warn(`No Safe Browsing API key provided. Not scanning url: ${url}`)
       return false
     }
-    let matches = await this.safeBrowsingRepository.get(url)
-    if (!matches) {
-      matches = await this.lookup([url])
+    let threat = await this.safeBrowsingRepository.get(url)
+    if (!threat) {
+      threat = await this.fetchWebRiskData(url)
     }
-    return !safeBrowsingLogOnly && Boolean(matches)
+    return !safeBrowsingLogOnly && Boolean(threat)
   }
 
-  private async lookup(urls: string[]) {
-    let matches = null
-    const request = { ...this.requestTemplate } as any
+  private constructWebRiskEndpoint: (
+    url: string,
+    threatTypes: string[],
+  ) => string = (url, threatTypes) => {
+    const encodedUrl = encodeURIComponent(url)
 
-    request.threatInfo.threatEntries = urls.map((url) => {
-      return { url }
-    })
+    const threatTypesQuery = threatTypes
+      .map((type: string) => `threatTypes=${type}`)
+      .join('&')
 
-    const response = await fetch(ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(request),
-    })
-    const body = await response.json()
-    if (!response.ok) {
-      const error = new Error(
-        `Safe Browsing failure:\tError: ${response.statusText}\t message: ${body.error.message}`,
-      )
-      if (safeBrowsingLogOnly) {
-        logger.error(error.message)
-      } else {
-        throw error
-      }
-    } else if (body?.matches) {
-      const prefix = safeBrowsingLogOnly
-        ? 'Considered threat by Safe Browsing but ignoring'
-        : 'Malicious link content'
+    return `${ENDPOINT}&${threatTypesQuery}&uri=${encodedUrl}`
+  }
 
-      /**
-       * Result.matches is a list of threat matches for all matched urls, example:
-       * [{ "threatType": "SOCIAL_ENGINEERING", "threat": { "url": "https://testsafebrowsing.appspot.com/s/phishing.html" } }]
-       * we use _.groupBy to group threat matches by url so that the serialized form
-       * matches what is currently written into our repository for single url lookups.
-       */
-      const matchesByUrl = _.groupBy(body.matches, (obj) => obj.threat.url)
-      Object.entries(matchesByUrl).forEach(
-        ([url, threatMatch]: [string, any]) => {
+  private fetchWebRiskData: (url: string) => Promise<WebRiskThreat | null> =
+    async (url) => {
+      const endpoint = this.constructWebRiskEndpoint(url, WEB_RISK_THREAT_TYPES)
+
+      const response = await fetch(endpoint, { method: 'GET' })
+      const body = await response.json()
+      if (!response.ok) {
+        const error = new Error(
+          `Safe Browsing failure:\tError: ${response.statusText}\t message: ${body.error.message}`,
+        )
+        if (safeBrowsingLogOnly) {
+          logger.error(error.message)
+        } else {
+          throw error
+        }
+      } else if (body?.threat) {
+        const prefix = safeBrowsingLogOnly
+          ? 'Considered threat by Safe Browsing but ignoring'
+          : 'Malicious link content'
+
+        /**
+         * Result.threat.threatTypes is a list of threat matches for a url, example:
+         * "threat": { "threatTypes": ["MALWARE"], "expireTime": "2024-03-20T05:29:41.898456500Z"}.
+         */
+        logger.warn(
+          `${prefix}: ${url} yields ${JSON.stringify(body.threat, null, 2)}`,
+        )
+        try {
+          // writing to the safeBrowsingRepository should be non-blocking
+          this.safeBrowsingRepository.set(url, body.threat)
+        } catch (e) {
+          // writes are wrapped in a try-catch block to prevent errors from bubbling up
           logger.warn(
-            `${prefix}: ${url} yields ${JSON.stringify(threatMatch, null, 2)}`,
+            `failed to set ${url} in safeBrowsingRepository, skipping`,
           )
-          try {
-            // writing to the safeBrowsingRepository should be non-blocking
-            this.safeBrowsingRepository.set(url, threatMatch)
-          } catch (e) {
-            // writes are wrapped in a try-catch block to prevent errors from bubbling up
-            logger.warn(
-              `failed to set ${url} in safeBrowsingRepository, skipping`,
-            )
-          }
-        },
-      )
-      matches = body.matches
+        }
+        return body.threat
+      }
+      return null
     }
-    return matches
-  }
 
-  public isThreatBulk: (
-    urls: string[],
-    batchSize?: number,
-  ) => Promise<boolean> = async (urls, batchSize = SAFE_BROWSING_LIMIT) => {
+  public isThreatBulk: (urls: string[]) => Promise<boolean> = async (urls) => {
     if (!safeBrowsingKey) {
       logger.warn(`No Safe Browsing API key provided. Not scanning in bulk`)
       return false
     }
 
-    const urlChunks: string[][] = []
-
-    for (let i = 0; i < urls.length; i += batchSize) {
-      urlChunks.push(urls.slice(i, i + batchSize))
-    }
-
-    const matches = await Promise.all(
-      urlChunks.map((urlChunk) => this.lookup(urlChunk)),
+    const results = await Promise.all(
+      urls.map((url) => this.fetchWebRiskData(url)),
     )
-    const isThreat = matches.some((match) => Boolean(match) === true)
+    const isThreat = results.some((result) => Boolean(result))
     if (!safeBrowsingLogOnly && isThreat) {
       return true
     }

--- a/src/server/modules/threat/services/SafeBrowsingService.ts
+++ b/src/server/modules/threat/services/SafeBrowsingService.ts
@@ -12,6 +12,10 @@ const WEB_RISK_THREAT_TYPES = [
   'SOCIAL_ENGINEERING',
   'MALWARE',
   'UNWANTED_SOFTWARE',
+  // SOCIAL_ENGINEERING_EXTENDED_COVERAGE improves coverage of malicious urls
+  // but may have small amount (<10%) of potential false positives,
+  // see details https://cloud.google.com/web-risk/docs/extended-coverage
+  'SOCIAL_ENGINEERING_EXTENDED_COVERAGE',
 ]
 
 @injectable()

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -87,12 +87,7 @@ export type StorableOtp = {
   retries: number
 }
 
-/**
- * Has a cache duration expressed as a human-readable
- * time interval. An example of this is the threat matches
- * returned by Google Safe Browsing, which have a cacheDuration
- * specified as the number of seconds followed by 's'.
- */
-export type HasCacheDuration = {
-  cacheDuration: string
+export type WebRiskThreat = {
+  threatTypes: string[]
+  expireTime: string
 }


### PR DESCRIPTION
## Context

Replaces Google Safe Browsing with Google Web Risk API, which has no daily quotas on number of links scanned. 

**Notes**
- There seems to be minor differences in the threat types detected by Web Risk and Safe Browsing.
  -  Web Risk: `MALWARE` `SOCIAL_ENGINEERING` `UNWANTED_SOFTWARE` `SOCIAL_ENGINEERING_EXTENDED_COVERAGE`
  - Safe Browsing: `MALWARE` `SOCIAL_ENGINEERING` `UNWANTED_SOFTWARE` `POTENTIALLY_HARMFUL_APPLICATION`
  - Checking w the Google team right now whether this will cause any adverse effect /regression
- Required abit of refactoring as the return types for Safe Browsing is different from Web Risk
  Safe Browsing return:
  ```
  // pass in list of urls, 
  // if threats found, returns list of matched threats
  {"matches": [{  "threatType":  "MALWARE", "platformType":  "WINDOWS", "threatEntryType": "URL", "threat": {"url": "http://www.urltocheck1.org/"}, "threatEntryMetadata": { "entries": [{ "key": "malware_threat_type", "value": "landing" }]}, "cacheDuration": "300.000s"}]}
  // if no threats 
  {}
  ```
  Web Risk return:
  ```
  // only single lookup endpoint available
  // if threat found, returns threat as object
  { "threat": { "threatTypes": ["MALWARE"], "expireTime": "2024-03-20T05:29:41.898456500Z"} }
  // if no threats
  {}
  ```

## Tests
Tests on staging
- [x] Try creating short link to malicious url, should see error "Link is likely malicious, please contact us for help"
- [x] Create short link to safe url, should be able to create short link
- [x] [API] Create short link to safe url, should be able to create short link
- [x] [API] Try creating short link to malicious url, should see error "Link is likely malicious, please contact us for help" 
- [x] [Bulk] Try creating short links with bulk upload of 500 links, all safe, should be able to bulk create
- [x] [Bulk] Try creating short links with bulk upload of 500 links, at least one malicious link, should not be able to bulk create
- [x] See usage on Web Risk API on Google console

## Deploy Notes
Before deploying,
- [ ] Activate Web Risk API on edu prod
- [ ] Activate Web Risk API on go prod
- [ ] Activate Web Risk API on health prod

After deployment, tests on production, 3 environments
- [ ] Try creating short link to malicious url, should see error "Link is likely malicious, please contact us for help"
- [ ] Create short link to safe url, should be able to create short link
- [ ] [API] Create short link to safe url, should be able to create short link
- [ ] [API] Try creating short link to malicious url, should see error "Link is likely malicious, please contact us for help" 
- [ ] [Bulk] Try creating short links with bulk upload of 500 links, all safe, should be able to bulk create
- [ ] [Bulk] Try creating short links with bulk upload of 500 links, at least one malicious link, should not be able to bulk 

**New environment variables**:
None, reusing existing Safe Browsing API keys
