### PR TITLE
[draft] feat: allow directory search ranking by relevance

### DIFF
--- a/src/client/directory/constants.ts
+++ b/src/client/directory/constants.ts
@@ -4,10 +4,11 @@ import { SearchResultsSortOrder } from '../../shared/search'
  * The available sorting options for GoDirectory which includes popularity and recency.
  */
 export const sortOptions = [
+  { key: SearchResultsSortOrder.Relevance, label: 'Most relevant' },
   { key: SearchResultsSortOrder.Popularity, label: 'Most popular' },
   { key: SearchResultsSortOrder.Recency, label: 'Most recent' },
 ]
 
-export const defaultSortOption = SearchResultsSortOrder.Recency
+export const defaultSortOption = SearchResultsSortOrder.Relevance
 
 export default { sortOptions, defaultSortOption }

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -226,6 +226,7 @@ export class UrlRepository implements UrlRepositoryInterface {
       order,
       urlTableName,
       urlClicksTableName,
+      urlVector,
     )
 
     const urlsModel = await (isEmail
@@ -548,17 +549,22 @@ export class UrlRepository implements UrlRepositoryInterface {
    * @param  {SearchResultsSortOrder} order
    * @param  {string} urlTableName
    * @param  {string} urlClicksTableName
+   * @param  {string} urlVector
    * @returns The clause as a string.
    */
   private getRankingAlgorithm(
     order: SearchResultsSortOrder,
     urlTableName: string,
     urlClicksTableName: string,
+    urlVector: string,
   ): string {
     let rankingAlgorithm
     switch (order) {
       case SearchResultsSortOrder.Recency:
         rankingAlgorithm = `${urlTableName}."createdAt"`
+        break
+      case SearchResultsSortOrder.Relevance:
+        rankingAlgorithm = `ts_rank(${urlVector}, query)`
         break
       case SearchResultsSortOrder.Popularity:
         rankingAlgorithm = `${urlClicksTableName}.clicks`

--- a/src/shared/search.ts
+++ b/src/shared/search.ts
@@ -1,6 +1,7 @@
 export enum SearchResultsSortOrder {
   Popularity = 'popularity',
   Recency = 'recency',
+  Relevance = 'relevance',
 }
 
 export default { SearchResultsSortOrder }


### PR DESCRIPTION
## Problem

Closes #2321

## Solution

Allow another search result sorting metric: relevance.

**Features**:

- Allow sorting directory search results by relevance

## Before & After Screenshots

**BEFORE**:
<img width="1380" alt="Screenshot 2024-06-04 at 12 43 47 PM" src="https://github.com/opengovsg/GoGovSG/assets/932949/645b9c25-c30c-486d-ae6f-c026f978bbf9">

**AFTER**:
<img width="1380" alt="Screenshot 2024-06-04 at 12 42 04 PM" src="https://github.com/opengovsg/GoGovSG/assets/932949/854f26e9-8095-4071-b1a2-229a5b46fa12">

## Tests

1. Create a few shortlinks with similar names.
2. Search in the directory.
3. Observe if closest matches are shown first