### PR TITLE
build: fix link to ibm plex sans font

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,8 +9,8 @@ RUN sudo apt-get update \
 RUN sudo mkdir -p /docker-entrypoint-initaws.d
 RUN sudo chown gitpod /docker-entrypoint-initaws.d
 
-# Installs IBMPlexSans-Regular.ttf for QRCodeService.
-RUN sudo wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf?raw=true -O /usr/share/fonts/truetype/IBMPlexSans-Regular.ttf
+# Installs IBMPlexSans-Regular.otf for QRCodeService.
+RUN sudo wget https://github.com/IBM/plex/blob/master/packages/plex-sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/truetype/IBMPlexSans-Regular.otf
 RUN sudo fc-cache -f
 
 USER gitpod

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ EXPOSE 3000
 RUN apk update && apk add font-freefont && rm -rf /var/cache/apk/*
 
 # Installs IBMPlexSans-Regular.otf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
+RUN wget https://github.com/IBM/plex/blob/master/packages/plex-sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
 RUN fc-cache -f
 
 # Install libraries

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ EXPOSE 3000
 RUN apk update && apk add font-freefont && rm -rf /var/cache/apk/*
 
 # Installs IBMPlexSans-Regular.otf for QRCodeService.
-RUN wget https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
+RUN wget https://github.com/IBM/plex/blob/master/packages/plex-sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true -O /usr/share/fonts/freefont/IBMPlexSans-Regular.otf
 RUN fc-cache -f
 
 # Install libraries

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "client-dev": "webpack serve --mode development --host 0.0.0.0 --devtool inline-source-map --hot",
     "server-dev": "ts-node-dev --poll --respawn --transpile-only --inspect=0.0.0.0 -r dotenv/config -- src/server/index.ts",
     "docker-dev": "concurrently \"npm run server-dev\" \"npm run client-dev\"",
-    "dev": "docker-compose -f docker-compose.yml up --build",
+    "dev": "docker compose -f docker-compose.yml up --build",
     "test": "jest --collectCoverage",
     "test:ci": "jest --coverage && coveralls < coverage/lcov.info",
     "test:e2e": "testcafe chrome ./test/end-to-end --app \"npm run dev\" --app-init-delay 270000",


### PR DESCRIPTION
This PR fixes some build issues:
1. `npm run dev` fails because the link to retrieve the IBM plex sans font is broken
   - Solution: replace the broken link (https://github.com/IBM/plex/blob/master/IBM-Plex-Sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true) with the updated link (https://github.com/IBM/plex/blob/master/packages/plex-sans/fonts/complete/otf/IBMPlexSans-Regular.otf?raw=true)
   - There could be better solutions (e.g. download a copy of the OTF file into this repo, use a fixed commit hash instead of referencing the `master` branch, use Google fonts API), but refraining from making further more extensive changes for now
2. GitHub actions are failing because `docker-compose` no longer exists, see [this discussion](https://github.com/orgs/community/discussions/116610)
   - Solution: replaced it with `docker compose` (without the dash)

## Tests

- [x] Test on staging that QR code generation works (png + svg)