### PR TITLE
chore: escape raw html

### DIFF
--- a/src/server/views/404.error.ejs
+++ b/src/server/views/404.error.ejs
@@ -6,10 +6,10 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta http-equiv="Content-Language" content="en">
     <meta charset="UTF-8">
-    <title><%- displayHostname %>: Page not found</title>
+    <title><%= displayHostname %>: Page not found</title>
     <base href="~/" />
     <link href="/assets/styles/shared/shared-styles.css" rel="stylesheet">
-    <link href="/assets/<%- assetVariant %>/styles/colours.css" rel="stylesheet">
+    <link href="/assets/<%= assetVariant %>/styles/colours.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="/assets/styles/not-found-page/not-found-page.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -17,7 +17,7 @@
 
 <body>
     <% if(assetVariant === 'gov') { %> 
-        <%- include('partial-masthead') %> 
+        <%= include('partial-masthead') %> 
     <% } %>
     <main id="main-container">
         <div id="main-message-container">
@@ -29,11 +29,11 @@
         <div id="divider" class="divider"></div>
         <div id="graphics-container">
             <div id="graphic-div">
-                <img src="/assets/<%- assetVariant %>/not-found-page/images/not-found-graphic.svg" draggable="false" />
+                <img src="/assets/<%= assetVariant %>/not-found-page/images/not-found-graphic.svg" draggable="false" />
             </div>
             <div id="go-logo-div">
                 <!-- go logo -->
-                <img src="/assets/<%- assetVariant %>/not-found-page/icons/go-logo.svg" draggable="false" />
+                <img src="/assets/<%= assetVariant %>/not-found-page/icons/go-logo.svg" draggable="false" />
             </div>
         </div>
     </main>

--- a/src/server/views/404.error.ejs
+++ b/src/server/views/404.error.ejs
@@ -17,7 +17,7 @@
 
 <body>
     <% if(assetVariant === 'gov') { %> 
-        <%= include('partial-masthead') %> 
+        <%- include('partial-masthead') %> 
     <% } %>
     <main id="main-container">
         <div id="main-message-container">

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -23,7 +23,7 @@
         <div class="top-half-content">
             <h3>Check your address bar</h3>
             <a href="https://go.gov.sg/go-antiphishing" target="_blank" rel="noreferrer noopener">Beware of phishing! <br class="mobile-break">Make sure your link starts with <%= displayHostname.toLowerCase() %></a>
-            <p id="url" data-href="<%= escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
+            <p id="url" data-href="<%- escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
             <img id="spinner" src="/assets/<%= assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
             <div class="browser-image" style="background-image: url('/assets/<%= assetVariant %>/transition-page/images/browser.svg');">
                 <div class="links links-<%= assetVariant %>" ><%= displayHostname.toLowerCase() %>/</div>

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -6,9 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta http-equiv="Content-Language" content="en">
     <meta charset="UTF-8">
-    <title><%- displayHostname %></title>
+    <title><%= displayHostname %></title>
     <link href="/assets/styles/shared/shared-styles.css" rel="stylesheet">
-    <link href="/assets/<%- assetVariant %>/styles/colours.css" rel="stylesheet">
+    <link href="/assets/<%= assetVariant %>/styles/colours.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="/assets/styles/transition-page/transition-page.css" rel="stylesheet">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
@@ -17,16 +17,16 @@
 
 <body>
     <% if(assetVariant === 'gov') { %> 
-        <%- include('partial-masthead') %> 
+        <%= include('partial-masthead') %> 
     <% } %>
     <div class="top-half">
         <div class="top-half-content">
             <h3>Check your address bar</h3>
-            <a href="https://go.gov.sg/go-antiphishing" target="_blank" rel="noreferrer noopener">Beware of phishing! <br class="mobile-break">Make sure your link starts with <%- displayHostname.toLowerCase() %></a>
-            <p id="url" data-href="<%- escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
-            <img id="spinner" src="/assets/<%- assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
-            <div class="browser-image" style="background-image: url('/assets/<%- assetVariant %>/transition-page/images/browser.svg');">
-                <div class="links links-<%- assetVariant %>" ><%- displayHostname.toLowerCase() %>/</div>
+            <a href="https://go.gov.sg/go-antiphishing" target="_blank" rel="noreferrer noopener">Beware of phishing! <br class="mobile-break">Make sure your link starts with <%= displayHostname.toLowerCase() %></a>
+            <p id="url" data-href="<%= escapedLongUrl %>">You will be redirected in <span id="countdown-seconds">6</span> second<span id="s">s</span></p>
+            <img id="spinner" src="/assets/<%= assetVariant %>/transition-page/images/spinner.gif" alt="loading" />
+            <div class="browser-image" style="background-image: url('/assets/<%= assetVariant %>/transition-page/images/browser.svg');">
+                <div class="links links-<%= assetVariant %>" ><%= displayHostname.toLowerCase() %>/</div>
             </div>
         </div>
     </div>
@@ -34,11 +34,11 @@
         
         <div id="skip">
             <span>I've checked the link. Skip ahead</span>
-            <img src="/assets/<%- assetVariant %>/transition-page/icons/icon-arrow-right.svg" alt="right arrow" />
+            <img src="/assets/<%= assetVariant %>/transition-page/icons/icon-arrow-right.svg" alt="right arrow" />
         </div>
         <div class="footer">
             <div id="logo">
-                <img src="/assets/<%- assetVariant %>/transition-page/icons/ogp-logo.svg" alt="ogp logo" />
+                <img src="/assets/<%= assetVariant %>/transition-page/icons/ogp-logo.svg" alt="ogp logo" />
             </div>
             <p>You will only be shown this page the first time you access this short link.</p>
         </div>

--- a/src/server/views/transition-page.ejs
+++ b/src/server/views/transition-page.ejs
@@ -17,7 +17,7 @@
 
 <body>
     <% if(assetVariant === 'gov') { %> 
-        <%= include('partial-masthead') %> 
+        <%- include('partial-masthead') %> 
     <% } %>
     <div class="top-half">
         <div class="top-half-content">


### PR DESCRIPTION
## Problem
Go uses raw html for templating without escaping them. This PR adds that in. 

## Solution
add escaping into the html template (ejs [docs](https://ejs.co/#docs))