### PR TITLE
isom-2008 feat(redirect): enhance checks for bypassing transition page

### DIFF
--- a/src/server/modules/redirect/services/RedirectService.ts
+++ b/src/server/modules/redirect/services/RedirectService.ts
@@ -68,7 +68,7 @@ export class RedirectService {
       }
     }
 
-    const isFromTrustedPage = referrer.startsWith(ogUrl)
+    const isFromTrustedPage = RedirectService.isFromTrustedPage(referrer)
 
     const renderTransitionPage =
       !this.cookieArrayReducerService.userHasVisitedShortlink(
@@ -87,6 +87,23 @@ export class RedirectService {
       redirectType: renderTransitionPage
         ? RedirectType.TransitionPage
         : RedirectType.Direct,
+    }
+  }
+
+  /**
+   * Checks whether the referrer is from a trusted page (same origin as ogUrl).
+   * This prevents malicious sites from bypassing the transition page.
+   * @param {string} referrer - The referrer URL to check.
+   * @returns {boolean} - True if referrer is from trusted origin, false otherwise.
+   */
+  private static isFromTrustedPage(referrer: string): boolean {
+    try {
+      const referrerUrl = new URL(referrer)
+      const trustedUrl = new URL(ogUrl)
+      return referrerUrl.origin === trustedUrl.origin
+    } catch {
+      // If referrer is not a valid URL, treat as untrusted
+      return false
     }
   }
 

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -59,7 +59,7 @@ describe('RedirectService', () => {
     )
   })
 
-  describe('referrer validation', () => {
+  describe('redirectFor', () => {
     it('should allow direct redirect for exact ogUrl match when user has not visited before', async () => {
       const result = await redirectService.redirectFor(
         'test',

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -1,0 +1,193 @@
+import { RedirectService } from '../RedirectService'
+import { UrlRepositoryInterface } from '../../../../repositories/interfaces/UrlRepositoryInterface'
+import { CrawlerCheckService } from '../CrawlerCheckService'
+import { CookieArrayReducerService } from '../CookieArrayReducerService'
+import { LinkStatisticsService } from '../../../analytics/interfaces'
+import { RedirectType } from '../..'
+
+const ogUrl = 'https://go.gov.sg'
+
+// Mock the config module
+jest.mock('../../../../config', () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+  ogUrl,
+}))
+
+// Mock dependencies
+const mockUrlRepository = {
+  getLongUrl: jest.fn(),
+}
+
+const mockCrawlerCheckService = {
+  isCrawler: jest.fn(),
+}
+
+const mockCookieArrayReducerService = {
+  userHasVisitedShortlink: jest.fn(),
+  writeShortlinkToCookie: jest.fn(),
+}
+
+const mockLinkStatisticsService = {
+  updateLinkStatistics: jest.fn(),
+}
+
+describe('RedirectService', () => {
+  let redirectService: RedirectService
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks()
+
+    // Setup default mock returns
+    mockUrlRepository.getLongUrl.mockResolvedValue('https://example.com')
+    mockCrawlerCheckService.isCrawler.mockReturnValue(false)
+    mockCookieArrayReducerService.userHasVisitedShortlink.mockReturnValue(false)
+    mockCookieArrayReducerService.writeShortlinkToCookie.mockReturnValue([
+      'test',
+    ])
+
+    // Create service instance with mocked dependencies
+    redirectService = new RedirectService(
+      mockUrlRepository as unknown as UrlRepositoryInterface,
+      mockCrawlerCheckService as unknown as CrawlerCheckService,
+      mockCookieArrayReducerService as unknown as CookieArrayReducerService,
+      mockLinkStatisticsService as unknown as LinkStatisticsService,
+    )
+  })
+
+  describe('referrer validation', () => {
+    it('should show transition page for exact ogUrl match when user has not visited before', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        ogUrl,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should show transition page for ogUrl with path when user has not visited before', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        `${ogUrl}/some-path`,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should show transition page for ogUrl with query params when user has not visited before', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        `${ogUrl}?param=value`,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should show transition page for ogUrl with different protocol when user has not visited before', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        'http://go.gov.sg', // different protocol
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should NOT allow transition page bypass for malicious domain that starts with ogUrl', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        `${ogUrl}.malicious.com`,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should NOT allow transition page bypass for subdomain of ogUrl', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        `staging.${ogUrl}`,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should NOT allow transition page bypass for domain containing ogUrl', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        `https://staging.${ogUrl}.malicious.com`,
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should NOT allow transition page bypass for completely different domain', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        'https://malicious.com',
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    it('should NOT allow transition page bypass for invalid referrer URL', async () => {
+      const result = await redirectService.redirectFor(
+        'test',
+        undefined,
+        'Mozilla/5.0',
+        'not-a-valid-url',
+      )
+
+      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+    })
+
+    // TODO: not a regression, but to consider if we want to fix this
+    it('should allow direct redirect when user has visited the shortlink before, even from malicious site', async () => {
+      // Mock that user has visited this shortlink before
+      mockCookieArrayReducerService.userHasVisitedShortlink.mockReturnValue(
+        true,
+      )
+
+      const result = await redirectService.redirectFor(
+        'test',
+        ['test'], // past visits include this shortlink
+        'Mozilla/5.0',
+        'https://malicious.com', // even from malicious site
+      )
+
+      expect(result.redirectType).toBe(RedirectType.Direct)
+    })
+
+    it('should allow direct redirect when user has visited the shortlink before, even from trusted page', async () => {
+      // Mock that user has visited this shortlink before
+      mockCookieArrayReducerService.userHasVisitedShortlink.mockReturnValue(
+        true,
+      )
+
+      const result = await redirectService.redirectFor(
+        'test',
+        ['test'], // past visits include this shortlink
+        'Mozilla/5.0',
+        ogUrl, // from trusted page
+      )
+
+      expect(result.redirectType).toBe(RedirectType.Direct)
+    })
+  })
+})

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -8,12 +8,14 @@ import { RedirectType } from '../..'
 const ogUrl = 'https://go.gov.sg'
 
 // Mock the config module
-jest.mock('../../../../config', () => ({
-  logger: {
-    warn: jest.fn(),
-  },
-  ogUrl,
-}))
+jest.mock('../../../../config', () => {
+  return {
+    logger: {
+      warn: jest.fn(),
+    },
+    ogUrl: 'https://go.gov.sg',
+  }
+})
 
 // Mock dependencies
 const mockUrlRepository = {
@@ -58,7 +60,7 @@ describe('RedirectService', () => {
   })
 
   describe('referrer validation', () => {
-    it('should show transition page for exact ogUrl match when user has not visited before', async () => {
+    it('should allow direct redirect for exact ogUrl match when user has not visited before', async () => {
       const result = await redirectService.redirectFor(
         'test',
         undefined,
@@ -66,10 +68,10 @@ describe('RedirectService', () => {
         ogUrl,
       )
 
-      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+      expect(result.redirectType).toBe(RedirectType.Direct)
     })
 
-    it('should show transition page for ogUrl with path when user has not visited before', async () => {
+    it('should allow direct redirect for ogUrl with path when user has not visited before', async () => {
       const result = await redirectService.redirectFor(
         'test',
         undefined,
@@ -77,10 +79,10 @@ describe('RedirectService', () => {
         `${ogUrl}/some-path`,
       )
 
-      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+      expect(result.redirectType).toBe(RedirectType.Direct)
     })
 
-    it('should show transition page for ogUrl with query params when user has not visited before', async () => {
+    it('should allow direct redirect for ogUrl with query params when user has not visited before', async () => {
       const result = await redirectService.redirectFor(
         'test',
         undefined,
@@ -88,7 +90,7 @@ describe('RedirectService', () => {
         `${ogUrl}?param=value`,
       )
 
-      expect(result.redirectType).toBe(RedirectType.TransitionPage)
+      expect(result.redirectType).toBe(RedirectType.Direct)
     })
 
     it('should show transition page for ogUrl with different protocol when user has not visited before', async () => {

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -120,7 +120,7 @@ describe('RedirectService', () => {
         'test',
         undefined,
         'Mozilla/5.0',
-        `staging.${ogUrl}`,
+        'https://staging.go.gov.sg',
       )
 
       expect(result.redirectType).toBe(RedirectType.TransitionPage)

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -36,27 +36,24 @@ const mockLinkStatisticsService = {
 }
 
 describe('RedirectService', () => {
-  let redirectService: RedirectService
+  // Create service instance with mocked dependencies
+  const redirectService = new RedirectService(
+    mockUrlRepository as unknown as UrlRepositoryInterface,
+    mockCrawlerCheckService as unknown as CrawlerCheckService,
+    mockCookieArrayReducerService as unknown as CookieArrayReducerService,
+    mockLinkStatisticsService as unknown as LinkStatisticsService,
+  )
 
   beforeEach(() => {
-    // Reset mocks
     jest.clearAllMocks()
 
-    // Setup default mock returns
+    // Setup default mock returns after clearing
     mockUrlRepository.getLongUrl.mockResolvedValue('https://example.com')
     mockCrawlerCheckService.isCrawler.mockReturnValue(false)
     mockCookieArrayReducerService.userHasVisitedShortlink.mockReturnValue(false)
     mockCookieArrayReducerService.writeShortlinkToCookie.mockReturnValue([
       'test',
     ])
-
-    // Create service instance with mocked dependencies
-    redirectService = new RedirectService(
-      mockUrlRepository as unknown as UrlRepositoryInterface,
-      mockCrawlerCheckService as unknown as CrawlerCheckService,
-      mockCookieArrayReducerService as unknown as CookieArrayReducerService,
-      mockLinkStatisticsService as unknown as LinkStatisticsService,
-    )
   })
 
   describe('redirectFor', () => {

--- a/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
+++ b/src/server/modules/redirect/services/__tests__/RedirectService.test.ts
@@ -131,7 +131,7 @@ describe('RedirectService', () => {
         'test',
         undefined,
         'Mozilla/5.0',
-        `https://staging.${ogUrl}.malicious.com`,
+        'https://staging.go.gov.sg.malicious.com',
       )
 
       expect(result.redirectType).toBe(RedirectType.TransitionPage)


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Closes https://linear.app/ogp/issue/ISOM-2008/vapt-insufficient-referrer-validation-bypasses-transition-page

## Solution

_How did you solve the problem?_

**Improvements**:

- use built-in `URL` function to check instead of `startsWith`
- extract into private method for readability 
- add tests

## Tests

_What tests should be run to confirm functionality?_

- refer to Linear ticket for steps to reproduce