### PR TITLE
chore: add workflow dispatch event for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: ci
 on:
+  workflow_dispatch:
   push:
   pull_request:
     types: [opened, reopened]


### PR DESCRIPTION
## Problem
we want to trigger the `ci` workflow manually as it is useful for updating stuff like dd agent (anything that runs in `.ebextensions`)

## Solution
add the `workflow_dispatch` event in `ci.yml`