### PR TITLE
fix: prevent IPs from being used as long URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32076,7 +32076,8 @@
     "acorn-import-phases": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -32151,7 +32152,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
@@ -32812,7 +32814,8 @@
     "bare-events": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "requires": {}
     },
     "bare-fs": {
       "version": "4.5.2",
@@ -46668,7 +46671,8 @@
           "version": "8.18.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
           "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -46985,7 +46989,8 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10347,7 +10347,6 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
       "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
-      "dev": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -30085,7 +30084,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.11.2",
@@ -31985,7 +31985,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
       "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.3.0",
@@ -32000,7 +32001,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz",
       "integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -32068,7 +32070,8 @@
     "acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "requires": {}
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -32079,7 +32082,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -34304,7 +34308,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
       "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "crc-32": {
       "version": "1.2.2",
@@ -34642,13 +34647,13 @@
     "date-fns": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
-      "dev": true
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
     },
     "date-fns-tz": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
-      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow=="
+      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
+      "requires": {}
     },
     "dd-trace": {
       "version": "2.46.0",
@@ -35757,13 +35762,15 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-alias": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
       "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -36124,7 +36131,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36490,7 +36498,8 @@
     "express-joi-validation": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/express-joi-validation/-/express-joi-validation-4.0.3.tgz",
-      "integrity": "sha512-XnEyhlllurczZDx1vLPWnaohTAQzxlvaP7ifEbvRf2zvYC5C5ZZrgFH75g0/XcL7OuaZ0XlVtB0J0E/R0O1L4A=="
+      "integrity": "sha512-XnEyhlllurczZDx1vLPWnaohTAQzxlvaP7ifEbvRf2zvYC5C5ZZrgFH75g0/XcL7OuaZ0XlVtB0J0E/R0O1L4A==",
+      "requires": {}
     },
     "express-rate-limit": {
       "version": "5.3.0",
@@ -39138,7 +39147,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -41686,7 +41696,8 @@
     "pg-pool": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
-      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ=="
+      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
+      "requires": {}
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -42291,7 +42302,8 @@
     "react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
-      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "requires": {}
     },
     "react-i18next": {
       "version": "11.18.6",
@@ -42672,12 +42684,14 @@
     "redux-devtools-extension": {
       "version": "2.13.9",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
-      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A=="
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "reflect-metadata": {
       "version": "0.1.13",
@@ -45734,7 +45748,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
       "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-jest": {
       "version": "26.5.6",

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -45,7 +45,11 @@ export function isHttps(url: string, useWhitelist = false): boolean {
 // Check if a URL string is valid.
 export function isValidUrl(url: string, useWhitelist = false): boolean {
   if (useWhitelist && isWhitelisted(url)) return true
-  return validator.isURL(url, URL_OPTS)
+  if (!validator.isURL(url, URL_OPTS)) return false
+
+  // NOTE: check whether it's an IP
+  const host = new URL(url).hostname
+  return !validator.isIP(host)
 }
 
 // Tests if a short link consists of alphanumeric and hyphen characters.

--- a/src/shared/util/validation.ts
+++ b/src/shared/util/validation.ts
@@ -47,9 +47,17 @@ export function isValidUrl(url: string, useWhitelist = false): boolean {
   if (useWhitelist && isWhitelisted(url)) return true
   if (!validator.isURL(url, URL_OPTS)) return false
 
-  // NOTE: check whether it's an IP
-  const host = new URL(url).hostname
-  return !validator.isIP(host)
+  // NOTE: Reject URLs with IP addresses to prevent the use of internal or private IPs
+  // as long URLs. This is a security measure to mitigate risks such as
+  // Server-Side Request Forgery (SSRF) and unauthorized access to internal resources.
+  try {
+    // NOTE: try/catch to avoid drifts in validation
+    // between validator library and `URL` constructor
+    const host = new URL(url).hostname
+    return !validator.isIP(host)
+  } catch {
+    return false
+  }
 }
 
 // Tests if a short link consists of alphanumeric and hyphen characters.

--- a/test/shared/util/validation.test.ts
+++ b/test/shared/util/validation.test.ts
@@ -67,6 +67,11 @@ describe('Test valid url check', () => {
     const url = 'http://localhost:4566/local-bucket/file1.pdf'
     expect(validation.isValidUrl(url, true)).toBe(true)
   })
+
+  test('IP addresses fails check', () => {
+    const url = 'https://8.8.8.8:4566/local-bucket/file1.pdf'
+    expect(validation.isValidUrl(url)).toBe(false)
+  })
 })
 
 describe('Test short url check', () => {


### PR DESCRIPTION
## Problem
closes https://linear.app/ogp/issue/ISOM-2009/vapt-low-internal-and-private-ip-addresses-as-long-urls

## Solution
- validate that the domain section of the url is not an IP address
- this validator is used across the dashboard, api and bulk upload 
- also validated that this prevents users from changing existing links to have an IP address as the long url 
    - i'm ok w/ the case where users **cannot** change existing long urls that are IP addresses but i haven't validated teh scale of the problem
