### PR TITLE
fix: increase express server timeout

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -244,7 +244,16 @@ initDb()
     app.use(errorHandler)
 
     const port = 8080
-    app.listen(port, () => logger.info(`Listening on port ${port}!`))
+    const server = app.listen(port, () =>
+      logger.info(`Listening on port ${port}!`),
+    )
+    // NOTE: Express has a default timeout of 5 seconds - this means that
+    // a request from ELB -> Express server can be in-flight
+    // while express has already closed the connection, resulting in a 5xx.
+    // Refer to the below link for more information
+    // adamcrowder.net/posts/node-express-api-and-aws-alb-502/
+    server.keepAliveTimeout = 65000 // Ensure all inactive connections are terminated by the ALB, by setting this a few seconds higher than the ALB idle timeout
+    server.headersTimeout = 66000 // Ensure the headersTimeout is set higher than the keepAliveTimeout due to this nodejs regression bug: https://github.com/nodejs/node/issues/27363
 
     process.on('unhandledRejection', (error) => {
       dogstatsd.increment(ERROR_UNHANDLED_REJECTION, 1, 1)


### PR DESCRIPTION
# Increase Express Server Timeout to Prevent ALB 502 Errors

## Summary

This PR increases the Express server's `keepAliveTimeout` and `headersTimeout` to prevent 502 errors when deployed behind an AWS Application Load Balancer (ALB).

## Problem

Express has a default timeout of 5 seconds, which is lower than the typical ALB idle timeout of 60 seconds. This mismatch can cause:

1. A request from ALB → Express server remains in-flight
2. Express closes the connection after 5 seconds (default timeout)
3. ALB still expects the connection to be alive
4. Result: ALB returns a **502 Bad Gateway** error

## Solution

Set Express server timeouts to be higher than the ALB idle timeout:

- **`keepAliveTimeout`**: Set to 65 seconds (ALB idle timeout + 5s buffer)
- **`headersTimeout`**: Set to 66 seconds (must be higher than keepAliveTimeout due to [Node.js regression bug](https://github.com/nodejs/node/issues/27363))

This ensures:
- ALB terminates inactive connections before Express does
- Express waits long enough for ALB to handle requests properly
- No premature connection closures causing 502s

## Changes

- Modified `src/server/index.ts` to configure server timeouts after Express app initialization

## References

- [Node Express API and AWS ALB 502 Errors](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/)
- [Node.js Issue #27363](https://github.com/nodejs/node/issues/27363)

## Testing

- [ ] Deploy to staging environment
- [ ] Verify no 502 errors under normal load
- [ ] Monitor ALB metrics for connection errors
- [ ] Test with requests that take longer than 5 seconds
