### PR TITLE
fix: add runtime metrics

### DIFF
--- a/src/server/util/tracing.ts
+++ b/src/server/util/tracing.ts
@@ -4,6 +4,7 @@ import { Span } from 'opentracing'
 
 tracer.init({
   logInjection: true,
+  runtimeMetrics: true,
 })
 tracer.use('http', {
   client: {
@@ -18,3 +19,5 @@ tracer.use('http', {
     },
   },
 })
+
+export default tracer


### PR DESCRIPTION
# Enable Datadog Runtime Metrics and Export Tracer

## Summary

This PR enables Datadog runtime metrics collection and properly exports the tracer instance for use across the application.

## Changes

### 1. Enable Runtime Metrics (`runtimeMetrics: true`)

Enables collection of Node.js runtime metrics including:
- **Memory usage**: Heap size, RSS, external memory
- **CPU usage**: User and system CPU time
- **Event loop**: Latency and utilization
- **Garbage collection**: GC pauses and frequency
- **Async operations**: Active handles and requests

These metrics provide visibility into application performance and resource utilization in Datadog APM.

### 2. Export Tracer Instance (`export default tracer`)

Exports the configured tracer instance, allowing other modules to:
- Create custom spans
- Add tags and context to traces
- Instrument custom code paths
- Access tracer utilities

## Benefits

- **Better observability**: Runtime metrics help identify performance bottlenecks (memory leaks, CPU spikes, GC issues)
- **Debugging**: Correlate application behavior with system resource usage
- **Reusability**: Exported tracer enables custom instrumentation throughout the codebase
- **Monitoring**: Track Node.js health metrics alongside APM traces

## Testing

- [ ] Verify runtime metrics appear in Datadog APM dashboard
- [ ] Confirm no performance impact from metrics collection
- [ ] Validate tracer export works correctly in other modules
- [ ] Check that existing traces continue to work as expected

## References

- [Datadog Runtime Metrics Documentation](https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs/)
