### PR TITLE
chore: remove `useMaster` true from read queries

### DIFF
--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -312,7 +312,6 @@ export class UrlRepository implements UrlRepositoryInterface {
       model: Url,
       raw: true,
       mapToModel: true,
-      useMaster: true,
     })) as Array<UrlDirectory>
     const countResult = (await sequelize.query(countQuery, {
       replacements: {
@@ -323,7 +322,6 @@ export class UrlRepository implements UrlRepositoryInterface {
       type: QueryTypes.SELECT,
       raw: true,
       plain: true,
-      useMaster: true,
     })) as { count: string }
 
     const count = Number(countResult.count)
@@ -387,7 +385,6 @@ export class UrlRepository implements UrlRepositoryInterface {
       type: QueryTypes.SELECT,
       model: Url,
       mapToModel: true,
-      useMaster: true,
     })) as Array<UrlDirectory>
     const countResult = (await sequelize.query(countQuery, {
       replacements: {
@@ -396,7 +393,6 @@ export class UrlRepository implements UrlRepositoryInterface {
       raw: true,
       plain: true,
       type: QueryTypes.SELECT,
-      useMaster: true,
     })) as { count: string }
 
     const count = Number(countResult.count)

--- a/test/integration/api/user/Urls.test.ts
+++ b/test/integration/api/user/Urls.test.ts
@@ -48,7 +48,8 @@ describe('Url integration tests', () => {
   const longUrl = 'https://example.com'
 
   beforeEach(async () => {
-    ;({ email } = await createIntegrationTestUser())
+    const { email: _email } = await createIntegrationTestUser()
+    email = _email
     authCookie = await getAuthCookie(email)
   })
 
@@ -112,17 +113,6 @@ describe('Url integration tests', () => {
       safeBrowsingExpiry: expect.stringMatching(DATETIME_REGEX),
     })
   })
-
-  // it('should be unable to create file that is too large', async () => {
-  //   const shortUrl = await generateRandomString(6)
-  //   const formData = new FormData()
-  //   const largeTextFile = readFile(LARGE_TEXT_FILE_PATH)
-  //   formData.append('file', largeTextFile)
-  //   formData.append('shortUrl', shortUrl)
-
-  //   const res = await postFormData(API_USER_URL, formData, authCookie)
-  //   expect(res.status).toBe(400)
-  // })
 
   it('should be able to update link url', async () => {
     const shortUrl = await generateRandomString(6)
@@ -235,10 +225,4 @@ describe('Url integration tests', () => {
       count: 1,
     })
   })
-
-  // it('should be able to transfer ownership', async () => {
-  // })
-
-  // it('should verify that transferred links no longer appear', async () => {
-  // })
 })

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -659,10 +659,6 @@ describe('UrlRepository', () => {
           },
         ],
       })
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ useMaster: true }),
-      )
     })
 
     it('should call sequelize.query that searches with plain text', async () => {
@@ -688,10 +684,6 @@ describe('UrlRepository', () => {
           },
         ],
       })
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ useMaster: true }),
-      )
     })
   })
 


### PR DESCRIPTION
## Problem
our select and count statements are reading from the writer instances and using alot of compute at present. we want to minimize CPU spikes on writer and offload to reader since this isn't time sensitive

## Solution
remove `useMaster: true` 
