### PR TITLE
fix: update branch extraction method in build-and-deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Extract branch name
         id: extract_branch
         shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        run: echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: Extract ECR tag
         id: extract_tag


### PR DESCRIPTION
deployment error: https://github.com/opengovsg/GoGovSG/actions/runs/24336425194/job/71054298507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just alters how the branch name is derived for image tagging; main risk is unexpected tag naming differences affecting downstream deploy expectations.
> 
> **Overview**
> Updates the `build-and-deploy` GitHub Actions workflow to extract the branch name via `github.ref_name` instead of parsing `GITHUB_REF`, to avoid branch-detection failures and ensure consistent ECR tag generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4933317677b6f8ec25a8c7982fc0b4739377cd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->