### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.com/opengovsg/GoGovSG.svg?branch=develop)](https://travis-ci.com/opengovsg/GoGovSG)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/opengovsg/GoGovSG)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opengovsg/GoGovSG)
 
 The official Singapore government link shortener.
 


### PR DESCRIPTION
## Problem

New joiners and external contributors lack an up-to-date, auto-refreshing wiki for the codebase.

## Solution

**Improvements**:

- Added a DeepWiki badge to the README that links to the auto-generated wiki at https://deepwiki.com/opengovsg/GoGovSG, which updates weekly.

## Tests

No functional changes — visual check of the README badge rendering on GitHub is sufficient.

## Deploy Notes

No new dependencies, scripts, or environment variables.