### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/client/app/helpers/monitoring.ts
+++ b/src/client/app/helpers/monitoring.ts
@@ -3,8 +3,8 @@ import { ddEnv, ddService } from '../../../shared/util/environment-variables'
 
 const initMonitoring = () => {
   datadogRum.init({
-    applicationId: '898ea704-7347-45dc-b40c-bf85359e062e',
-    clientToken: 'pub40fb07aa43d3f6f034d8fcc7f1df867b',
+    applicationId: process.env.REACT_APP_DATADOG_APP_ID || '',
+    clientToken: process.env.REACT_APP_DATADOG_CLIENT_TOKEN || '',
     site: 'datadoghq.com',
     service: ddService,
     env: ddEnv,

--- a/src/client/app/store.tsx
+++ b/src/client/app/store.tsx
@@ -1,12 +1,13 @@
-import { applyMiddleware, createStore } from 'redux'
+import { applyMiddleware, compose, createStore } from 'redux'
 import thunk from 'redux-thunk'
 import { composeWithDevTools } from 'redux-devtools-extension'
 
 import rootReducer from './reducers'
 
-const composeEnhancers = composeWithDevTools({
-  trace: true,
-})
+const composeEnhancers =
+  process.env.NODE_ENV === 'development'
+    ? composeWithDevTools({ trace: true })
+    : compose
 
 const store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunk)))
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `src/client/app/helpers/monitoring.ts:L7`

Datadog applicationId and clientToken are hardcoded directly in the client-side monitoring initialization code. While client tokens are generally public, exposing them in source code makes it difficult to rotate them and could allow attackers to inject malicious telemetry data into your Datadog dashboard, potentially skewing metrics or causing denial of service via data pollution.

## Solution

Load the Datadog applicationId and clientToken from environment variables injected at build time (e.g., process.env.REACT_APP_DATADOG_APP_ID) rather than hardcoding them in the source file.

## Changes

- `src/client/app/helpers/monitoring.ts` (modified)
- `src/client/app/store.tsx` (modified)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR externalizes Datadog RUM credentials and restricts Redux DevTools integration to development builds.
- Reads the Datadog application ID and client token from build-time environment variables.
- Uses standard Redux composition outside development to disable production DevTools tracing.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the new Datadog variables are injected by the client build, otherwise deployed browser monitoring will stop working.

Current webpack and Docker builds do not define the newly referenced credentials, so monitoring initializes with empty values and Datadog RUM collection is disabled; the Redux store change is safe.

**Files Needing Attention:** src/client/app/helpers/monitoring.ts and the corresponding webpack/Docker build configuration
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured a pre-upgrade Webpack run transcript showing three size warnings, zero application-ID occurrences, and exit status 1.
- Captured a post-upgrade Webpack run transcript showing the same three warnings, placeholders present once in dist/bundle.js, and exit status 0.
- Ran the executable harness against the emitted bundle and confirmed that Datadog.init received empty appId and clientToken, with the process exiting successfully, and noted that the environment-variable injection should be updated for regression testing.
- Produced a finding-proof for a posted P1 finding.

<a href="https://app.greptile.com/trex/runs/15863178/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client/app/helpers/monitoring.ts | Replaces fixed RUM credentials with variables that the current build does not inject, disabling telemetry. |
| src/client/app/store.tsx | Correctly limits Redux DevTools composition to development while retaining the middleware enhancer in other builds. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Datadog build-time variables were not injected into the production client bundle**

   - **Bug**
     - Supplying `REACT_APP_DATADOG_APP_ID` and `REACT_APP_DATADOG_CLIENT_TOKEN` to the documented production build did not place either value in emitted assets, preventing monitoring initialization from receiving the configured credentials. This was corrected and validated with exact non-secret placeholders.
   - **Cause**
     - The Webpack `DefinePlugin` configuration defined only `ASSET_VARIANT`, `DD_SERVICE`, and `DD_ENV`. Webpack therefore could not replace the newly added `process.env.REACT_APP_DATADOG_*` client references.
   - **Fix**
     - Added both Datadog variables to `DefinePlugin`, JSON-stringifying their build-time values. The rebuilt `dist/bundle.js` contains each supplied placeholder exactly once.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fclient%2Fapp%2Fhelpers%2Fmonitoring.ts%3A6-7%0A**Build%20omits%20monitoring%20credentials**%0A%0AWhen%20the%20repository's%20current%20client%20build%20runs%2C%20neither%20new%20environment%20variable%20is%20injected%2C%20so%20these%20fallbacks%20pass%20empty%20credentials%20to%20Datadog%20and%20browser%20telemetry%20and%20session%20replay%20stop%20being%20collected.%0A%0A&repo=opengovsg%2Fgogovsg&pr=2515&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fclient%2Fapp%2Fhelpers%2Fmonitoring.ts%3A6-7%0A**Build%20omits%20monitoring%20credentials**%0A%0AWhen%20the%20repository's%20current%20client%20build%20runs%2C%20neither%20new%20environment%20variable%20is%20injected%2C%20so%20these%20fallbacks%20pass%20empty%20credentials%20to%20Datadog%20and%20browser%20telemetry%20and%20session%20replay%20stop%20being%20collected.%0A%0A&pr=2515&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fgogovsg%22%20on%20the%20existing%20branch%20%22fix%2Fsecurity%2Fhardcoded-datadog-api-credentials-in-cli%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsecurity%2Fhardcoded-datadog-api-credentials-in-cli%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fclient%2Fapp%2Fhelpers%2Fmonitoring.ts%3A6-7%0A**Build%20omits%20monitoring%20credentials**%0A%0AWhen%20the%20repository's%20current%20client%20build%20runs%2C%20neither%20new%20environment%20variable%20is%20injected%2C%20so%20these%20fallbacks%20pass%20empty%20credentials%20to%20Datadog%20and%20browser%20telemetry%20and%20session%20replay%20stop%20being%20collected.%0A%0A&repo=opengovsg%2Fgogovsg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/client/app/helpers/monitoring.ts:6-7
**Build omits monitoring credentials**

When the repository's current client build runs, neither new environment variable is injected, so these fallbacks pass empty credentials to Datadog and browser telemetry and session replay stop being collected.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): 2 improvements across 2 f..."](https://github.com/opengovsg/gogovsg/commit/69056259110a3e5b786c7da4bd5e06ce4fd81dac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47234869)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->