### PR TITLE
build(deps): upgrade nodemailer to 7.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "moment-timezone": "^0.5.35",
         "morgan": "^1.11.0",
         "nanoid": "^3.3.2",
-        "nodemailer": "^6.6.2",
+        "nodemailer": "^7.0.13",
         "opentracing": "^0.14.7",
         "papaparse": "^5.3.2",
         "pg": "^8.6.0",
@@ -19376,9 +19376,10 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.3.tgz",
-      "integrity": "sha512-faZFufgTMrphYoDjvyVpbpJcYzwyFnbAMmQtj1lVBYAUSm3SOy2fIdd9+Mr4UxPosBa0JRw9bJoIwQn+nswiew==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -41669,9 +41670,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.3.tgz",
-      "integrity": "sha512-faZFufgTMrphYoDjvyVpbpJcYzwyFnbAMmQtj1lVBYAUSm3SOy2fIdd9+Mr4UxPosBa0JRw9bJoIwQn+nswiew=="
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="
     },
     "noms": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "moment-timezone": "^0.5.35",
     "morgan": "^1.11.0",
     "nanoid": "^3.3.2",
-    "nodemailer": "^6.6.2",
+    "nodemailer": "^7.0.13",
     "opentracing": "^0.14.7",
     "papaparse": "^5.3.2",
     "pg": "^8.6.0",

--- a/src/server/services/__tests__/nodemailer-addressparser.test.ts
+++ b/src/server/services/__tests__/nodemailer-addressparser.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 /// <reference types="jest" />
 /// <reference types="node" />
 

--- a/src/server/services/__tests__/nodemailer-addressparser.test.ts
+++ b/src/server/services/__tests__/nodemailer-addressparser.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="jest" />
+/// <reference types="node" />
+
+type ParsedAddress = { address: string; name: string }
+type AddressParser = (address: string) => ParsedAddress[]
+
+const addressparser = require('nodemailer/lib/addressparser') as AddressParser
+
+/**
+ * Regression tests for nodemailer addressparser.
+ * Quoted nested addresses like `"user@gmail.com"@agency.gov.sg` previously
+ * misparsed as delivering to gmail.com (fixed in nodemailer >= 7.0.7).
+ */
+describe('nodemailer addressparser', () => {
+  it('does not misroute quoted nested emails to an external domain', () => {
+    const payloads = [
+      '"test@gmail.com"@tech.gov.sg',
+      '"sample@gmail.com"@tech.gov.sg',
+    ]
+
+    payloads.forEach((payload) => {
+      const parsed = addressparser(payload)
+
+      expect(parsed).toHaveLength(1)
+      expect(parsed[0].address).not.toMatch(/@(gmail|yahoo|outlook)\.com$/i)
+      expect(parsed[0].address).toMatch(/@tech\.gov\.sg$/)
+    })
+  })
+
+  it('parses a normal government email unchanged', () => {
+    const parsed = addressparser('user@tech.gov.sg')
+
+    expect(parsed).toEqual([{ address: 'user@tech.gov.sg', name: '' }])
+  })
+
+  it('parses display-name form without changing the mailbox', () => {
+    const parsed = addressparser('Alexis <user@open.gov.sg>')
+
+    expect(parsed).toEqual([{ address: 'user@open.gov.sg', name: 'Alexis' }])
+  })
+})


### PR DESCRIPTION
## Summary
- Bump `nodemailer` from 6.6.x to 7.0.13 to pick up the addressparser fix for quoted nested addresses (e.g. `"user@gmail.com"@agency.gov.sg`), which previously could misroute to an external mailbox.
- Add regression tests covering the nested-address case plus normal and display-name government emails.

## Test plan
- [ ] `npm test -- --testPathPattern=nodemailer-addressparser`
- [ ] Confirm OTP / notification emails still send in a local or staging environment
- [ ] Spot-check that `package-lock.json` resolves only `nodemailer@7.0.13`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change upgrades Nodemailer to 7.0.13 and adds regression coverage for quoted local-part addresses, ordinary government addresses, and display-name syntax.

The quoted-address external-mailbox-routing hypothesis was disproved by direct execution: `"test@gmail.com"@tech.gov.sg` and `"sample@gmail.com"@tech.gov.sg` both retained the `tech.gov.sg` recipient domain. The focused address-parser test suite also passed all three tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Nodemailer quoted-local-probe.js script against Nodemailer 7.0.13 and observed that quoted local-parts map to internal addresses, with test@gmail.com mapping to test@gmail.com@tech.gov.sg and sample@gmail.com mapping to sample@gmail.com@tech.gov.sg.
- Ran the Jest tests for nodemailer-addressparser.test.ts and the single test suite passed all three tests.
- Executed the probe again and confirmed the addressparser loaded from Nodemailer 7.0.13 and the process exited with code 0, with the observed mappings again not ending in external Gmail domains.
- Ran the Jest suite again and confirmed all tests passed with exit code 0.
- Together, these executions contradict the claimed external-Gmail parsing path.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow require in nodemailer address..."](https://github.com/opengovsg/gogovsg/commit/1994f1071eb7c1f19a12fa96577f6caed8c462bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50313484)</sub>

<!-- /greptile_comment -->