### PR TITLE
chore: sync package.json version with latest release tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "GoGovSG",
-  "version": "1.86.1",
+  "version": "1.88.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "GoGovSG",
-      "version": "1.86.1",
+      "version": "1.88.1",
       "license": "MIT",
       "dependencies": {
         "@datadog/browser-rum": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GoGovSG",
-  "version": "1.86.1",
+  "version": "1.88.1",
   "description": "Link shortener for Singapore government.",
   "main": "src/server/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- `package.json`/`package-lock.json` on `develop` still say `1.86.1`, while the latest git tag is `v1.88.1` (and even `master`'s field lags further behind, at `1.76.1`). The `version` field has been drifting from the actual tags across several releases.
- Sets the `version` field to `1.88.1` to match the latest release tag. No lifecycle scripts were run (`--ignore-scripts`), so `CHANGELOG.md` is untouched — this is a field correction, not a new release.

## Why this matters
An in-progress workflow (`auto-release-deps.yml`, not yet merged) computes the next release version from the latest git tag rather than trusting this field, specifically to avoid being tripped up by this kind of drift going forward. This PR fixes the drift that already exists.

## Test plan
- [ ] Confirm `npm run build` / CI passes with the corrected version field
- [ ] Confirm Datadog source-map upload in `build-and-deploy.yml` (which reads `package.json` version) reports the expected version on the next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the application release metadata from 1.86.1 to 1.88.1 in `package.json` and both root-package version fields in `package-lock.json`.

The root-version contract was exercised with a deliberately mismatched lockfile fixture, which failed and identified both inconsistent fields. The updated repository then passed the same check: all root version fields are 1.88.1, and the release, deployment source-map, and production image consumers resolve the version from `package.json`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the release version is synchronized across the root package metadata consumed by deployment tooling.

No defects remain. A mismatched manifest fixture failed as expected, while the updated repository passed the same version-consistency check and confirmed downstream consumers receive version 1.88.1.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Node validator against an isolated fixture with a mismatched root version setup, and it exited with code 1 while reporting the mismatches.
- Validated the repository state with the same validator; it exited with code 0 and confirmed all three root version fields are 1.88.1 and that the release, deployment source-map, and production image consumers resolve package.json.version.
- Simulated the pre-change mismatch and observed the validator fail with exit code 1, identifying both divergent lockfile version fields.
- PR state validation passed with exit code 0, showing all three root version fields are 1.88.1 and that consumers resolve package.json.version.

<a href="https://app.greptile.com/trex/runs/17378140/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: sync package.json version with la..."](https://github.com/opengovsg/gogovsg/commit/8d5ff3d4c4061fa65123cb32a2c70d212f5cd4e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50320946)</sub>

<!-- /greptile_comment -->