### PR TITLE
ci: auto-release develop when only dependencies changed

### DIFF
--- a/.github/workflows/auto-release-deps.yml
+++ b/.github/workflows/auto-release-deps.yml
@@ -1,0 +1,97 @@
+name: Auto release on dependency-only changes
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_call:
+
+concurrency:
+  group: auto-release-develop
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  check-and-release:
+    name: Check and release
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - name: Find latest release tag
+        id: last_tag
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if only dependency files changed since last release
+        id: classify
+        run: |
+          TAG="${{ steps.last_tag.outputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "No previous release tag found, skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$TAG" HEAD)
+
+          if [ -z "$changed" ]; then
+            echo "No changes since $TAG, skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files since $TAG:"
+          echo "$changed"
+
+          non_deps=$(echo "$changed" | grep -vE '^(package\.json|package-lock\.json)$|\.test\.ts$|^test/' || true)
+
+          if [ -z "$non_deps" ]; then
+            echo "Only dependency and/or test files changed since $TAG, releasing."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-dependency files changed since $TAG, skipping auto-release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Use Node.js
+        if: steps.classify.outputs.should_release == 'true'
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        if: steps.classify.outputs.should_release == 'true'
+        run: npm ci --legacy-peer-deps
+
+      - name: Bump patch version and tag
+        if: steps.classify.outputs.should_release == 'true'
+        id: bump
+        env:
+          TAG: ${{ steps.last_tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          current_version="${TAG#v}"
+          next_version=$(node -e "console.log(require('semver').inc('$current_version', 'patch'))")
+
+          echo "version=$(npm version "$next_version" -m "chore(release): %s [skip ci]")" >> "$GITHUB_OUTPUT"
+
+      - name: Push version bump and tag
+        if: steps.classify.outputs.should_release == 'true'
+        run: |
+          git push origin develop
+          git push origin "${{ steps.bump.outputs.version }}"
+
+      - name: Publish GitHub release
+        if: steps.classify.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.version }}" \
+            --title "${{ steps.bump.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- New `auto-release-deps.yml` workflow, triggered monthly (1st of the month, midnight UTC) plus `workflow_call` for on-demand invocation from other workflows.
- Compares the diff since the latest git tag; if every changed file is `package.json`, `package-lock.json`, a `*.test.ts` file, or anything under `test/`, it's classified as safe to auto-release.
- If safe: bumps the version (computed from the latest tag via `semver`, not from `package.json`'s field, to avoid drift — see #2521), commits + tags on `develop`, and publishes a GitHub release. Publishing triggers the existing `deploy_production.yml` (`on: release: types: [released]`), so a dependency-only release goes straight to production for gogov/edu/health.
- If anything else changed, it's a no-op — the existing manual `release.sh` flow (develop/release/master PRs) still handles real feature/fix releases.

## Notes / follow-ups
- Requires `develop` branch protection to allow the workflow's `contents: write` push, or this will fail at the "Push version bump and tag" step.
- Depends on #2521 landing first (or at least the version drift being fixed) so the semver-based bump starts from a correct baseline.

## Test plan
- [ ] Manually trigger via `workflow_call` (or `workflow_dispatch` temporarily) against a test scenario to confirm classification and version bump work end-to-end
- [ ] Confirm `gh release create` output actually fires `deploy_production.yml` as expected
- [ ] Confirm branch protection on `develop` permits the bot's push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change adds a monthly and reusable workflow that releases a patch when all changes since the latest tag are dependency manifests, lockfiles, or tests. Focused reproductions confirmed that an allowed manifest change can run an npm lifecycle script and push an unintended commit before the release logic, and that mutable action references run in the same repository-write workflow.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>




</details>


<details open><summary><h3>Security Review</h3></summary>

The workflow accepts `package.json` as a dependency-only input even though it can define executable npm lifecycle hooks. Those hooks run during `npm ci` with a persisted checkout credential in a job that can write repository contents, allowing a manifest-only change to make unintended repository writes. The same privileged job uses mutable `actions/checkout@v2` and `actions/setup-node@v1` references, so a retargeted action tag could execute replacement code with repository-write access.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the executable lifecycle-script workflow for the P1 finding and captured artifact checksums to verify integrity.
- Validated the executable-focused workflow pinning validator and observed the real validation results showing mutable tags with contents write, and pinned fixture clearing the mutable action association.
- Two additional P1 finding proofs were produced with no artifacts.
- General contract validation confirmed the after-capture lifecycle result occurred in an isolated environment with no repository write.
- Further contract validation highlighted differences between real and pinned workflow refs and noted that the workflow token scope could allow repository write access.

<a href="https://app.greptile.com/trex/runs/17378480/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Dependency-only release workflow executes manifest-controlled lifecycle scripts with write credentials**

   - **Bug**
     - The release gate accepts changes limited to `package.json` and `package-lock.json`, but `package.json` can define root lifecycle scripts. The subsequent `npm ci --legacy-peer-deps` executes those scripts. Because job permissions grant `contents: write` and checkout@v2 persists its credential for later steps by default, such a script can perform authenticated repository writes before the intended release logic.
   - **Cause**
     - The file allowlist treats `package.json` as dependency-only input despite it also containing executable lifecycle-script definitions; npm lifecycle execution is not disabled and the checkout credential remains available to the install step.
   - **Fix**
     - Do not run install scripts in this privileged job (for example, use `npm ci --ignore-scripts --legacy-peer-deps` if lifecycle hooks are unnecessary), or separate untrusted dependency validation from the write-capable release job. Also explicitly set `persist-credentials: false` unless a later step needs the checkout credential, and use a narrowly scoped authenticated push mechanism only at that step.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mutable action tags execute in a contents-write release workflow**

   - **Bug**
     - The scheduled and reusable release workflow has workflow-level `contents: write` at lines 12–13, but invokes `actions/checkout@v2` at line 20 and, on the release path, `actions/setup-node@v1` at line 62. These version tags are mutable rather than immutable commit identifiers, so retargeting either tag changes code executed by a job holding contents-write access.
   - **Cause**
     - Action references are pinned to mutable major-version tags instead of full 40-character commit SHAs while the same workflow grants repository write permissions.
   - **Fix**
     - Pin both actions to audited full-length commit SHAs (optionally retaining the human-readable release version in a comment) and keep `contents: write` limited to the job/path that must push the release.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A68%0A**Lifecycle%20scripts%20inherit%20write%20access**%0A%0AThe%20release%20gate%20accepts%20%60package.json%60%20and%20%60package-lock.json%60%20as%20dependency-only%20changes%2C%20but%20%60package.json%60%20can%20add%20a%20lifecycle%20hook.%20%60npm%20ci%20--legacy-peer-deps%60%20executes%20that%20hook%20while%20the%20job%20has%20%60contents%3A%20write%60%20and%20checkout%20has%20persisted%20its%20token%20by%20default.%20A%20manifest-only%20change%20can%20therefore%20run%20arbitrary%20code%20that%20pushes%20commits%20or%20tags%20before%20the%20intended%20release%20steps.%20Install%20with%20scripts%20disabled%2C%20or%20isolate%20installation%20from%20the%20write-capable%20release%20operation%20and%20authenticate%20only%20for%20the%20narrow%20push%20step.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A20-62%0A**Mutable%20actions%20run%20with%20repository-write%20permission**%0A%0AThis%20scheduled%20and%20reusable%20release%20job%20grants%20%60contents%3A%20write%60%2C%20then%20executes%20%60actions%2Fcheckout%40v2%60%20and%20%60actions%2Fsetup-node%40v1%60.%20Those%20mutable%20major-version%20tags%20can%20be%20retargeted%2C%20changing%20the%20code%20that%20receives%20the%20write-capable%20token.%20Pin%20both%20actions%20to%20audited%20full%2040-character%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fgogovsg&pr=2522&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A68%0A**Lifecycle%20scripts%20inherit%20write%20access**%0A%0AThe%20release%20gate%20accepts%20%60package.json%60%20and%20%60package-lock.json%60%20as%20dependency-only%20changes%2C%20but%20%60package.json%60%20can%20add%20a%20lifecycle%20hook.%20%60npm%20ci%20--legacy-peer-deps%60%20executes%20that%20hook%20while%20the%20job%20has%20%60contents%3A%20write%60%20and%20checkout%20has%20persisted%20its%20token%20by%20default.%20A%20manifest-only%20change%20can%20therefore%20run%20arbitrary%20code%20that%20pushes%20commits%20or%20tags%20before%20the%20intended%20release%20steps.%20Install%20with%20scripts%20disabled%2C%20or%20isolate%20installation%20from%20the%20write-capable%20release%20operation%20and%20authenticate%20only%20for%20the%20narrow%20push%20step.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A20-62%0A**Mutable%20actions%20run%20with%20repository-write%20permission**%0A%0AThis%20scheduled%20and%20reusable%20release%20job%20grants%20%60contents%3A%20write%60%2C%20then%20executes%20%60actions%2Fcheckout%40v2%60%20and%20%60actions%2Fsetup-node%40v1%60.%20Those%20mutable%20major-version%20tags%20can%20be%20retargeted%2C%20changing%20the%20code%20that%20receives%20the%20write-capable%20token.%20Pin%20both%20actions%20to%20audited%20full%2040-character%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2522&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fgogovsg%22%20on%20the%20existing%20branch%20%22chore%2Fcd%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fcd%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A68%0A**Lifecycle%20scripts%20inherit%20write%20access**%0A%0AThe%20release%20gate%20accepts%20%60package.json%60%20and%20%60package-lock.json%60%20as%20dependency-only%20changes%2C%20but%20%60package.json%60%20can%20add%20a%20lifecycle%20hook.%20%60npm%20ci%20--legacy-peer-deps%60%20executes%20that%20hook%20while%20the%20job%20has%20%60contents%3A%20write%60%20and%20checkout%20has%20persisted%20its%20token%20by%20default.%20A%20manifest-only%20change%20can%20therefore%20run%20arbitrary%20code%20that%20pushes%20commits%20or%20tags%20before%20the%20intended%20release%20steps.%20Install%20with%20scripts%20disabled%2C%20or%20isolate%20installation%20from%20the%20write-capable%20release%20operation%20and%20authenticate%20only%20for%20the%20narrow%20push%20step.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fauto-release-deps.yml%3A20-62%0A**Mutable%20actions%20run%20with%20repository-write%20permission**%0A%0AThis%20scheduled%20and%20reusable%20release%20job%20grants%20%60contents%3A%20write%60%2C%20then%20executes%20%60actions%2Fcheckout%40v2%60%20and%20%60actions%2Fsetup-node%40v1%60.%20Those%20mutable%20major-version%20tags%20can%20be%20retargeted%2C%20changing%20the%20code%20that%20receives%20the%20write-capable%20token.%20Pin%20both%20actions%20to%20audited%20full%2040-character%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fgogovsg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/auto-release-deps.yml:68
**Lifecycle scripts inherit write access**

The release gate accepts `package.json` and `package-lock.json` as dependency-only changes, but `package.json` can add a lifecycle hook. `npm ci --legacy-peer-deps` executes that hook while the job has `contents: write` and checkout has persisted its token by default. A manifest-only change can therefore run arbitrary code that pushes commits or tags before the intended release steps. Install with scripts disabled, or isolate installation from the write-capable release operation and authenticate only for the narrow push step.

### Issue 2
.github/workflows/auto-release-deps.yml:20-62
**Mutable actions run with repository-write permission**

This scheduled and reusable release job grants `contents: write`, then executes `actions/checkout@v2` and `actions/setup-node@v1`. Those mutable major-version tags can be retargeted, changing the code that receives the write-capable token. Pin both actions to audited full 40-character commit SHAs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: auto-release develop when only depen..."](https://github.com/opengovsg/gogovsg/commit/a48f941e8f0a2500274ea1761749423134893460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50321570)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->