### PR TITLE
chore: harden email validation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,11 @@ module.exports = {
   coveragePathIgnorePatterns: ['./node_modules/', './test/', '__tests__'],
   setupFiles: ['./test/server/setup.ts'],
   modulePathIgnorePatterns: ['./test/end-to-end', './test/integration'],
+  // Jest 26 does not resolve package.json "exports"; map CJS entry points explicitly.
+  moduleNameMapper: {
+    '^@opengovsg/validators/email$':
+      '<rootDir>/node_modules/@opengovsg/validators/dist/email/index.js',
+    '^zod/v4/core$': '<rootDir>/node_modules/zod/v4/core/index.cjs',
+    '^zod/v4$': '<rootDir>/node_modules/zod/v4/index.cjs',
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "validator": "^13.7.0",
         "webpack": "^5.76.0",
         "winston": "^3.19.0",
-        "zod": "^4.4.3"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -3280,58 +3280,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
@@ -10585,6 +10533,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
       "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
+      "dev": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -27431,9 +27380,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -29643,64 +29592,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
-    "@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
-    "@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -30554,8 +30445,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.2",
@@ -31025,8 +30915,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
       "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/cookie-session": {
       "version": "2.0.43",
@@ -32518,8 +32407,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
       "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.3.0",
@@ -32534,8 +32422,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz",
       "integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -32603,15 +32490,13 @@
     "acorn-import-attributes": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "requires": {}
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -32679,8 +32564,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -33355,8 +33239,7 @@
     "bare-events": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-      "requires": {}
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="
     },
     "bare-fs": {
       "version": "4.5.3",
@@ -34817,8 +34700,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz",
       "integrity": "sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "crc-32": {
       "version": "1.2.2",
@@ -35141,13 +35023,13 @@
     "date-fns": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
+      "dev": true
     },
     "date-fns-tz": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.4.tgz",
-      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
-      "requires": {}
+      "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow=="
     },
     "dayjs": {
       "version": "1.11.20",
@@ -36234,15 +36116,13 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-alias": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
       "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -36603,8 +36483,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36946,8 +36825,7 @@
     "express-joi-validation": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/express-joi-validation/-/express-joi-validation-5.0.1.tgz",
-      "integrity": "sha512-BztcU64addcAdxys2j42pZVSnJjEyFaLxNko7YSYDUuEBtKq2XnhzYZuy9ex9Q+Fdhef+NwLXhX1djwZmShCLg==",
-      "requires": {}
+      "integrity": "sha512-BztcU64addcAdxys2j42pZVSnJjEyFaLxNko7YSYDUuEBtKq2XnhzYZuy9ex9Q+Fdhef+NwLXhX1djwZmShCLg=="
     },
     "express-rate-limit": {
       "version": "5.3.0",
@@ -39642,8 +39520,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -42338,8 +42215,7 @@
     "pg-pool": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
-      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
-      "requires": {}
+      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ=="
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -43011,8 +42887,7 @@
     "react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
-      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
-      "requires": {}
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
     },
     "react-i18next": {
       "version": "11.18.6",
@@ -43393,14 +43268,12 @@
     "redux-devtools-extension": {
       "version": "2.13.9",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
-      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
-      "requires": {}
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A=="
     },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {}
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "reflect-metadata": {
       "version": "0.1.13",
@@ -44400,8 +44273,7 @@
         "b4a": {
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-          "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-          "requires": {}
+          "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="
         },
         "node-addon-api": {
           "version": "6.1.0",
@@ -46158,8 +46030,7 @@
         "b4a": {
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-          "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-          "requires": {}
+          "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="
         }
       }
     },
@@ -46370,8 +46241,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
       "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-jest": {
       "version": "26.5.6",
@@ -47052,8 +46922,7 @@
         "acorn-import-phases": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-          "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-          "requires": {}
+          "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="
         },
         "ajv": {
           "version": "8.17.1",
@@ -47279,8 +47148,7 @@
           "version": "8.19.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
           "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -47602,8 +47470,7 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -47716,15 +47583,14 @@
       }
     },
     "zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
     "zod-validation-error": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-5.0.0.tgz",
-      "integrity": "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==",
-      "requires": {}
+      "integrity": "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@datadog/browser-rum": "^4.15.0",
         "@material-ui/core": "^4.11.4",
         "@material-ui/lab": "^4.0.0-alpha.61",
+        "@opengovsg/validators": "^1.4.1",
         "@types/express-rate-limit": "^5.1.3",
         "@types/papaparse": "^5.3.5",
         "archiver": "^5.3.1",
@@ -85,7 +86,8 @@
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
         "webpack": "^5.76.0",
-        "winston": "^3.19.0"
+        "winston": "^3.19.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -4592,6 +4594,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opengovsg/validators": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opengovsg/validators/-/validators-1.4.1.tgz",
+      "integrity": "sha512-jynSts9f51gG2CP3vApgtIVx/GTE/5DanWDN7UnISyjDIfjT1mpoit43Mxl9UAxh5UwjLrfcJxKJHQHPj7A9QA==",
+      "dependencies": {
+        "email-addresses": "^5.0.0",
+        "zod-validation-error": "^5.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -11408,6 +11422,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "license": "MIT"
     },
     "node_modules/email-validator": {
       "version": "2.0.4",
@@ -27409,6 +27429,27 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-5.0.0.tgz",
+      "integrity": "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   },
   "dependencies": {
@@ -30565,6 +30606,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@opengovsg/validators": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opengovsg/validators/-/validators-1.4.1.tgz",
+      "integrity": "sha512-jynSts9f51gG2CP3vApgtIVx/GTE/5DanWDN7UnISyjDIfjT1mpoit43Mxl9UAxh5UwjLrfcJxKJHQHPj7A9QA==",
+      "requires": {
+        "email-addresses": "^5.0.0",
+        "zod-validation-error": "^5.0.0"
       }
     },
     "@opentelemetry/api": {
@@ -35720,6 +35770,11 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="
     },
     "email-validator": {
       "version": "2.0.4",
@@ -47659,6 +47714,17 @@
           }
         }
       }
+    },
+    "zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+    },
+    "zod-validation-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-5.0.0.tgz",
+      "integrity": "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@datadog/browser-rum": "^4.15.0",
     "@material-ui/core": "^4.11.4",
     "@material-ui/lab": "^4.0.0-alpha.61",
+    "@opengovsg/validators": "^1.4.1",
     "@types/express-rate-limit": "^5.1.3",
     "@types/papaparse": "^5.3.5",
     "archiver": "^5.3.1",
@@ -124,7 +125,8 @@
     "uuid": "^8.3.2",
     "validator": "^13.7.0",
     "webpack": "^5.76.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "validator": "^13.7.0",
     "webpack": "^5.76.0",
     "winston": "^3.19.0",
-    "zod": "^4.4.3"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/src/server/util/__tests__/email.test.ts
+++ b/src/server/util/__tests__/email.test.ts
@@ -1,0 +1,49 @@
+import { isValidGovEmail } from '../email'
+
+/**
+ * Unit tests for isValidGovEmail.
+ * Test setup mocks emailValidator to `*.test.sg` (see test/server/config.ts).
+ */
+describe('isValidGovEmail', () => {
+  it('accepts a well-formed government email on an allowed domain', () => {
+    expect(isValidGovEmail('user@agency.test.sg')).toBe(true)
+  })
+
+  it('accepts plus-tagged local parts on an allowed domain', () => {
+    expect(isValidGovEmail('user.name+tag@agency.test.sg')).toBe(true)
+  })
+
+  it('rejects emails on a disallowed domain', () => {
+    expect(isValidGovEmail('user@gmail.com')).toBe(false)
+  })
+
+  it('rejects malformed strings', () => {
+    expect(isValidGovEmail('not-an-email')).toBe(false)
+    expect(isValidGovEmail('')).toBe(false)
+    expect(isValidGovEmail('a@b@c@agency.test.sg')).toBe(false)
+  })
+
+  it('rejects emails with leading or trailing whitespace', () => {
+    expect(isValidGovEmail(' user@agency.test.sg')).toBe(false)
+    expect(isValidGovEmail('user@agency.test.sg ')).toBe(false)
+  })
+
+  /**
+   * Quoted nested addresses can pass validator.isEmail and the domain glob
+   * (local part looks like a quoted string, domain is still *.test.sg) but must
+   * be rejected by the well-formedness schema.
+   */
+  it('rejects quoted nested emails that pass domain matching', () => {
+    expect(isValidGovEmail('"user@gmail.com"@agency.test.sg')).toBe(false)
+  })
+
+  it('rejects %-escaped mail routes on an allowed domain', () => {
+    expect(isValidGovEmail('user%gmail.com@agency.test.sg')).toBe(false)
+  })
+
+  it('rejects encoded-word local parts on an allowed domain', () => {
+    expect(
+      isValidGovEmail('=?utf-7?b?JkFHWUFid0J2QUdJQVlRQnkt?=@agency.test.sg'),
+    ).toBe(false)
+  })
+})

--- a/src/server/util/email.ts
+++ b/src/server/util/email.ts
@@ -1,12 +1,17 @@
+import { createEmailSchema } from '@opengovsg/validators/email'
 import validator from 'validator'
 import { emailValidator } from '../config'
+
+// Validates well-formedness only (no domain restriction).
+// Domain checking is handled separately by emailValidator.
+const wellFormedEmailSchema = createEmailSchema()
 
 /**
  * Checks if an email is valid and whether it follows a specified regex pattern.
  * @param email The email to be validated.
  */
 export function isValidGovEmail(email: string) {
-  return validator.isEmail(email) && emailValidator.match(email)
+  return validator.isEmail(email) && emailValidator.match(email) && wellFormedEmailSchema.safeParse(email).success
 }
 
 export default { isValidGovEmail }

--- a/src/server/util/email.ts
+++ b/src/server/util/email.ts
@@ -1,4 +1,4 @@
-import { createEmailSchema } from '@opengovsg/validators/email'
+import { createEmailSchema } from '@opengovsg/validators'
 import validator from 'validator'
 import { emailValidator } from '../config'
 

--- a/src/server/util/email.ts
+++ b/src/server/util/email.ts
@@ -1,4 +1,4 @@
-import { createEmailSchema } from '@opengovsg/validators'
+import { createEmailSchema } from '@opengovsg/validators/email'
 import validator from 'validator'
 import { emailValidator } from '../config'
 

--- a/src/server/util/email.ts
+++ b/src/server/util/email.ts
@@ -11,7 +11,11 @@ const wellFormedEmailSchema = createEmailSchema()
  * @param email The email to be validated.
  */
 export function isValidGovEmail(email: string) {
-  return validator.isEmail(email) && emailValidator.match(email) && wellFormedEmailSchema.safeParse(email).success
+  return (
+    validator.isEmail(email) &&
+    emailValidator.match(email) &&
+    wellFormedEmailSchema.safeParse(email).success
+  )
 }
 
 export default { isValidGovEmail }

--- a/src/types/opengovsg-validators-email.d.ts
+++ b/src/types/opengovsg-validators-email.d.ts
@@ -4,6 +4,7 @@
  * which this repo's TypeScript 4.7 cannot parse. Runtime still resolves
  * the real package; tsconfig paths only remaps types for tsc.
  */
+/* eslint-disable import/prefer-default-export */
 export declare function createEmailSchema(options?: unknown): {
   safeParse(email: string): { success: boolean; data?: string }
 }

--- a/src/types/opengovsg-validators-email.d.ts
+++ b/src/types/opengovsg-validators-email.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Local type stub for @opengovsg/validators/email.
+ * The package's real types pull zod/v4 .d.cts (TS 5+ const type params),
+ * which this repo's TypeScript 4.7 cannot parse. Runtime still resolves
+ * the real package; tsconfig paths only remaps types for tsc.
+ */
+export declare function createEmailSchema(options?: unknown): {
+  safeParse(email: string): { success: boolean; data?: string }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,9 @@
       ],
       "@assets/*": [
         "./src/client/app/assets/gov/*"
+      ],
+      "@opengovsg/validators/email": [
+        "./src/types/opengovsg-validators-email"
       ]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -68,6 +71,8 @@
     ] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // Required: @opengovsg/validators pulls zod/v4 .d.cts that use TS 5+ syntax (const type params).
+    "skipLibCheck": true,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
## Summary
- Tighten server-side email validation with an additional well-formedness check via `@opengovsg/validators`
- Add unit tests for `isValidGovEmail`

## Test plan
- [ ] `npm test -- src/server/util/__tests__/email.test.ts`
- [ ] Confirm valid government emails still pass login / ownership flows
- [ ] Confirm clearly malformed emails are rejected

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change adds a stricter well-formedness check to government-email validation while retaining the existing syntax and approved-domain requirements. Executed checks confirmed that quoted nested, percent-routed, encoded-word, display-name, and multiple-`@` address forms are rejected by `isValidGovEmail`, while valid ordinary and plus-tagged approved-domain addresses remain accepted. The focused email test suite passed all 8 checks.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Jest reproduction that exercises quoted nested, percent-routed, display-name, encoded-word, and multiple-@ inputs through the email predicates and isValidGovEmail.
- Compared the baseline behavior before the schema check with the after-schema results, observing that hostile inputs are rejected and ordinary or plus-tagged approved-domain addresses pass.
- Validated that the existing focused email-validation regression suite passes all eight tests.
- Reviewed the reproduction source and the before/after/regression logs to validate the end-to-end changes and the evidence trail.

<a href="https://app.greptile.com/trex/runs/17381849/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["style: disable prefer-default-export on ..."](https://github.com/opengovsg/gogovsg/commit/872a9996f855a0fd8594838530f8f0d70187d36a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50325372)</sub>

<!-- /greptile_comment -->