### PR TITLE
feat(otp): generate 6-character alphanumeric OTPs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
     init: pip install --quiet localstack[full]
     command: /workspace/.pip-modules/bin/localstack start --host
   - before: npm install maildev -g
-    command: echo "maildev.on('new', ({ html }) => console.log('The login OTP is ' + html.match(/\d{6}/)[0]))" >> $(which maildev) && maildev --verbose
+    command: echo "maildev.on('new', ({ html }) => console.log('The login OTP is ' + html.match(/<b>([A-Z0-9]{6})<\\/b>/)[1]))" >> $(which maildev) && maildev --verbose
   - before: export ACCESS_ENDPOINT=`gp url 4566`
     init: npm install
     command: /tmp/wait-for-it.sh localhost:4566 -t 0 -- ./init-localstack.sh && echo "Run npm run docker-dev to begin"

--- a/Dockerfile.maildev-logging
+++ b/Dockerfile.maildev-logging
@@ -1,3 +1,3 @@
 FROM maildev/maildev:1.1.0
 WORKDIR /usr/src/app
-RUN echo "maildev.on('new', ({ html }) => { if(html.includes('OTP')) { console.log('Login OTP: ' + html.match(/\d{6}/)[0]) } else { console.log(html) } } )" >> bin/maildev
+RUN echo "maildev.on('new', ({ html }) => { if(html.includes('OTP')) { console.log('Login OTP: ' + html.match(/<b>([A-Z0-9]{6})<\\/b>/)[1]) } else { console.log(html) } } )" >> bin/maildev

--- a/src/client/login/index.tsx
+++ b/src/client/login/index.tsx
@@ -200,7 +200,7 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({
             dispatch(loginActions.verifyOTP(otp))
           },
           titleMessage: 'One time password',
-          placeholder: 'e.g. 123456',
+          placeholder: 'e.g. A1B2C3',
           buttonMessage: 'Submit',
           textError: () => false,
           textErrorMessage: () => '',

--- a/src/server/api/login/validators.ts
+++ b/src/server/api/login/validators.ts
@@ -14,7 +14,12 @@ export const otpVerificationSchema = Joi.object({
       return email
     })
     .required(),
-  otp: Joi.string().required(),
+  otp: Joi.string()
+    .pattern(/^[A-Za-z0-9]{6}$/)
+    .required()
+    .messages({
+      'string.pattern.base': 'OTP must be 6 alphanumeric characters.',
+    }),
 })
 
 export const otpGenerationSchema = Joi.object({

--- a/src/server/modules/auth/services/AuthService.ts
+++ b/src/server/modules/auth/services/AuthService.ts
@@ -87,7 +87,7 @@ export class AuthService implements interfaces.AuthService {
     }
 
     const isOtpMatch = await this.cryptography.compare(
-      otp,
+      otp.toUpperCase(),
       retrievedOtp.hashedOtp,
     )
 

--- a/src/server/util/__tests__/otp.test.ts
+++ b/src/server/util/__tests__/otp.test.ts
@@ -1,0 +1,14 @@
+import generateOTP from '../otp'
+
+describe('generateOTP', () => {
+  it('should generate a 6-character alphanumeric OTP', () => {
+    const otp = generateOTP()
+    expect(otp).toHaveLength(6)
+    expect(otp).toMatch(/^[A-Z0-9]{6}$/)
+  })
+
+  it('should generate different OTPs across multiple calls', () => {
+    const otps = new Set(Array.from({ length: 20 }, () => generateOTP()))
+    expect(otps.size).toBeGreaterThan(1)
+  })
+})

--- a/src/server/util/otp.ts
+++ b/src/server/util/otp.ts
@@ -5,7 +5,7 @@ export type OtpFunction = () => string
 
 const generateOTP: OtpFunction = () => {
   const length: number = 6
-  const chars: string = '0123456789'
+  const chars: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
   // Generates cryptographically strong pseudo-random data.
   // The size argument is a number indicating the number of bytes to generate.
   const rnd: Buffer = crypto.randomBytes(length)

--- a/test/end-to-end/util/LoginProcedure.ts
+++ b/test/end-to-end/util/LoginProcedure.ts
@@ -30,7 +30,7 @@ const loginProcedure = async (t, loginEmail = testEmail) => {
     .then((json) => {
       const mailIndex = json.length - 1
       const mailBody = json[mailIndex].html
-      const mailOTP = JSON.stringify(mailBody).match(/\d{6}/)[0]
+      const mailOTP = JSON.stringify(mailBody).match(/<b>([A-Z0-9]{6})<\/b>/)[1]
       return mailOTP
     })
     .then(async (mailOTP) => {

--- a/test/integration/util/helpers.ts
+++ b/test/integration/util/helpers.ts
@@ -68,7 +68,7 @@ export const getAuthCookie: (email: string) => Promise<string> = async (
   if (!emailRes.ok) throw new Error('Failed to check email for OTP')
   const emailJson = await emailRes.json()
   const emailBody = emailJson[emailJson.length - 1].html
-  const emailOTP = JSON.stringify(emailBody).match(/\d{6}/)![0]
+  const emailOTP = JSON.stringify(emailBody).match(/<b>([A-Z0-9]{6})<\/b>/)![1]
   const verifyRes = await postJson(API_LOGIN_VERIFY, {
     email,
     otp: emailOTP,

--- a/test/server/api/LoginRoute.test.ts
+++ b/test/server/api/LoginRoute.test.ts
@@ -56,13 +56,13 @@ describe('POST /api/login/otp', () => {
 describe('POST /api/login/verify', () => {
   test('verify the OTP', async (done) => {
     // Prime cache
-    getOtpCache().setOtpForEmail('otpgo.gov@open.test.sg', '127.0.0.1', {
-      hashedOtp: '1',
+    getOtpCache().setOtpForEmail('otpgo.gov@open.test.sg', '::ffff:127.0.0.1', {
+      hashedOtp: '111111',
       retries: 100,
     })
     const res = await request(app)
       .post('/api/login/verify')
-      .send({ email: 'otpgo.gov@open.test.sg', otp: '1' })
+      .send({ email: 'otpgo.gov@open.test.sg', otp: '111111' })
     expect(res.status).toBe(200)
     expect(res.body.message).toBe('OTP hash verification ok.')
     done()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

OTP codes were limited to 6 numeric digits, which reduces the search space and makes them easier to guess.

## Solution

Updated OTP generation to use 6 uppercase alphanumeric characters (`A-Z`, `0-9`).

**Features**:

- OTPs are now generated from uppercase letters and digits instead of digits only
- Server-side verification validates that submitted OTPs are exactly 6 alphanumeric characters
- User input is normalized to uppercase during verification so casing does not block login

**Improvements**:

- Updated login page OTP placeholder example to `A1B2C3`
- Updated integration and end-to-end test helpers to extract alphanumeric OTPs from email HTML
- Fixed maildev logging hook that crashed on non-numeric OTPs and took down the test mail server in CI
- Added unit tests for OTP generation
- Fixed login route verify test to use the correct request IP for OTP cache lookup

## Tests

- `npx jest --testPathPattern="otp.test|LoginRoute.test" --no-coverage --forceExit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19fcc01a-6b7e-42d1-bac2-0bca5ce03875?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19fcc01a-6b7e-42d1-bac2-0bca5ce03875&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change expands login OTPs from six numeric digits to six uppercase alphanumeric characters, updates the login prompt, and updates email parsing helpers used by development and automated login checks.

The login flow was exercised through the production verification route. Generated OTPs matched the new format; both uppercase and lowercase input verified successfully; and malformed OTPs with invalid lengths or symbols were rejected. The focused OTP contract test and the affected existing test suites passed.

No defects were found.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused OTP contract test source file and saw 1 suite and 5 tests pass.
- Executed the baseline OTP tests across server utilities and login route; the run reported 2 suites and 7 tests pass.
- Validated the OTP format and acceptance rules by inspecting the login route tests; 256 generated OTPs matched the pattern ^\[A-Z0-9\]{6}$, A1B2C3 was accepted for the same stored OTP, and five-character, seven-character, and symbol-containing values were rejected.
- Noted that the AWS SDK v2 end-of-support notice was non-failing and unrelated to OTP behavior.

<a href="https://app.greptile.com/trex/runs/17424770/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otp): update gitpod maildev logging ..."](https://github.com/opengovsg/gogovsg/commit/47e9b05415ee11a8c753a3cfcdbf2c2567675333) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50417978)</sub>

<!-- /greptile_comment -->