### PR TITLE
chore(deps): bump testcafe to v3.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,7 @@
         "sequelize-mock": "^0.10.2",
         "serverless-plugin-include-dependencies": "^5.0.0",
         "supertest": "^6.1.3",
-        "testcafe": "^2.6.2",
+        "testcafe": "3.7.4",
         "ts-jest": "^29.4.12",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
@@ -165,6 +165,13 @@
       "engines": {
         "node": "18"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -343,19 +350,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -663,26 +657,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
-      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-remap-async-to-generator": "^7.18.9",
-        "@babel/plugin-syntax-async-generators": "^7.8.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
@@ -711,45 +685,6 @@
         "@babel/helper-create-class-features-plugin": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/plugin-syntax-decorators": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
-      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2861,14 +2796,98 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@devexpress/error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@devexpress/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-fneVypElGUH6Be39mlRZeAu00pccTlf4oVuzf9xPJD1cdEqI8NyAiQua/EW7lZdrbMUbgyXcJmfKPefhYius3A==",
+    "node_modules/@devexpress/callsite-record": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@devexpress/callsite-record/-/callsite-record-4.1.7.tgz",
+      "integrity": "sha512-qr3VQYc0KopduFkEY6SxaOIi1Xhm0jIWQfrxxMVboI/p2rjF/Mj/iqaiUxQQP6F3ujpW/7l0mzhf17uwcFZhBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "@types/lodash": "^4.14.72",
+        "callsite": "^1.0.0",
+        "chalk": "^2.4.0",
+        "error-stack-parser": "^2.1.4",
+        "highlight-es": "^1.0.0",
+        "lodash": "4.6.1 || ^4.16.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@devexpress/callsite-record/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -3759,16 +3778,6 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/@miherlosev/esm": {
-      "version": "3.2.26",
-      "resolved": "https://registry.npmjs.org/@miherlosev/esm/-/esm-3.2.26.tgz",
-      "integrity": "sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
@@ -3810,6 +3819,21 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@node-ntlm/core": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@node-ntlm/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-uCKcLcl8UCCkIDZZlgkDXNzJGaDTP/+DThwurluBOPZ8/21kvFKMVw75MC7cQsNxnbkLagp4jfu+2oX/IIXNYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.0.1",
+        "js-md4": "^0.3.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16.19.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6105,6 +6129,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/address": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -6165,16 +6199,6 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "license": "BSD-3-Clause OR MIT",
-      "engines": {
-        "node": ">=0.4.2"
       }
     },
     "node_modules/ansi-colors": {
@@ -6663,19 +6687,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/auto-changelog": {
@@ -7602,100 +7613,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/callsite-record": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/callsite-record/-/callsite-record-4.1.5.tgz",
-      "integrity": "sha512-OqeheDucGKifjQRx524URgV4z4NaKjocGhygTptDea+DLROre4ZEecA4KXDq+P7qlGCohYVNOh3qr+y5XH5Ftg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@devexpress/error-stack-parser": "^2.0.6",
-        "@types/lodash": "^4.14.72",
-        "callsite": "^1.0.0",
-        "chalk": "^2.4.0",
-        "highlight-es": "^1.0.0",
-        "lodash": "4.6.1 || ^4.16.1",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
-    "node_modules/callsite-record/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/callsite-record/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/callsite-record/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/callsite-record/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/callsite-record/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/callsite-record/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/callsite-record/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -9074,19 +8991,6 @@
         "node": ">=0.5.2"
       }
     },
-    "node_modules/css": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.5.1",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -9175,18 +9079,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css/node_modules/source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/csstype": {
@@ -9489,16 +9381,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
@@ -10038,6 +9920,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1109433",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1109433.tgz",
+      "integrity": "sha512-w1Eqih66egbSr2eOoGZ+NsdF7HdxmKDo3pKFBySEGsmVvwWWNXzNCDcKrbFnd23Jf7kH1M806OfelXwu+Jk11g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -10362,40 +10251,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/endpoint-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
-      "integrity": "sha512-s5IrlLvx7qVXPOjcxjF00CRBlybiQWOoGCNiIZ/Vin2WeJ3SHtfkWHRsyu7C1+6QAwYXf0ULoweylxUa19Khjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^1.1.3",
-        "pinkie-promise": "^1.0.0"
-      }
-    },
-    "node_modules/endpoint-utils/node_modules/pinkie": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "integrity": "sha512-VFVaU1ysKakao68ktZm76PIdOhvEfoNNRaGkyLln9Os7r0/MCxqHjHyBM7dT3pgTiBybqiPtpqKfpENwdBp50Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/endpoint-utils/node_modules/pinkie-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "integrity": "sha512-5mvtVNse2Ml9zpFKkWBpGsTPwm3DKhs+c95prO/F6E7d6DN0FPqxs6LONpLNpyD7Iheb7QN4BbUoKJgo+DnkQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
@@ -10460,21 +10315,14 @@
       }
     },
     "node_modules/error-stack-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
-      "integrity": "sha512-xhuSYd8wLgOXwNgjcPeXMPL/IiiA1Huck+OPvClpJViVNNlJVtM41o+1emp7bPvlCJwCatFX2DWc05/DgfbWzA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dev": true,
-      "license": "Unlicense",
+      "license": "MIT",
       "dependencies": {
-        "stackframe": "^0.3.1"
+        "stackframe": "^1.3.4"
       }
-    },
-    "node_modules/error-stack-parser/node_modules/stackframe": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-      "integrity": "sha512-XmoiF4T5nuWEp2x2w92WdGjdHGY/cZa6LIbRsDRQR/Xlk4uW0PAUlH1zJYVffocwKpCdwyuypIp25xsSXEtZHw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -11336,9 +11184,9 @@
       "license": "MIT"
     },
     "node_modules/esotope-hammerhead": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.4.tgz",
-      "integrity": "sha512-QY4HXqvjLSFGoGgHvm3H1QUMNcpwnUpGRBaVVFWE5uqbPQh9HSWcA1YD7KwwL/IrgerDwZn00z5dtYT9Ot/C/A==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.9.tgz",
+      "integrity": "sha512-rD9Jbh0SFJzKe1RGfsbwpN5IBdubHKC61xRW7A5BPgBTtEnFxsWOqPITVhBaVDc4r5VPmh+Y1U1wmqReTfn1AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13668,13 +13516,6 @@
       "integrity": "sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==",
       "license": "MIT"
     },
-    "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -14018,14 +13859,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-jquery-obj": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz",
-      "integrity": "sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==",
-      "deprecated": "The is-jquery-obj package has reached end-of-life and will not receive further updates.",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -17267,16 +17100,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
@@ -18511,6 +18334,13 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -19555,14 +19385,6 @@
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "license": "MIT"
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -20564,21 +20386,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -20589,14 +20396,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/spark-md5": {
       "version": "3.0.2",
@@ -21314,52 +21113,53 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.6.2.tgz",
-      "integrity": "sha512-BVlrx6bjVMMIG4JBle0AO9t6dER51+t7ncWGptbnJYzUE/FkigZTHLCPDj4uNid6WYg4yz4AzfkA408WvTiCQg==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-3.7.4.tgz",
+      "integrity": "sha512-RADoEWAfGCQ1q08zr4kRQ+bEOhOiI3hmzF2s5dFv835ndERdE44V14DVqeOWGEFm0o+x6IYHyWhmQp0g9mz4ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.12.1",
-        "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
-        "@babel/plugin-proposal-class-properties": "^7.12.1",
-        "@babel/plugin-proposal-decorators": "^7.12.1",
-        "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
-        "@babel/plugin-proposal-private-methods": "^7.14.5",
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-proposal-decorators": "^7.23.2",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-transform-async-to-generator": "^7.12.1",
-        "@babel/plugin-transform-exponentiation-operator": "^7.12.1",
-        "@babel/plugin-transform-for-of": "^7.12.1",
-        "@babel/plugin-transform-runtime": "^7.12.1",
-        "@babel/preset-env": "^7.12.1",
-        "@babel/preset-flow": "^7.12.1",
-        "@babel/preset-react": "^7.12.1",
-        "@babel/runtime": "^7.12.5",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.22.5",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-class-static-block": "^7.24.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.22.5",
+        "@babel/plugin-transform-for-of": "^7.22.15",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.25.4",
+        "@babel/plugin-transform-runtime": "7.23.3",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-flow": "^7.22.15",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/runtime": "^7.23.2",
         "@devexpress/bin-v8-flags-filter": "^1.3.0",
-        "@miherlosev/esm": "3.2.26",
-        "@types/node": "^12.20.10",
+        "@devexpress/callsite-record": "^4.1.6",
+        "@types/node": "20.14.5",
+        "address": "^2.0.2",
         "async-exit-hook": "^1.1.2",
-        "babel-plugin-module-resolver": "^5.0.0",
+        "babel-plugin-module-resolver": "5.0.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
         "bowser": "^2.8.1",
         "callsite": "^1.0.0",
-        "callsite-record": "^4.0.0",
         "chai": "4.3.4",
         "chalk": "^2.3.0",
-        "chrome-remote-interface": "^0.32.1",
+        "chrome-remote-interface": "^0.32.2",
         "coffeescript": "^2.3.1",
         "commander": "^8.3.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
         "device-specs": "^1.0.0",
-        "diff": "^4.0.2",
+        "devtools-protocol": "0.0.1109433",
+        "diff": "^8.0.3",
         "elegant-spinner": "^1.0.1",
         "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
-        "endpoint-utils": "^1.0.2",
-        "error-stack-parser": "^1.3.6",
+        "error-stack-parser": "^2.1.4",
         "execa": "^4.0.3",
         "get-os-info": "^1.0.2",
         "globby": "^11.0.4",
@@ -21375,7 +21175,7 @@
         "is-podman": "^1.0.1",
         "is-stream": "^2.0.0",
         "json5": "^2.2.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "log-update-async-hook": "^2.0.7",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
@@ -21397,22 +21197,21 @@
         "resolve-cwd": "^1.0.0",
         "resolve-from": "^4.0.0",
         "sanitize-filename": "^1.6.0",
-        "semver": "^5.6.0",
+        "semver": "^7.5.3",
         "set-cookie-parser": "^2.5.1",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.25",
-        "testcafe-hammerhead": "31.4.3",
-        "testcafe-legacy-api": "5.1.6",
+        "testcafe-browser-tools": "2.0.26",
+        "testcafe-hammerhead": "31.7.7",
+        "testcafe-legacy-api": "5.1.8",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.2.0",
         "testcafe-reporter-minimal": "^2.2.0",
         "testcafe-reporter-spec": "^2.2.0",
         "testcafe-reporter-xunit": "^2.2.1",
-        "testcafe-safe-storage": "^1.1.1",
         "testcafe-selector-generator": "^0.1.0",
         "time-limit-promise": "^1.0.2",
-        "tmp": "0.0.28",
+        "tmp": "0.2.5",
         "tree-kill": "^1.2.2",
         "typescript": "4.7.4",
         "unquote": "^1.1.1",
@@ -21426,9 +21225,9 @@
       }
     },
     "node_modules/testcafe-browser-tools": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.25.tgz",
-      "integrity": "sha512-LK/ZOJUwnpjdJl131qrBN0toCv2wZj2Elb8UPTU71n9Woq7kZtGine4P5XvvvO7mE8bjBfWJOBW9jRhHxyIWzQ==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.26.tgz",
+      "integrity": "sha512-nTKSJhBzn9BmnOs0xVzXMu8dN2Gu13Ca3x3SJr/zF6ZdKjXO82JlbHu55dt5MFoWjzAQmwlqBkSxPaYicsTgUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21604,39 +21403,40 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "31.4.3",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.4.3.tgz",
-      "integrity": "sha512-Z8wubj/8t3T5udVyqf2Kqy9oZFE8zDIWnuItVIEscYQ8PB6eWCkjq3oSx9J0XzSdakFnsUYP1T/KVlNe5z306w==",
+      "version": "31.7.8",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.7.8.tgz",
+      "integrity": "sha512-AMLZdS4dbU6M64a/VgBu0O/qlfsv7MWROk91C4jyMmCjkq6FsKfknzqWtlh5w8o8fLJGjyGBDUFaRb/jpIuEoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@adobe/css-tools": "^4.3.0-rc.1",
         "@electron/asar": "^3.2.3",
+        "@node-ntlm/core": "^0.3.2",
         "acorn-hammerhead": "0.6.2",
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
-        "css": "2.2.3",
         "debug": "4.3.1",
-        "esotope-hammerhead": "0.6.4",
+        "esotope-hammerhead": "0.6.9",
         "http-cache-semantics": "^4.1.0",
-        "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",
-        "lodash": "^4.17.20",
-        "lru-cache": "2.6.3",
+        "lodash": "^4.17.21",
+        "lru-cache": "11.0.2",
         "match-url-wildcard": "0.0.4",
         "merge-stream": "^1.0.1",
         "mime": "~1.4.1",
         "mustache": "^2.1.1",
         "nanoid": "^3.1.12",
         "os-family": "^1.0.0",
-        "parse5": "2.2.3",
+        "parse5": "^7.1.2",
         "pinkie": "2.0.4",
         "read-file-relative": "^1.2.0",
-        "semver": "5.5.0",
-        "tough-cookie": "4.0.0",
-        "tunnel-agent": "0.6.0"
+        "semver": "7.5.3",
+        "tough-cookie": "4.1.3",
+        "tunnel-agent": "0.6.0",
+        "ws": "^7.4.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/testcafe-hammerhead/node_modules/bowser": {
@@ -21664,6 +21464,19 @@
         }
       }
     },
+    "node_modules/testcafe-hammerhead/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/testcafe-hammerhead/node_modules/iconv-lite": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
@@ -21678,11 +21491,14 @@
       }
     },
     "node_modules/testcafe-hammerhead/node_modules/lru-cache": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
-      "integrity": "sha512-qkisDmHMe8gxKujmC1BdaqgkoFlioLDCUwaFBA3lX8Ilhr3YzsasbGYaiADMjxQnj+aiZUKgGKe/BN3skMwXWw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
       "dev": true,
-      "license": "MIT"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/testcafe-hammerhead/node_modules/merge-stream": {
       "version": "1.0.1",
@@ -21712,11 +21528,17 @@
       "license": "MIT"
     },
     "node_modules/testcafe-hammerhead/node_modules/parse5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-      "integrity": "sha512-yJQdbcT+hCt6HD+BuuUvjHUdNwerQIKSJSm7tXjtp6oIH5Mxbzlt/VIIeWxblsgcDt1+E7kxPeilD5McWswStA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/testcafe-hammerhead/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -21742,13 +21564,32 @@
       "license": "MIT"
     },
     "node_modules/testcafe-hammerhead/node_modules/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/testcafe-hammerhead/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/testcafe-hammerhead/node_modules/string_decoder": {
@@ -21761,17 +21602,23 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/testcafe-hammerhead/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/testcafe-legacy-api": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.6.tgz",
-      "integrity": "sha512-Q451IdSUX1NmRfE8kzIcEeoqbUlLaMv2fwVNgQOBEFmA5E57c3jsIpLDTDqv6FPcNwdNMYIZMiB6tzlXB5wf1g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.8.tgz",
+      "integrity": "sha512-Jp/8xPQ+tjr2iS569Og8fFRaSx/7h/N/t6DVzhWpVNO3D5AtPkGmSjCAABh7tHkUwrKfBI7sLuVaxekiT5PWTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "3.2.3",
         "dedent": "^0.6.0",
         "highlight-es": "^1.0.0",
-        "is-jquery-obj": "^0.1.0",
         "lodash": "^4.14.0",
         "moment": "^2.14.1",
         "mustache": "^2.2.1",
@@ -21866,17 +21713,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/testcafe-safe-storage": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.6.tgz",
-      "integrity": "sha512-WFm1UcmO3uZs+uW8lYtBBJpnrvgTKkMQMKG9BvTEKbjeqhonEXVTxOkGEs3DM1ZB/ylPuwh7Jux7qUtjcM/D2Q==",
-      "deprecated": "The testcafe-safe-storage package has reached end-of-life and will not receive further updates.",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "test"
-      ]
-    },
     "node_modules/testcafe-selector-generator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/testcafe-selector-generator/-/testcafe-selector-generator-0.1.0.tgz",
@@ -21885,11 +21721,14 @@
       "license": "MIT"
     },
     "node_modules/testcafe/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "20.14.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
+      "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/testcafe/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -21959,6 +21798,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/testcafe/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/testcafe/node_modules/dedent": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.4.0.tgz",
@@ -22021,6 +21878,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/testcafe/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/testcafe/node_modules/emittery": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
@@ -22029,6 +21896,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/testcafe/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/testcafe/node_modules/escape-string-regexp": {
@@ -22099,6 +21979,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/iconv-lite": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+      "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/testcafe/node_modules/indent-string": {
@@ -22178,6 +22071,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/testcafe/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/testcafe/node_modules/mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      }
+    },
+    "node_modules/testcafe/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/testcafe/node_modules/p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
@@ -22212,6 +22132,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/testcafe/node_modules/resolve-cwd": {
@@ -22261,14 +22197,24 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/testcafe/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/testcafe/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/testcafe/node_modules/source-map-support": {
@@ -22280,6 +22226,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/testcafe/node_modules/strip-bom": {
@@ -22308,6 +22264,102 @@
         "node": ">=4"
       }
     },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead": {
+      "version": "31.7.7",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.7.7.tgz",
+      "integrity": "sha512-vSI/ak8MTuDENCMLGNyPS+tsf7hLisQfaBDYB6NCY5y/arz26cad86P6+eIrm3ncH3SsnFcm+BmkmNjJxzPyoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.0-rc.1",
+        "@electron/asar": "^3.2.3",
+        "acorn-hammerhead": "0.6.2",
+        "bowser": "1.6.0",
+        "crypto-md5": "^1.0.0",
+        "debug": "4.3.1",
+        "esotope-hammerhead": "0.6.9",
+        "http-cache-semantics": "^4.1.0",
+        "httpntlm": "^1.8.10",
+        "iconv-lite": "0.5.1",
+        "lodash": "^4.17.21",
+        "lru-cache": "11.0.2",
+        "match-url-wildcard": "0.0.4",
+        "merge-stream": "^1.0.1",
+        "mime": "~1.4.1",
+        "mustache": "^2.1.1",
+        "nanoid": "^3.1.12",
+        "os-family": "^1.0.0",
+        "parse5": "^7.1.2",
+        "pinkie": "2.0.4",
+        "read-file-relative": "^1.2.0",
+        "semver": "7.5.3",
+        "tough-cookie": "4.1.3",
+        "tunnel-agent": "0.6.0",
+        "ws": "^7.4.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/bowser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+      "integrity": "sha512-Fk23J0+vRnI2eKDEDoUZXWtbMjijr098lKhuj4DKAfMKMCRVfJOuxXlbpxy0sTgbZ/Nr2N8MexmOir+GGI/ZMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/testcafe/node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -22321,6 +22373,20 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/testcafe/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/testcafe/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
@@ -22497,16 +22563,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -22588,24 +22651,25 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23406,14 +23470,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/url": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
@@ -23426,6 +23482,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-to-options": {

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "sequelize-mock": "^0.10.2",
     "serverless-plugin-include-dependencies": "^5.0.0",
     "supertest": "^6.1.3",
-    "testcafe": "^2.6.2",
+    "testcafe": "3.7.4",
     "ts-jest": "^29.4.12",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",

--- a/test/end-to-end/DrawerLogin.test.ts
+++ b/test/end-to-end/DrawerLogin.test.ts
@@ -1,4 +1,4 @@
-import { ClientFunction, Selector } from 'testcafe'
+import { ClientFunction } from 'testcafe'
 import {
   apiLocation,
   dummyFilePath,
@@ -27,6 +27,7 @@ import {
   inactiveWord,
   largeFileError,
   linkErrorSnackBar,
+  linkRowByShortUrl,
   linkTransferField,
   longUrl,
   longUrlTextField,
@@ -63,7 +64,7 @@ test('Drawer functionality test for url.', async (t) => {
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
 
   const generatedUrl = await shortUrlTextField.value
-  const linkRow = Selector(`h6[title="${generatedUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedUrl)
   const linkTableRow = linkRow.parent('tr')
 
   await t.typeText(tagsAutocompleteInput, tagText1).pressKey('enter')
@@ -179,7 +180,7 @@ test('Drawer functionality test for file.', async (t) => {
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
 
   const generatedFileUrl = await shortUrlTextField.value
-  const linkRow = Selector(`h6[title="${generatedFileUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedFileUrl)
 
   await createEmptyFileOfSize(dummyFilePath, smallFileSize)
 
@@ -212,7 +213,7 @@ test.before(async (t) => {
   await t.typeText(tagsAutocompleteInput, tagText1).pressKey('enter')
 
   const generatedUrl = await shortUrlTextField.value
-  const linkRow = Selector(`h6[title="${generatedUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedUrl)
   const linkTableRow = linkRow.parent('tr')
 
   await t
@@ -264,7 +265,7 @@ test('Link transfer toast test.', async (t) => {
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
 
   const generatedUrl = await shortUrlTextField.value
-  const linkRow = Selector(`h6[title="${generatedUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedUrl)
 
   await t
     .typeText(longUrlTextField, `${shortUrl}`)

--- a/test/end-to-end/LinkAudit.test.ts
+++ b/test/end-to-end/LinkAudit.test.ts
@@ -16,6 +16,7 @@ import {
   linkHistoryOriginalLinkH6,
   linkHistoryTagsH6,
   linkHistoryViewButton,
+  linkRowByShortUrl,
   linkTransferField,
   longUrl,
   signOutButton,
@@ -39,7 +40,7 @@ fixture(`URL Creation`)
 test('Creating a new url updates the link history with create change set', async (t) => {
   // Create new link
   const generatedShortLink = await CreateNewLink(t)
-  const linkRow = Selector(`h6[title="${generatedShortLink}"]`)
+  const linkRow = linkRowByShortUrl(generatedShortLink)
   // Click the url in the table to open the drawer
   await t.click(linkRow)
   // Go to link history
@@ -51,7 +52,7 @@ test('Creating a new url updates the link history with create change set', async
 test('Disabling the link should update the link history with Link Status update change set', async (t) => {
   // Create new link
   const generatedShortLink = await CreateNewLink(t)
-  const linkRow = Selector(`h6[title="${generatedShortLink}"]`)
+  const linkRow = linkRowByShortUrl(generatedShortLink)
   // Click the url in the table to open the drawer
   await t.click(linkRow)
   // Disable the link
@@ -65,7 +66,7 @@ test('Disabling the link should update the link history with Link Status update 
 test('Changing the original link should update the link history with Original Link update change set', async (t) => {
   // Create new link
   const generatedShortLink = await CreateNewLink(t)
-  const linkRow = Selector(`h6[title="${generatedShortLink}"]`)
+  const linkRow = linkRowByShortUrl(generatedShortLink)
   // Click the url in the table to open the drawer
   await t.click(linkRow)
 
@@ -84,7 +85,7 @@ test('Changing the original link should update the link history with Original Li
 test('Changing the link owner should update the link history with Link Owner update change set', async (t) => {
   // Create new link
   const generatedShortLink = await CreateNewLink(t)
-  const linkRow = Selector(`h6[title="${generatedShortLink}"]`)
+  const linkRow = linkRowByShortUrl(generatedShortLink)
   // Click the url in the table to open the drawer
   await t.click(linkRow)
   // Transfer ownership of the link
@@ -108,7 +109,7 @@ test('Changing the link owner should update the link history with Link Owner upd
 test('Changing the tags should update the link history with Tags update change set', async (t) => {
   // Create new link
   const generatedShortLink = await CreateNewLink(t)
-  const linkRow = Selector(`h6[title="${generatedShortLink}"]`)
+  const linkRow = linkRowByShortUrl(generatedShortLink)
   // Click the url in the table to open the drawer
   await t.click(linkRow)
   // Remove one existing tag and add two new tags

--- a/test/end-to-end/UrlCreation.test.ts
+++ b/test/end-to-end/UrlCreation.test.ts
@@ -35,6 +35,7 @@ import {
   generateUrlImage,
   getLinkCount,
   largeFileError,
+  linkRowByShortUrl,
   longUrlTextField,
   maliciousFileCreation,
   resultTable,
@@ -79,7 +80,7 @@ test('The URL based shortlink test.', async (t) => {
   await t.click(generateUrlImage).expect(shortUrlTextField.value).notEql('')
 
   const generatedUrl = await shortUrlTextField.value
-  const linkRow = Selector(`h6[title="${generatedUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedUrl)
   const linkTableRow = linkRow.parent('tr')
 
   // It should prevent creation of short urls pointing to long urls hosted on blacklisted domains
@@ -150,7 +151,7 @@ test('The file based shortlink test.', async (t) => {
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
 
   const generatedfileUrl = await shortUrlTextField.value
-  const fileRow = Selector(`h6[title="${generatedfileUrl}"]`)
+  const fileRow = linkRowByShortUrl(generatedfileUrl)
   const fileTableRow = fileRow.parent('tr')
 
   // Generate 1mb file
@@ -323,7 +324,7 @@ test.skip('The malicious file test.', async (t) => {
     .ok()
   await deleteFile(dummyMaliciousFilePath)
   // Check that row is not created
-  const linkRow = Selector(`h6[title="${generatedfileUrl}"]`)
+  const linkRow = linkRowByShortUrl(generatedfileUrl)
 
   await t.expect(linkRow.exists).notOk()
 })
@@ -332,7 +333,7 @@ test('The update file test', async (t) => {
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
 
   const generatedfileUrl = await shortUrlTextField.value
-  const fileRow = Selector(`h6[title="${generatedfileUrl}"]`)
+  const fileRow = linkRowByShortUrl(generatedfileUrl)
   const directoryPath = `${process.env.HOME}/Downloads/${generatedfileUrl}.csv`
   // Generate 1mb file
   await createEmptyFileOfSize(dummyFilePath, smallFileSize)

--- a/test/end-to-end/UserPage.test.ts
+++ b/test/end-to-end/UserPage.test.ts
@@ -1,4 +1,3 @@
-import { Selector } from 'testcafe'
 import { parse } from 'csv-parse'
 import { createReadStream } from 'fs'
 import {
@@ -22,6 +21,7 @@ import {
   filterSortPanel,
   generateRandomString,
   generateUrlImage,
+  linkRowByShortUrl,
   longUrl,
   longUrlTextField,
   mostNumberOfVisitsButton,
@@ -74,7 +74,7 @@ test('User page test on filter search by link', async (t) => {
 
   // Save short url 2 - inactive link
   const generatedUrlInactive = await shortUrlTextField.value
-  const linkRowInactive = Selector(`h6[title="${generatedUrlInactive}"]`)
+  const linkRowInactive = linkRowByShortUrl(generatedUrlInactive)
 
   await t
     .typeText(longUrlTextField, `${shortUrl}`)
@@ -193,7 +193,7 @@ test('User page test on filter search by tags', async (t) => {
   // Save short url 1: link with tag 1
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
   const generatedUrl1 = await shortUrlTextField.value
-  const linkTableRow1 = Selector(`h6[title="${generatedUrl1}"]`).parent('tr')
+  const linkTableRow1 = linkRowByShortUrl(generatedUrl1).parent('tr')
   await t
     .typeText(longUrlTextField, shortUrl)
     .click(tagsAutocompleteInput)
@@ -205,7 +205,7 @@ test('User page test on filter search by tags', async (t) => {
   // Save short url 2: link with tags 1 and 2
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
   const generatedUrl2 = await shortUrlTextField.value
-  const linkTableRow2 = Selector(`h6[title="${generatedUrl2}"]`).parent('tr')
+  const linkTableRow2 = linkRowByShortUrl(generatedUrl2).parent('tr')
   await t
     .typeText(longUrlTextField, shortUrl)
     .click(tagsAutocompleteInput)
@@ -218,7 +218,7 @@ test('User page test on filter search by tags', async (t) => {
   // Save short url 3: file with tags 2 and 3
   await t.click(createLinkButton.nth(0)).click(generateUrlImage)
   const generatedUrl3 = await shortUrlTextField.value
-  const linkTableRow3 = Selector(`h6[title="${generatedUrl3}"]`).parent('tr')
+  const linkTableRow3 = linkRowByShortUrl(generatedUrl3).parent('tr')
   await createEmptyFileOfSize(dummyFilePath, smallFileSize)
   await t
     .click(fileTab)

--- a/test/end-to-end/util/LinkCreationProcedure.ts
+++ b/test/end-to-end/util/LinkCreationProcedure.ts
@@ -16,6 +16,7 @@ import {
   fileTab,
   generateRandomString,
   generateUrlImage,
+  linkRowByShortUrl,
   longUrl,
   longUrlTextField,
   mobileCreateLinkButton,
@@ -49,8 +50,24 @@ const fetchLink = async (shortUrlSlug, numberOfFetches) => {
   })
 }
 
+<<<<<<< HEAD
 const seedLinkClicks = async (generatedUrl, numberOfFetches) => {
   await fetchLink(generatedUrl, numberOfFetches)
+=======
+const getUrlAndFetch = async (t, generatedUrl, numberOfFetches) => {
+  const linkRowPopular = linkRowByShortUrl(generatedUrl)
+  await t.click(linkRowPopular)
+
+  const shortLink = Selector(
+    '.MuiTypography-root.MuiTypography-subtitle2',
+  ).withText(generatedUrl)
+
+  const shortUrlValue = await shortLink.innerText
+
+  await t.click(closeDrawerButton)
+
+  await fetchLink(shortUrlValue, numberOfFetches)
+>>>>>>> 856781dc (fix(e2e): select link rows by short-url text, not Tooltip title)
 }
 
 const generateSearchKey = () => {
@@ -129,7 +146,7 @@ export const linkCreationProcedure = async (t) => {
 
   const generatedUrlInactive = `${await shortUrlTextField.value}${searchKeyWithDash}`
 
-  const linkRowInactive = Selector(`h6[title="${generatedUrlInactive}"]`)
+  const linkRowInactive = linkRowByShortUrl(generatedUrlInactive)
 
   await t
     .typeText(shortUrlTextField, searchKeyWithDash) // concat generated searchKey

--- a/test/end-to-end/util/LinkCreationProcedure.ts
+++ b/test/end-to-end/util/LinkCreationProcedure.ts
@@ -1,4 +1,3 @@
-import { Selector } from 'testcafe'
 import { fetch } from 'cross-fetch'
 import {
   apiLocation,
@@ -50,24 +49,8 @@ const fetchLink = async (shortUrlSlug, numberOfFetches) => {
   })
 }
 
-<<<<<<< HEAD
 const seedLinkClicks = async (generatedUrl, numberOfFetches) => {
   await fetchLink(generatedUrl, numberOfFetches)
-=======
-const getUrlAndFetch = async (t, generatedUrl, numberOfFetches) => {
-  const linkRowPopular = linkRowByShortUrl(generatedUrl)
-  await t.click(linkRowPopular)
-
-  const shortLink = Selector(
-    '.MuiTypography-root.MuiTypography-subtitle2',
-  ).withText(generatedUrl)
-
-  const shortUrlValue = await shortLink.innerText
-
-  await t.click(closeDrawerButton)
-
-  await fetchLink(shortUrlValue, numberOfFetches)
->>>>>>> 856781dc (fix(e2e): select link rows by short-url text, not Tooltip title)
 }
 
 const generateSearchKey = () => {

--- a/test/end-to-end/util/helpers.ts
+++ b/test/end-to-end/util/helpers.ts
@@ -84,6 +84,10 @@ export const urlTableRow = (index: number) =>
   // eslint-disable-next-line newline-per-chained-call
   urlTable.child(index).child(1).child('div').child(0).child('h6')
 
+// Prefer text over h6[title]: MUI Tooltip strips the native title attribute while open.
+export const linkRowByShortUrl = (shortUrl: string) =>
+  Selector('h6').withExactText(`/${shortUrl}`)
+
 export const urlTableRowShortUrlText = async (row: Selector) =>
   // eslint-disable-next-line newline-per-chained-call
   row.find('td').nth(1).find('div').nth(1).textContent


### PR DESCRIPTION
## Summary
- Bumps `testcafe` from `^2.6.2` to a pinned `3.7.4` (not `^3.7.4`/latest `3.7.6`, since testcafe 3.7.5+ requires Node >=20 while this repo's `engines` field and CI workflows are pinned to Node 18)
- `npm audit` improves as a side effect of the transitive dependency refresh: **17 → 13 vulnerabilities** (moderate: 8→7, high: 9→6, critical: 0→0)
- No usage of testcafe's other v3.0.0 breaking change (IE11 removal) found in this repo

## ⚠️ Prior attempt in this branch's history
An earlier attempt to bump testcafe to v3 happened today on `cursor/fix-security-advisories-383b` (an ancestor of this branch):
- It bumped to `^3.7.6` and needed `--disable-native-automation` added to `test:e2e`/`test:e2e-headless` to work around testcafe v3's new CDP-based Chrome automation
- Despite that workaround, it was **fully reverted** back to `^2.6.2` shortly after (`cc453a22`, `ab8a9b5a`), alongside a larger batch of other dependency upgrades that were also rolled back in the same cleanup — consistent with CI/e2e instability, though the revert commits don't spell out the exact failure.

This PR does not include the `--disable-native-automation` flag. We're opening this to observe the CI e2e job directly rather than guessing at the workaround up front.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx testcafe --version` reports `3.7.4`
- [ ] Watch `test:e2e-headless` CI job for the flakiness/failures seen in the prior attempt
- [ ] If CDP automation issues resurface, add `--disable-native-automation` to `test:e2e` / `test:e2e-headless`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change pins TestCafe 3.7.4 and updates E2E link-row selectors to use the exact visible short URL rather than a Tooltip-managed title attribute.

The direct popularity-seeding path was exercised with generated short-link slugs. Ten requests for the most-popular link and eight for the second-most-popular link reached the redirect route and received manual 302 responses. The previously removed drawer-display-text approach was also exercised: its leading slash produced a double-slash URL, returned 404, and did not record a redirect-route hit. This disproves a regression in the retained `seedLinkClicks` implementation.

No defects remain for this change.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The focused redirect-route exercise confirmed that popularity seeding reaches the intended short-link routes, while the removed display-text path produces an invalid double-slash route.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored Node/Express route harness for test/end-to-end/util/LinkCreationProcedure.ts to exercise source-contract assertions and requests to the short-link redirect route.
- Observed that a drawer-style value with a leading slash produced a double-slash request, returned 404, and did not reach a redirect route; bare generated slugs produced ten and eight manual 302 responses, with all eighteen requests reaching the expected redirect routes.
- Validated via runtime evidence that the retained helper passes the raw input-field slug to fetchLink.
- Reviewed code and server wiring to confirm how slug values are constructed and accepted, including that shortUrlTextField.value drives popularity seeding, a single leading slash is added, and the server accepts the bare route parameter.
- Artifacts associated with the proofs were collected and prepared for review.

<a href="https://app.greptile.com/trex/runs/17486848/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(e2e): finish link-row selector confl..."](https://github.com/opengovsg/gogovsg/commit/14084cc1ad0a748f6feb31f9599a8c2aba758cad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50465184)</sub>

<!-- /greptile_comment -->