### PR TITLE
chore: Update CI workflow to trigger on develop and staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: ci
 on:
   workflow_dispatch:
   push:
+    branches:
+      - develop
+      - staging
   pull_request:
-    types: [opened, reopened]
+    types: [opened, synchronize]
 
 jobs:
   ci:


### PR DESCRIPTION
reduce unnecessary CI runs
this mirrors Isomer's setup

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This workflow now limits push-triggered CI to `develop` and `staging` and runs on pull-request opening and updates. A focused execution check confirmed that each update to an open pull request schedules the unguarded end-to-end and integration jobs, so the change does not achieve the intended reduction in GitHub Actions usage for those expensive suites.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge as written because ordinary pull-request updates still launch the end-to-end and integration suites that the change is intended to defer.

The workflow behavior was directly evaluated with an executed validator that confirmed `synchronize` schedules both unguarded jobs. There is one non-security issue requiring a workflow change.

**Files Needing Attention:** .github/workflows/ci.yml needs an event or job-level condition that prevents end-to-end and integration execution for routine pull-request updates.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored and captured the workflow scheduling validation source to support the P1 proof.
- Ran the synchronize-event scheduling validation and confirmed a successful output for the P1 proof.
- T-Rex produced a finding-comment-proof for a posted P2 finding.
- Executed the end-to-end sync-e2e validation using the pr2540-sync-e2e-validation.py script and captured the after-run logs to verify the scheduling relationship and PR schedule update.

<a href="https://app.greptile.com/trex/runs/17720262/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **E2E and integration jobs run on every PR synchronize event**

   - **Bug**
     - A pushed commit to an already-open pull request emits `synchronize`, which is listed in `.github/workflows/ci.yml:9`. The unguarded `testcafe` and `integration` jobs are therefore scheduled on that workflow run.
   - **Cause**
     - The `pull_request` trigger explicitly includes `synchronize` at line 9, while the `testcafe` job (lines 64-92) and `integration` job (lines 93-121) contain no job-level `if` condition.
   - **Fix**
     - Remove `synchronize` from `pull_request.types` if repeat execution is not intended, or add appropriate job-level `if` guards to `testcafe` and `integration` so they run only for the intended PR actions.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A9%0A**Per-push%20E2E%20remains%20enabled**%0A%0AA%20new%20commit%20pushed%20to%20an%20already-open%20pull%20request%20emits%20%60synchronize%60%2C%20which%20triggers%20this%20entire%20workflow.%20Since%20neither%20%60testcafe%60%20nor%20%60integration%60%20has%20a%20job-level%20condition%2C%20both%20expensive%20suites%20run%20for%20every%20PR%20update%20rather%20than%20only%20at%20merge%20time.%20This%20leaves%20the%20intended%20GitHub%20Actions%20usage%20reduction%20unmet%3B%20remove%20%60synchronize%60%20for%20this%20workflow%20or%20gate%20these%20two%20jobs%20to%20the%20intended%20merge-time%20event.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fgogovsg&pr=2540&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A9%0A**Per-push%20E2E%20remains%20enabled**%0A%0AA%20new%20commit%20pushed%20to%20an%20already-open%20pull%20request%20emits%20%60synchronize%60%2C%20which%20triggers%20this%20entire%20workflow.%20Since%20neither%20%60testcafe%60%20nor%20%60integration%60%20has%20a%20job-level%20condition%2C%20both%20expensive%20suites%20run%20for%20every%20PR%20update%20rather%20than%20only%20at%20merge%20time.%20This%20leaves%20the%20intended%20GitHub%20Actions%20usage%20reduction%20unmet%3B%20remove%20%60synchronize%60%20for%20this%20workflow%20or%20gate%20these%20two%20jobs%20to%20the%20intended%20merge-time%20event.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2540&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fgogovsg%22%20on%20the%20existing%20branch%20%22chore%2Fci-unnecessary-run%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fci-unnecessary-run%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A9%0A**Per-push%20E2E%20remains%20enabled**%0A%0AA%20new%20commit%20pushed%20to%20an%20already-open%20pull%20request%20emits%20%60synchronize%60%2C%20which%20triggers%20this%20entire%20workflow.%20Since%20neither%20%60testcafe%60%20nor%20%60integration%60%20has%20a%20job-level%20condition%2C%20both%20expensive%20suites%20run%20for%20every%20PR%20update%20rather%20than%20only%20at%20merge%20time.%20This%20leaves%20the%20intended%20GitHub%20Actions%20usage%20reduction%20unmet%3B%20remove%20%60synchronize%60%20for%20this%20workflow%20or%20gate%20these%20two%20jobs%20to%20the%20intended%20merge-time%20event.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fgogovsg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/ci.yml:9
**Per-push E2E remains enabled**

A new commit pushed to an already-open pull request emits `synchronize`, which triggers this entire workflow. Since neither `testcafe` nor `integration` has a job-level condition, both expensive suites run for every PR update rather than only at merge time. This leaves the intended GitHub Actions usage reduction unmet; remove `synchronize` for this workflow or gate these two jobs to the intended merge-time event.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Update CI workflow to trigger on ..."](https://github.com/opengovsg/gogovsg/commit/e207ef7ac9f4b5bb53c1a404a7ae575f93a45e5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51009942)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->