### PR TITLE
feat(api): add POST /api/v1/urls/bulk for external API

### DIFF
--- a/src/server/api/external-v1/index.ts
+++ b/src/server/api/external-v1/index.ts
@@ -6,6 +6,7 @@ import { DependencyIds } from '../../constants'
 import { ApiV1Controller } from '../../modules/api/external-v1'
 import { UrlCheckController } from '../../modules/threat'
 import {
+  urlBulkSchema,
   urlEditSchema,
   urlRetrievalSchema,
   urlSchema,
@@ -42,6 +43,12 @@ router.get(
   validator.body(urlRetrievalSchema),
   validator.query(userUrlsQueryConditions),
   apiV1Controller.getUrlsWithConditions,
+)
+
+router.post(
+  '/urls/bulk',
+  validator.body(urlBulkSchema),
+  apiV1Controller.bulkCreateUrls,
 )
 
 router.post(

--- a/src/server/api/external-v1/index.ts
+++ b/src/server/api/external-v1/index.ts
@@ -57,9 +57,8 @@ function preprocessExternalBulkRows(
     type?: string
   }[] = []
 
-  /* eslint-disable no-restricted-syntax */
-  for (let index = 0; index < urls.length; index += 1) {
-    const { error, value } = urlBulkRowSchema.validate(urls[index], {
+  urls.forEach((row: unknown, index: number) => {
+    const { error, value } = urlBulkRowSchema.validate(row, {
       abortEarly: true,
     })
     if (error) {
@@ -67,19 +66,18 @@ function preprocessExternalBulkRows(
         index,
         ...extractBulkRowValidationError(error),
       })
-    } else {
-      validatedBulkRows.push({
-        index,
-        longUrl: value.longUrl,
-        shortUrl: value.shortUrl,
-      })
+      return
     }
-  }
-  /* eslint-enable no-restricted-syntax */
+    validatedBulkRows.push({
+      index,
+      longUrl: value.longUrl,
+      shortUrl: value.shortUrl,
+    })
+  })
 
   req.body.validatedBulkRows = validatedBulkRows
   req.body.bulkValidationErrors = bulkValidationErrors
-  req.body.bulkLongUrls = validatedBulkRows.map((row) => row.longUrl)
+  req.body.longUrls = validatedBulkRows.map((row) => row.longUrl)
   next()
 }
 
@@ -94,7 +92,7 @@ router.post(
   '/urls/bulk',
   validator.body(urlBulkSchema),
   preprocessExternalBulkRows,
-  urlCheckController.externalBulkUrlCheck,
+  urlCheckController.bulkUrlCheck,
   apiV1Controller.bulkCreateUrls,
 )
 

--- a/src/server/api/external-v1/index.ts
+++ b/src/server/api/external-v1/index.ts
@@ -6,6 +6,8 @@ import { DependencyIds } from '../../constants'
 import { ApiV1Controller } from '../../modules/api/external-v1'
 import { UrlCheckController } from '../../modules/threat'
 import {
+  extractBulkRowValidationError,
+  urlBulkRowSchema,
   urlBulkSchema,
   urlEditSchema,
   urlRetrievalSchema,
@@ -38,6 +40,49 @@ function preprocessShortUrl(
   next()
 }
 
+function preprocessExternalBulkRows(
+  req: Express.Request,
+  _: Express.Response,
+  next: Express.NextFunction,
+) {
+  const { urls } = req.body
+  const validatedBulkRows: {
+    index: number
+    longUrl: string
+    shortUrl?: string
+  }[] = []
+  const bulkValidationErrors: {
+    index: number
+    message: string
+    type?: string
+  }[] = []
+
+  /* eslint-disable no-restricted-syntax */
+  for (let index = 0; index < urls.length; index += 1) {
+    const { error, value } = urlBulkRowSchema.validate(urls[index], {
+      abortEarly: true,
+    })
+    if (error) {
+      bulkValidationErrors.push({
+        index,
+        ...extractBulkRowValidationError(error),
+      })
+    } else {
+      validatedBulkRows.push({
+        index,
+        longUrl: value.longUrl,
+        shortUrl: value.shortUrl,
+      })
+    }
+  }
+  /* eslint-enable no-restricted-syntax */
+
+  req.body.validatedBulkRows = validatedBulkRows
+  req.body.bulkValidationErrors = bulkValidationErrors
+  req.body.bulkLongUrls = validatedBulkRows.map((row) => row.longUrl)
+  next()
+}
+
 router.get(
   '/urls',
   validator.body(urlRetrievalSchema),
@@ -48,6 +93,8 @@ router.get(
 router.post(
   '/urls/bulk',
   validator.body(urlBulkSchema),
+  preprocessExternalBulkRows,
+  urlCheckController.externalBulkUrlCheck,
   apiV1Controller.bulkCreateUrls,
 )
 

--- a/src/server/api/external-v1/validators.ts
+++ b/src/server/api/external-v1/validators.ts
@@ -68,15 +68,15 @@ export const urlBulkRowSchema = Joi.object({
   shortUrl: shortUrlValidator,
 })
 
-export const urlBulkRowEnvelopeSchema = Joi.object({
-  longUrl: Joi.string().optional(),
-  shortUrl: Joi.string().optional(),
-}).unknown(false)
-
 export const urlBulkSchema = Joi.object({
   userId: Joi.number().required(),
   urls: Joi.array()
-    .items(urlBulkRowEnvelopeSchema)
+    .items(
+      Joi.object({
+        longUrl: Joi.string().optional(),
+        shortUrl: Joi.string().optional(),
+      }).unknown(false),
+    )
     .min(1)
     .max(bulkUploadMaxNum)
     .required(),

--- a/src/server/api/external-v1/validators.ts
+++ b/src/server/api/external-v1/validators.ts
@@ -6,8 +6,39 @@ import {
   isValidShortUrl,
   isValidUrl,
 } from '../../../shared/util/validation'
-import { ogHostname } from '../../config'
+import { bulkUploadMaxNum, ogHostname } from '../../config'
 import { ACTIVE, INACTIVE } from '../../models/types'
+
+const longUrlValidator = Joi.string()
+  .custom((url: string, helpers) => {
+    if (!isHttps(url)) {
+      return helpers.message({ custom: 'Only HTTPS URLs are allowed.' })
+    }
+    if (!isValidUrl(url)) {
+      return helpers.message({ custom: 'Long URL format is invalid.' })
+    }
+    if (isCircularRedirects(url, ogHostname)) {
+      return helpers.message({
+        custom: 'Circular redirects are not allowed.',
+      })
+    }
+    if (isBlacklisted(url)) {
+      return helpers.message({
+        custom: 'Creation of URLs to link shortener sites are not allowed.',
+      })
+    }
+    return url
+  })
+  .required()
+
+const shortUrlValidator = Joi.string()
+  .custom((url: string, helpers) => {
+    if (!isValidShortUrl(url)) {
+      return helpers.message({ custom: 'Short URL format is invalid.' })
+    }
+    return url
+  })
+  .optional()
 
 export const urlRetrievalSchema = Joi.object({
   userId: Joi.number().required(),
@@ -26,34 +57,21 @@ export const userUrlsQueryConditions = Joi.object({
 
 export const urlSchema = Joi.object({
   userId: Joi.number().required(),
-  shortUrl: Joi.string()
-    .custom((url: string, helpers) => {
-      if (!isValidShortUrl(url)) {
-        return helpers.message({ custom: 'Short URL format is invalid.' })
-      }
-      return url
-    })
-    .optional(),
-  longUrl: Joi.string()
-    .custom((url: string, helpers) => {
-      if (!isHttps(url)) {
-        return helpers.message({ custom: 'Only HTTPS URLs are allowed.' })
-      }
-      if (!isValidUrl(url)) {
-        return helpers.message({ custom: 'Long URL format is invalid.' })
-      }
-      if (isCircularRedirects(url, ogHostname)) {
-        return helpers.message({
-          custom: 'Circular redirects are not allowed.',
-        })
-      }
-      if (isBlacklisted(url)) {
-        return helpers.message({
-          custom: 'Creation of URLs to link shortener sites are not allowed.',
-        })
-      }
-      return url
-    })
+  shortUrl: shortUrlValidator,
+  longUrl: longUrlValidator,
+})
+
+export const urlBulkRowSchema = Joi.object({
+  longUrl: longUrlValidator,
+  shortUrl: shortUrlValidator,
+})
+
+export const urlBulkSchema = Joi.object({
+  userId: Joi.number().required(),
+  urls: Joi.array()
+    .items(Joi.object().unknown(false))
+    .min(1)
+    .max(bulkUploadMaxNum)
     .required(),
 })
 

--- a/src/server/api/external-v1/validators.ts
+++ b/src/server/api/external-v1/validators.ts
@@ -9,27 +9,28 @@ import {
 import { bulkUploadMaxNum, ogHostname } from '../../config'
 import { ACTIVE, INACTIVE } from '../../models/types'
 
-const longUrlValidator = Joi.string()
-  .custom((url: string, helpers) => {
-    if (!isHttps(url)) {
-      return helpers.message({ custom: 'Only HTTPS URLs are allowed.' })
-    }
-    if (!isValidUrl(url)) {
-      return helpers.message({ custom: 'Long URL format is invalid.' })
-    }
-    if (isCircularRedirects(url, ogHostname)) {
-      return helpers.message({
-        custom: 'Circular redirects are not allowed.',
-      })
-    }
-    if (isBlacklisted(url)) {
-      return helpers.message({
-        custom: 'Creation of URLs to link shortener sites are not allowed.',
-      })
-    }
-    return url
-  })
-  .required()
+const longUrlRules = (url: string, helpers: Joi.CustomHelpers) => {
+  if (!isHttps(url)) {
+    return helpers.message({ custom: 'Only HTTPS URLs are allowed.' })
+  }
+  if (!isValidUrl(url)) {
+    return helpers.message({ custom: 'Long URL format is invalid.' })
+  }
+  if (isCircularRedirects(url, ogHostname)) {
+    return helpers.message({
+      custom: 'Circular redirects are not allowed.',
+    })
+  }
+  if (isBlacklisted(url)) {
+    return helpers.message({
+      custom: 'Creation of URLs to link shortener sites are not allowed.',
+    })
+  }
+  return url
+}
+
+const longUrlValidator = Joi.string().custom(longUrlRules).required()
+const optionalLongUrlValidator = Joi.string().custom(longUrlRules).optional()
 
 const shortUrlValidator = Joi.string()
   .custom((url: string, helpers) => {
@@ -78,26 +79,6 @@ export const urlBulkSchema = Joi.object({
 export const urlEditSchema = Joi.object({
   userId: Joi.number().required(),
   shortUrl: Joi.string().required(),
-  longUrl: Joi.string()
-    .custom((url: string, helpers) => {
-      if (!isHttps(url)) {
-        return helpers.message({ custom: 'Only HTTPS URLs are allowed.' })
-      }
-      if (!isValidUrl(url)) {
-        return helpers.message({ custom: 'Long URL format is invalid.' })
-      }
-      if (isCircularRedirects(url, ogHostname)) {
-        return helpers.message({
-          custom: 'Circular redirects are not allowed.',
-        })
-      }
-      if (isBlacklisted(url)) {
-        return helpers.message({
-          custom: 'Creation of URLs to link shortener sites are not allowed.',
-        })
-      }
-      return url
-    })
-    .optional(),
+  longUrl: optionalLongUrlValidator,
   state: Joi.string().valid(ACTIVE, INACTIVE).optional(),
 })

--- a/src/server/api/external-v1/validators.ts
+++ b/src/server/api/external-v1/validators.ts
@@ -6,6 +6,7 @@ import {
   isValidShortUrl,
   isValidUrl,
 } from '../../../shared/util/validation'
+import { MessageType } from '../../../shared/util/messages'
 import { bulkUploadMaxNum, ogHostname } from '../../config'
 import { ACTIVE, INACTIVE } from '../../models/types'
 
@@ -67,14 +68,39 @@ export const urlBulkRowSchema = Joi.object({
   shortUrl: shortUrlValidator,
 })
 
+export const urlBulkRowEnvelopeSchema = Joi.object({
+  longUrl: Joi.string().optional(),
+  shortUrl: Joi.string().optional(),
+}).unknown(false)
+
 export const urlBulkSchema = Joi.object({
   userId: Joi.number().required(),
   urls: Joi.array()
-    .items(Joi.object().unknown(false))
+    .items(urlBulkRowEnvelopeSchema)
     .min(1)
     .max(bulkUploadMaxNum)
     .required(),
 })
+
+export const extractBulkRowValidationError = (
+  error: Joi.ValidationError,
+): { message: string; type?: MessageType } => {
+  const detail = error.details[0]
+  const field = detail.path[0]
+  let { message } = detail
+  const customMatch = message.match(/because (.+)$/)
+  if (customMatch) {
+    ;[, message] = customMatch
+  }
+
+  if (field === 'shortUrl') {
+    return { message, type: MessageType.ShortUrlError }
+  }
+  if (field === 'longUrl') {
+    return { message, type: MessageType.LongUrlError }
+  }
+  return { message }
+}
 
 export const urlEditSchema = Joi.object({
   userId: Joi.number().required(),

--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -1,4 +1,5 @@
 import Express from 'express'
+import * as Joi from 'joi'
 import { inject, injectable } from 'inversify'
 import Sequelize from 'sequelize'
 
@@ -19,8 +20,10 @@ import {
 } from '../../../repositories/enums'
 import { UserUrlsQueryConditions } from '../../../repositories/types'
 
-import { UrlCreationRequest, UrlEditRequest } from '.'
+import { UrlBulkCreationRequest, UrlCreationRequest, UrlEditRequest } from '.'
 import { UrlV1Mapper } from '../../../mappers/UrlV1Mapper'
+import { UrlThreatScanService } from '../../threat/interfaces'
+import { urlBulkRowSchema } from '../../../api/external-v1/validators'
 
 @injectable()
 export class ApiV1Controller {
@@ -28,14 +31,19 @@ export class ApiV1Controller {
 
   private urlV1Mapper: UrlV1Mapper
 
+  private urlThreatScanService: UrlThreatScanService
+
   public constructor(
     @inject(DependencyIds.urlManagementService)
     urlManagementService: UrlManagementService,
     @inject(DependencyIds.urlV1Mapper)
     urlV1Mapper: UrlV1Mapper,
+    @inject(DependencyIds.urlThreatScanService)
+    urlThreatScanService: UrlThreatScanService,
   ) {
     this.urlManagementService = urlManagementService
     this.urlV1Mapper = urlV1Mapper
+    this.urlThreatScanService = urlThreatScanService
   }
 
   public createUrl: (
@@ -71,6 +79,126 @@ export class ApiV1Controller {
       res.serverError(jsonMessage('Server error.'))
       return
     }
+  }
+
+  public bulkCreateUrls: (
+    req: Express.Request,
+    res: Express.Response,
+  ) => Promise<void> = async (req, res) => {
+    const { userId, urls }: UrlBulkCreationRequest = req.body
+    const created = []
+    const errors = []
+    const usedShortUrls = new Set<string>()
+
+    for (let index = 0; index < urls.length; index += 1) {
+      const row = urls[index]
+      const { error, value } = urlBulkRowSchema.validate(row, {
+        abortEarly: true,
+      })
+      if (error) {
+        errors.push({
+          index,
+          ...ApiV1Controller.extractRowValidationError(error),
+        })
+      } else {
+        const { longUrl, shortUrl } = value
+        let rowError: { message: string; type?: MessageType } | undefined
+
+        if (shortUrl && usedShortUrls.has(shortUrl)) {
+          rowError = {
+            message: `Short link "${shortUrl}" is already used.`,
+            type: MessageType.ShortUrlError,
+          }
+        } else {
+          try {
+            // Rows are processed sequentially to preserve order and batch slug tracking.
+            // eslint-disable-next-line no-await-in-loop
+            const isThreat = await this.urlThreatScanService.isThreat(longUrl)
+            if (isThreat) {
+              rowError = {
+                message:
+                  'Link is likely to be malicious, please contact us for further assistance',
+              }
+            }
+          } catch (scanError) {
+            rowError = {
+              message: (scanError as Error).message,
+            }
+          }
+
+          if (!rowError) {
+            try {
+              // eslint-disable-next-line no-await-in-loop
+              const url = await this.urlManagementService.createUrl(
+                userId,
+                StorableUrlSource.Api,
+                shortUrl,
+                longUrl,
+              )
+              usedShortUrls.add(url.shortUrl)
+              created.push(this.urlV1Mapper.persistenceToDto(url))
+            } catch (createError) {
+              if (createError instanceof AlreadyExistsError) {
+                rowError = {
+                  message: createError.message,
+                  type: MessageType.ShortUrlError,
+                }
+              } else if (createError instanceof NotFoundError) {
+                rowError = {
+                  message: createError.message,
+                }
+              } else if (createError instanceof Sequelize.ValidationError) {
+                rowError = {
+                  message: createError.message,
+                }
+              } else {
+                logger.error(
+                  `Error creating short URL in bulk:\t${createError}`,
+                )
+                rowError = {
+                  message: 'Server error.',
+                }
+              }
+            }
+          }
+        }
+
+        if (rowError) {
+          errors.push({
+            index,
+            ...rowError,
+          })
+        }
+      }
+    }
+
+    const response = { created, errors }
+    if (created.length > 0) {
+      res.ok(response)
+      return
+    }
+    res.badRequest(response)
+  }
+
+  private static extractRowValidationError(error: Joi.ValidationError): {
+    message: string
+    type?: MessageType
+  } {
+    const detail = error.details[0]
+    const field = detail.path[0]
+    let { message } = detail
+    const customMatch = message.match(/because (.+)$/)
+    if (customMatch) {
+      ;[, message] = customMatch
+    }
+
+    if (field === 'shortUrl') {
+      return { message, type: MessageType.ShortUrlError }
+    }
+    if (field === 'longUrl') {
+      return { message, type: MessageType.LongUrlError }
+    }
+    return { message }
   }
 
   public getUrlsWithConditions: (

--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -1,5 +1,4 @@
 import Express from 'express'
-import * as Joi from 'joi'
 import { inject, injectable } from 'inversify'
 import Sequelize from 'sequelize'
 
@@ -22,8 +21,18 @@ import { UserUrlsQueryConditions } from '../../../repositories/types'
 
 import { UrlBulkCreationRequest, UrlCreationRequest, UrlEditRequest } from '.'
 import { UrlV1Mapper } from '../../../mappers/UrlV1Mapper'
-import { UrlThreatScanService } from '../../threat/interfaces'
-import { urlBulkRowSchema } from '../../../api/external-v1/validators'
+
+type ValidatedBulkRow = {
+  index: number
+  longUrl: string
+  shortUrl?: string
+}
+
+type BulkValidationError = {
+  index: number
+  message: string
+  type?: MessageType
+}
 
 @injectable()
 export class ApiV1Controller {
@@ -31,19 +40,14 @@ export class ApiV1Controller {
 
   private urlV1Mapper: UrlV1Mapper
 
-  private urlThreatScanService: UrlThreatScanService
-
   public constructor(
     @inject(DependencyIds.urlManagementService)
     urlManagementService: UrlManagementService,
     @inject(DependencyIds.urlV1Mapper)
     urlV1Mapper: UrlV1Mapper,
-    @inject(DependencyIds.urlThreatScanService)
-    urlThreatScanService: UrlThreatScanService,
   ) {
     this.urlManagementService = urlManagementService
     this.urlV1Mapper = urlV1Mapper
-    this.urlThreatScanService = urlThreatScanService
   }
 
   public createUrl: (
@@ -85,50 +89,26 @@ export class ApiV1Controller {
     req: Express.Request,
     res: Express.Response,
   ) => Promise<void> = async (req, res) => {
-    const { userId, urls }: UrlBulkCreationRequest = req.body
+    const {
+      userId,
+      validatedBulkRows = [],
+      bulkValidationErrors = [],
+    }: UrlBulkCreationRequest & {
+      validatedBulkRows?: ValidatedBulkRow[]
+      bulkValidationErrors?: BulkValidationError[]
+    } = req.body
     const created = []
-    const errors = []
+    const errors = [...bulkValidationErrors]
     const usedShortUrls = new Set<string>()
 
     /* eslint-disable no-await-in-loop, no-continue */
-    for (let index = 0; index < urls.length; index += 1) {
-      const row = urls[index]
-      const { error, value } = urlBulkRowSchema.validate(row, {
-        abortEarly: true,
-      })
-      if (error) {
-        errors.push({
-          index,
-          ...ApiV1Controller.extractRowValidationError(error),
-        })
-        continue
-      }
-
-      const { longUrl, shortUrl } = value
-
+    for (let i = 0; i < validatedBulkRows.length; i += 1) {
+      const { index, longUrl, shortUrl } = validatedBulkRows[i]
       if (shortUrl && usedShortUrls.has(shortUrl)) {
         errors.push({
           index,
           message: `Short link "${shortUrl}" is already used.`,
           type: MessageType.ShortUrlError,
-        })
-        continue
-      }
-
-      try {
-        const isThreat = await this.urlThreatScanService.isThreat(longUrl)
-        if (isThreat) {
-          errors.push({
-            index,
-            message:
-              'Link is likely to be malicious, please contact us for further assistance',
-          })
-          continue
-        }
-      } catch (scanError) {
-        errors.push({
-          index,
-          message: (scanError as Error).message,
         })
         continue
       }
@@ -176,27 +156,6 @@ export class ApiV1Controller {
       return
     }
     res.badRequest(response)
-  }
-
-  private static extractRowValidationError(error: Joi.ValidationError): {
-    message: string
-    type?: MessageType
-  } {
-    const detail = error.details[0]
-    const field = detail.path[0]
-    let { message } = detail
-    const customMatch = message.match(/because (.+)$/)
-    if (customMatch) {
-      ;[, message] = customMatch
-    }
-
-    if (field === 'shortUrl') {
-      return { message, type: MessageType.ShortUrlError }
-    }
-    if (field === 'longUrl') {
-      return { message, type: MessageType.LongUrlError }
-    }
-    return { message }
   }
 
   public getUrlsWithConditions: (

--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -90,6 +90,7 @@ export class ApiV1Controller {
     const errors = []
     const usedShortUrls = new Set<string>()
 
+    /* eslint-disable no-await-in-loop, no-continue */
     for (let index = 0; index < urls.length; index += 1) {
       const row = urls[index]
       const { error, value } = urlBulkRowSchema.validate(row, {
@@ -100,77 +101,74 @@ export class ApiV1Controller {
           index,
           ...ApiV1Controller.extractRowValidationError(error),
         })
-      } else {
-        const { longUrl, shortUrl } = value
-        let rowError: { message: string; type?: MessageType } | undefined
+        continue
+      }
 
-        if (shortUrl && usedShortUrls.has(shortUrl)) {
-          rowError = {
-            message: `Short link "${shortUrl}" is already used.`,
-            type: MessageType.ShortUrlError,
-          }
-        } else {
-          try {
-            // Rows are processed sequentially to preserve order and batch slug tracking.
-            // eslint-disable-next-line no-await-in-loop
-            const isThreat = await this.urlThreatScanService.isThreat(longUrl)
-            if (isThreat) {
-              rowError = {
-                message:
-                  'Link is likely to be malicious, please contact us for further assistance',
-              }
-            }
-          } catch (scanError) {
-            rowError = {
-              message: (scanError as Error).message,
-            }
-          }
+      const { longUrl, shortUrl } = value
 
-          if (!rowError) {
-            try {
-              // eslint-disable-next-line no-await-in-loop
-              const url = await this.urlManagementService.createUrl(
-                userId,
-                StorableUrlSource.Api,
-                shortUrl,
-                longUrl,
-              )
-              usedShortUrls.add(url.shortUrl)
-              created.push(this.urlV1Mapper.persistenceToDto(url))
-            } catch (createError) {
-              if (createError instanceof AlreadyExistsError) {
-                rowError = {
-                  message: createError.message,
-                  type: MessageType.ShortUrlError,
-                }
-              } else if (createError instanceof NotFoundError) {
-                rowError = {
-                  message: createError.message,
-                }
-              } else if (createError instanceof Sequelize.ValidationError) {
-                rowError = {
-                  message: createError.message,
-                }
-              } else {
-                logger.error(
-                  `Error creating short URL in bulk:\t${createError}`,
-                )
-                rowError = {
-                  message: 'Server error.',
-                }
-              }
-            }
-          }
-        }
+      if (shortUrl && usedShortUrls.has(shortUrl)) {
+        errors.push({
+          index,
+          message: `Short link "${shortUrl}" is already used.`,
+          type: MessageType.ShortUrlError,
+        })
+        continue
+      }
 
-        if (rowError) {
+      try {
+        const isThreat = await this.urlThreatScanService.isThreat(longUrl)
+        if (isThreat) {
           errors.push({
             index,
-            ...rowError,
+            message:
+              'Link is likely to be malicious, please contact us for further assistance',
+          })
+          continue
+        }
+      } catch (scanError) {
+        errors.push({
+          index,
+          message: (scanError as Error).message,
+        })
+        continue
+      }
+
+      try {
+        const url = await this.urlManagementService.createUrl(
+          userId,
+          StorableUrlSource.Api,
+          shortUrl,
+          longUrl,
+        )
+        usedShortUrls.add(url.shortUrl)
+        created.push(this.urlV1Mapper.persistenceToDto(url))
+      } catch (createError) {
+        if (createError instanceof AlreadyExistsError) {
+          errors.push({
+            index,
+            message: createError.message,
+            type: MessageType.ShortUrlError,
+          })
+        } else if (createError instanceof NotFoundError) {
+          errors.push({
+            index,
+            message: createError.message,
+          })
+        } else if (createError instanceof Sequelize.ValidationError) {
+          errors.push({
+            index,
+            message: createError.message,
+          })
+        } else {
+          logger.error(`Error creating short URL in bulk:\t${createError}`)
+          errors.push({
+            index,
+            message: 'Server error.',
           })
         }
       }
     }
+    /* eslint-enable no-await-in-loop, no-continue */
 
     const response = { created, errors }
     if (created.length > 0) {

--- a/src/server/modules/api/external-v1/ApiV1Controller.ts
+++ b/src/server/modules/api/external-v1/ApiV1Controller.ts
@@ -19,20 +19,8 @@ import {
 } from '../../../repositories/enums'
 import { UserUrlsQueryConditions } from '../../../repositories/types'
 
-import { UrlBulkCreationRequest, UrlCreationRequest, UrlEditRequest } from '.'
+import { UrlCreationRequest, UrlEditRequest } from '.'
 import { UrlV1Mapper } from '../../../mappers/UrlV1Mapper'
-
-type ValidatedBulkRow = {
-  index: number
-  longUrl: string
-  shortUrl?: string
-}
-
-type BulkValidationError = {
-  index: number
-  message: string
-  type?: MessageType
-}
 
 @injectable()
 export class ApiV1Controller {
@@ -93,9 +81,6 @@ export class ApiV1Controller {
       userId,
       validatedBulkRows = [],
       bulkValidationErrors = [],
-    }: UrlBulkCreationRequest & {
-      validatedBulkRows?: ValidatedBulkRow[]
-      bulkValidationErrors?: BulkValidationError[]
     } = req.body
     const created = []
     const errors = [...bulkValidationErrors]

--- a/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
+++ b/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
@@ -155,26 +155,26 @@ describe('ApiV1Controller', () => {
     const userId = 1
     const longUrl = 'https://www.agency.gov.sg'
     const shortUrl = 'abcdef'
-    const state = 'ACTIVE'
-    const source = 'API'
-    const clicks = 0
-    const contactEmail = 'person@open.gov.sg'
-    const description = 'test description'
-    const tags: string[] = []
-    const tagStrings = ''
     const createdAt = moment().toISOString()
     const updatedAt = moment().toISOString()
-
     const createdUrl = {
       shortUrl,
       longUrl,
-      state,
-      source,
-      clicks,
-      contactEmail,
-      description,
-      tags,
-      tagStrings,
+      state: 'ACTIVE',
+      source: 'API',
+      clicks: 0,
+      contactEmail: 'person@open.gov.sg',
+      description: 'test description',
+      tags: [],
+      tagStrings: '',
+      createdAt,
+      updatedAt,
+    }
+    const dto = {
+      shortUrl,
+      longUrl,
+      state: 'ACTIVE',
+      clicks: 0,
       createdAt,
       updatedAt,
     }
@@ -187,37 +187,20 @@ describe('ApiV1Controller', () => {
 
     it('creates all valid rows and returns 200', async () => {
       const req = httpMocks.createRequest({
-        body: {
-          userId,
-          urls: [{ shortUrl, longUrl }],
-        },
+        body: { userId, urls: [{ shortUrl, longUrl }] },
       })
       const res: any = httpMocks.createResponse()
       res.ok = jest.fn()
-
       urlManagementService.createUrl.mockResolvedValue(createdUrl)
 
       await controller.bulkCreateUrls(req, res)
-      expect(urlThreatScanService.isThreat).toHaveBeenCalledWith(longUrl)
       expect(urlManagementService.createUrl).toHaveBeenCalledWith(
         userId,
-        source,
+        'API',
         shortUrl,
         longUrl,
       )
-      expect(res.ok).toHaveBeenCalledWith({
-        created: [
-          {
-            shortUrl,
-            longUrl,
-            state,
-            clicks,
-            createdAt,
-            updatedAt,
-          },
-        ],
-        errors: [],
-      })
+      expect(res.ok).toHaveBeenCalledWith({ created: [dto], errors: [] })
     })
 
     it('returns partial success with row validation errors', async () => {
@@ -229,21 +212,11 @@ describe('ApiV1Controller', () => {
       })
       const res: any = httpMocks.createResponse()
       res.ok = jest.fn()
-
       urlManagementService.createUrl.mockResolvedValue(createdUrl)
 
       await controller.bulkCreateUrls(req, res)
       expect(res.ok).toHaveBeenCalledWith({
-        created: [
-          {
-            shortUrl,
-            longUrl,
-            state,
-            clicks,
-            createdAt,
-            updatedAt,
-          },
-        ],
+        created: [dto],
         errors: [
           {
             index: 1,
@@ -256,10 +229,7 @@ describe('ApiV1Controller', () => {
 
     it('returns 400 when every row fails', async () => {
       const req = httpMocks.createRequest({
-        body: {
-          userId,
-          urls: [{ longUrl: 'not-a-url' }],
-        },
+        body: { userId, urls: [{ longUrl: 'not-a-url' }] },
       })
       const res: any = httpMocks.createResponse()
       res.badRequest = jest.fn()
@@ -289,22 +259,12 @@ describe('ApiV1Controller', () => {
       })
       const res: any = httpMocks.createResponse()
       res.ok = jest.fn()
-
       urlManagementService.createUrl.mockResolvedValue(createdUrl)
 
       await controller.bulkCreateUrls(req, res)
       expect(urlManagementService.createUrl).toHaveBeenCalledTimes(1)
       expect(res.ok).toHaveBeenCalledWith({
-        created: [
-          {
-            shortUrl,
-            longUrl,
-            state,
-            clicks,
-            createdAt,
-            updatedAt,
-          },
-        ],
+        created: [dto],
         errors: [
           {
             index: 1,
@@ -317,14 +277,10 @@ describe('ApiV1Controller', () => {
 
     it('reports malicious links as row errors', async () => {
       const req = httpMocks.createRequest({
-        body: {
-          userId,
-          urls: [{ shortUrl, longUrl }],
-        },
+        body: { userId, urls: [{ shortUrl, longUrl }] },
       })
       const res: any = httpMocks.createResponse()
       res.badRequest = jest.fn()
-
       urlThreatScanService.isThreat.mockResolvedValue(true)
 
       await controller.bulkCreateUrls(req, res)
@@ -342,14 +298,10 @@ describe('ApiV1Controller', () => {
 
     it('reports shortUrl collision from createUrl as row error', async () => {
       const req = httpMocks.createRequest({
-        body: {
-          userId,
-          urls: [{ shortUrl, longUrl }],
-        },
+        body: { userId, urls: [{ shortUrl, longUrl }] },
       })
       const res: any = httpMocks.createResponse()
       res.badRequest = jest.fn()
-
       urlManagementService.createUrl.mockRejectedValue(
         new AlreadyExistsError(`Short link "${shortUrl}" is already used.`),
       )

--- a/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
+++ b/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
@@ -19,9 +19,18 @@ const urlManagementService = {
   deactivateMaliciousShortUrl: jest.fn(),
 }
 
+const urlThreatScanService = {
+  isThreat: jest.fn(),
+  isThreatBulk: jest.fn(),
+}
+
 const urlV1Mapper = new UrlV1Mapper()
 
-const controller = new ApiV1Controller(urlManagementService, urlV1Mapper)
+const controller = new ApiV1Controller(
+  urlManagementService,
+  urlV1Mapper,
+  urlThreatScanService,
+)
 
 /**
  * Unit tests for API v1 controller.
@@ -138,6 +147,223 @@ describe('ApiV1Controller', () => {
       await controller.createUrl(req, res)
       expect(res.serverError).toHaveBeenCalledWith({
         message: expect.any(String),
+      })
+    })
+  })
+
+  describe('bulkCreateUrls', () => {
+    const userId = 1
+    const longUrl = 'https://www.agency.gov.sg'
+    const shortUrl = 'abcdef'
+    const state = 'ACTIVE'
+    const source = 'API'
+    const clicks = 0
+    const contactEmail = 'person@open.gov.sg'
+    const description = 'test description'
+    const tags: string[] = []
+    const tagStrings = ''
+    const createdAt = moment().toISOString()
+    const updatedAt = moment().toISOString()
+
+    const createdUrl = {
+      shortUrl,
+      longUrl,
+      state,
+      source,
+      clicks,
+      contactEmail,
+      description,
+      tags,
+      tagStrings,
+      createdAt,
+      updatedAt,
+    }
+
+    beforeEach(() => {
+      urlManagementService.createUrl.mockReset()
+      urlThreatScanService.isThreat.mockReset()
+      urlThreatScanService.isThreat.mockResolvedValue(false)
+    })
+
+    it('creates all valid rows and returns 200', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [{ shortUrl, longUrl }],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.ok = jest.fn()
+
+      urlManagementService.createUrl.mockResolvedValue(createdUrl)
+
+      await controller.bulkCreateUrls(req, res)
+      expect(urlThreatScanService.isThreat).toHaveBeenCalledWith(longUrl)
+      expect(urlManagementService.createUrl).toHaveBeenCalledWith(
+        userId,
+        source,
+        shortUrl,
+        longUrl,
+      )
+      expect(res.ok).toHaveBeenCalledWith({
+        created: [
+          {
+            shortUrl,
+            longUrl,
+            state,
+            clicks,
+            createdAt,
+            updatedAt,
+          },
+        ],
+        errors: [],
+      })
+    })
+
+    it('returns partial success with row validation errors', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [{ shortUrl, longUrl }, { longUrl: 'not-a-url' }],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.ok = jest.fn()
+
+      urlManagementService.createUrl.mockResolvedValue(createdUrl)
+
+      await controller.bulkCreateUrls(req, res)
+      expect(res.ok).toHaveBeenCalledWith({
+        created: [
+          {
+            shortUrl,
+            longUrl,
+            state,
+            clicks,
+            createdAt,
+            updatedAt,
+          },
+        ],
+        errors: [
+          {
+            index: 1,
+            message: 'Only HTTPS URLs are allowed.',
+            type: 'LongUrlError',
+          },
+        ],
+      })
+    })
+
+    it('returns 400 when every row fails', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [{ longUrl: 'not-a-url' }],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
+
+      await controller.bulkCreateUrls(req, res)
+      expect(res.badRequest).toHaveBeenCalledWith({
+        created: [],
+        errors: [
+          {
+            index: 0,
+            message: 'Only HTTPS URLs are allowed.',
+            type: 'LongUrlError',
+          },
+        ],
+      })
+    })
+
+    it('reports duplicate shortUrl within the same request', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [
+            { shortUrl, longUrl },
+            { shortUrl, longUrl: 'https://www.agency2.gov.sg' },
+          ],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.ok = jest.fn()
+
+      urlManagementService.createUrl.mockResolvedValue(createdUrl)
+
+      await controller.bulkCreateUrls(req, res)
+      expect(urlManagementService.createUrl).toHaveBeenCalledTimes(1)
+      expect(res.ok).toHaveBeenCalledWith({
+        created: [
+          {
+            shortUrl,
+            longUrl,
+            state,
+            clicks,
+            createdAt,
+            updatedAt,
+          },
+        ],
+        errors: [
+          {
+            index: 1,
+            message: `Short link "${shortUrl}" is already used.`,
+            type: 'ShortUrlError',
+          },
+        ],
+      })
+    })
+
+    it('reports malicious links as row errors', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [{ shortUrl, longUrl }],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
+
+      urlThreatScanService.isThreat.mockResolvedValue(true)
+
+      await controller.bulkCreateUrls(req, res)
+      expect(res.badRequest).toHaveBeenCalledWith({
+        created: [],
+        errors: [
+          {
+            index: 0,
+            message:
+              'Link is likely to be malicious, please contact us for further assistance',
+          },
+        ],
+      })
+    })
+
+    it('reports shortUrl collision from createUrl as row error', async () => {
+      const req = httpMocks.createRequest({
+        body: {
+          userId,
+          urls: [{ shortUrl, longUrl }],
+        },
+      })
+      const res: any = httpMocks.createResponse()
+      res.badRequest = jest.fn()
+
+      urlManagementService.createUrl.mockRejectedValue(
+        new AlreadyExistsError(`Short link "${shortUrl}" is already used.`),
+      )
+
+      await controller.bulkCreateUrls(req, res)
+      expect(res.badRequest).toHaveBeenCalledWith({
+        created: [],
+        errors: [
+          {
+            index: 0,
+            message: `Short link "${shortUrl}" is already used.`,
+            type: 'ShortUrlError',
+          },
+        ],
       })
     })
   })

--- a/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
+++ b/src/server/modules/api/external-v1/__tests__/ApiV1Controller.test.ts
@@ -19,18 +19,9 @@ const urlManagementService = {
   deactivateMaliciousShortUrl: jest.fn(),
 }
 
-const urlThreatScanService = {
-  isThreat: jest.fn(),
-  isThreatBulk: jest.fn(),
-}
-
 const urlV1Mapper = new UrlV1Mapper()
 
-const controller = new ApiV1Controller(
-  urlManagementService,
-  urlV1Mapper,
-  urlThreatScanService,
-)
+const controller = new ApiV1Controller(urlManagementService, urlV1Mapper)
 
 /**
  * Unit tests for API v1 controller.
@@ -181,13 +172,15 @@ describe('ApiV1Controller', () => {
 
     beforeEach(() => {
       urlManagementService.createUrl.mockReset()
-      urlThreatScanService.isThreat.mockReset()
-      urlThreatScanService.isThreat.mockResolvedValue(false)
     })
 
     it('creates all valid rows and returns 200', async () => {
       const req = httpMocks.createRequest({
-        body: { userId, urls: [{ shortUrl, longUrl }] },
+        body: {
+          userId,
+          validatedBulkRows: [{ index: 0, shortUrl, longUrl }],
+          bulkValidationErrors: [],
+        },
       })
       const res: any = httpMocks.createResponse()
       res.ok = jest.fn()
@@ -207,7 +200,14 @@ describe('ApiV1Controller', () => {
       const req = httpMocks.createRequest({
         body: {
           userId,
-          urls: [{ shortUrl, longUrl }, { longUrl: 'not-a-url' }],
+          validatedBulkRows: [{ index: 0, shortUrl, longUrl }],
+          bulkValidationErrors: [
+            {
+              index: 1,
+              message: 'Only HTTPS URLs are allowed.',
+              type: 'LongUrlError',
+            },
+          ],
         },
       })
       const res: any = httpMocks.createResponse()
@@ -229,7 +229,17 @@ describe('ApiV1Controller', () => {
 
     it('returns 400 when every row fails', async () => {
       const req = httpMocks.createRequest({
-        body: { userId, urls: [{ longUrl: 'not-a-url' }] },
+        body: {
+          userId,
+          validatedBulkRows: [],
+          bulkValidationErrors: [
+            {
+              index: 0,
+              message: 'Only HTTPS URLs are allowed.',
+              type: 'LongUrlError',
+            },
+          ],
+        },
       })
       const res: any = httpMocks.createResponse()
       res.badRequest = jest.fn()
@@ -251,10 +261,11 @@ describe('ApiV1Controller', () => {
       const req = httpMocks.createRequest({
         body: {
           userId,
-          urls: [
-            { shortUrl, longUrl },
-            { shortUrl, longUrl: 'https://www.agency2.gov.sg' },
+          validatedBulkRows: [
+            { index: 0, shortUrl, longUrl },
+            { index: 1, shortUrl, longUrl: 'https://www.agency2.gov.sg' },
           ],
+          bulkValidationErrors: [],
         },
       })
       const res: any = httpMocks.createResponse()
@@ -275,30 +286,13 @@ describe('ApiV1Controller', () => {
       })
     })
 
-    it('reports malicious links as row errors', async () => {
-      const req = httpMocks.createRequest({
-        body: { userId, urls: [{ shortUrl, longUrl }] },
-      })
-      const res: any = httpMocks.createResponse()
-      res.badRequest = jest.fn()
-      urlThreatScanService.isThreat.mockResolvedValue(true)
-
-      await controller.bulkCreateUrls(req, res)
-      expect(res.badRequest).toHaveBeenCalledWith({
-        created: [],
-        errors: [
-          {
-            index: 0,
-            message:
-              'Link is likely to be malicious, please contact us for further assistance',
-          },
-        ],
-      })
-    })
-
     it('reports shortUrl collision from createUrl as row error', async () => {
       const req = httpMocks.createRequest({
-        body: { userId, urls: [{ shortUrl, longUrl }] },
+        body: {
+          userId,
+          validatedBulkRows: [{ index: 0, shortUrl, longUrl }],
+          bulkValidationErrors: [],
+        },
       })
       const res: any = httpMocks.createResponse()
       res.badRequest = jest.fn()

--- a/src/server/modules/api/external-v1/index.ts
+++ b/src/server/modules/api/external-v1/index.ts
@@ -1,5 +1,4 @@
 import { StorableUrl } from '../../../repositories/types'
-import { MessageType } from '../../../../shared/util/messages'
 
 export { ApiV1Controller } from './ApiV1Controller'
 
@@ -32,22 +31,9 @@ export type UrlV1DTO = Pick<
   'shortUrl' | 'longUrl' | 'state' | 'clicks' | 'createdAt' | 'updatedAt'
 >
 
-export type UrlBulkRow = {
-  longUrl?: string
-  shortUrl?: string
-}
-
 export type UrlBulkCreationRequest = UserIdProperty & {
-  urls: UrlBulkRow[]
-}
-
-export type UrlBulkError = {
-  index: number
-  message: string
-  type?: MessageType
-}
-
-export type UrlBulkCreationResponse = {
-  created: UrlV1DTO[]
-  errors: UrlBulkError[]
+  urls: {
+    longUrl?: string
+    shortUrl?: string
+  }[]
 }

--- a/src/server/modules/api/external-v1/index.ts
+++ b/src/server/modules/api/external-v1/index.ts
@@ -1,4 +1,5 @@
 import { StorableUrl } from '../../../repositories/types'
+import { MessageType } from '../../../../shared/util/messages'
 
 export { ApiV1Controller } from './ApiV1Controller'
 
@@ -30,3 +31,23 @@ export type UrlV1DTO = Pick<
   StorableUrl,
   'shortUrl' | 'longUrl' | 'state' | 'clicks' | 'createdAt' | 'updatedAt'
 >
+
+export type UrlBulkRow = {
+  longUrl?: string
+  shortUrl?: string
+}
+
+export type UrlBulkCreationRequest = UserIdProperty & {
+  urls: UrlBulkRow[]
+}
+
+export type UrlBulkError = {
+  index: number
+  message: string
+  type?: MessageType
+}
+
+export type UrlBulkCreationResponse = {
+  created: UrlV1DTO[]
+  errors: UrlBulkError[]
+}

--- a/src/server/modules/threat/UrlCheckController.ts
+++ b/src/server/modules/threat/UrlCheckController.ts
@@ -89,6 +89,46 @@ export class UrlCheckController {
     }
     next()
   }
+
+  externalBulkUrlCheck: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<void> = async (req, res, next) => {
+    const {
+      bulkLongUrls,
+      userId,
+    }: { bulkLongUrls?: string[]; userId: number } = req.body
+
+    if (!bulkLongUrls?.length) {
+      next()
+      return
+    }
+
+    try {
+      const isThreat = await this.urlThreatScanService.isThreatBulk(
+        bulkLongUrls,
+      )
+      if (isThreat) {
+        logger.warn(
+          `Malicious link attempt: User ${userId} tried to create malicious urls via external bulk API`,
+        )
+        dogstatsd.increment(MALICIOUS_ACTIVITY_LINK, 1, 1)
+        res.badRequest(
+          jsonMessage(
+            'Link is likely to be malicious, please contact us for further assistance',
+          ),
+        )
+        return
+      }
+    } catch (error) {
+      dogstatsd.increment(SCAN_FAILED_LINK, 1, 1)
+      logger.error(error)
+      res.serverError(jsonMessage((error as Error).message))
+      return
+    }
+    next()
+  }
 }
 
 export default UrlCheckController

--- a/src/server/modules/threat/UrlCheckController.ts
+++ b/src/server/modules/threat/UrlCheckController.ts
@@ -62,61 +62,29 @@ export class UrlCheckController {
     res: Response,
     next: NextFunction,
   ) => Promise<void> = async (req, res, next) => {
-    const { longUrls }: { longUrls: string[] } = req.body
+    const { longUrls, userId }: { longUrls?: string[]; userId?: number } =
+      req.body
 
-    if (longUrls) {
-      try {
-        const isThreat = await this.urlThreatScanService.isThreatBulk(longUrls)
-        if (isThreat) {
-          const user = req.session?.user
-          logger.warn(
-            `Malicious link attempt: User ${
-              user?.email || user?.id
-            } tried to create a malicious url via bulk upload`,
-          )
-          res.badRequest(
-            jsonMessage(
-              'Csv contains a link that is likely to be malicious, please contact us for further assistance',
-            ),
-          )
-          return
-        }
-      } catch (error) {
-        logger.error(error)
-        res.serverError(jsonMessage((error as Error).message))
-        return
-      }
-    }
-    next()
-  }
-
-  externalBulkUrlCheck: (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => Promise<void> = async (req, res, next) => {
-    const {
-      bulkLongUrls,
-      userId,
-    }: { bulkLongUrls?: string[]; userId: number } = req.body
-
-    if (!bulkLongUrls?.length) {
+    if (!longUrls?.length) {
       next()
       return
     }
 
     try {
-      const isThreat = await this.urlThreatScanService.isThreatBulk(
-        bulkLongUrls,
-      )
+      const isThreat = await this.urlThreatScanService.isThreatBulk(longUrls)
       if (isThreat) {
+        const user = req.session?.user
         logger.warn(
-          `Malicious link attempt: User ${userId} tried to create malicious urls via external bulk API`,
+          `Malicious link attempt: User ${
+            user?.email || user?.id || userId
+          } tried to create a malicious url via bulk upload`,
         )
         dogstatsd.increment(MALICIOUS_ACTIVITY_LINK, 1, 1)
         res.badRequest(
           jsonMessage(
-            'Link is likely to be malicious, please contact us for further assistance',
+            req.body.urls
+              ? 'Link is likely to be malicious, please contact us for further assistance'
+              : 'Csv contains a link that is likely to be malicious, please contact us for further assistance',
           ),
         )
         return

--- a/src/server/modules/threat/__tests__/UrlCheckController.test.ts
+++ b/src/server/modules/threat/__tests__/UrlCheckController.test.ts
@@ -166,4 +166,79 @@ describe('UrlCheckController test', () => {
       expect(next).toHaveBeenCalled()
     })
   })
+
+  describe('externalBulkUrlCheck tests', () => {
+    const urls = ['https://example.com', 'https://example1.com']
+    const controller = new UrlCheckController(mockUrlThreatScanService)
+    const badRequest = jest.fn()
+
+    beforeEach(() => {
+      mockUrlThreatScanService.isThreatBulk.mockClear()
+      badRequest.mockClear()
+    })
+
+    it('does not invoke checks if no urls', async () => {
+      const req = createRequestWithUser(undefined)
+      req.body.userId = 1
+      const res = httpMocks.createResponse()
+      const next = jest.fn()
+
+      await controller.externalBulkUrlCheck(req, res, next)
+
+      expect(mockUrlThreatScanService.isThreatBulk).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('reports on server error', async () => {
+      const req = createRequestWithUser(undefined)
+      req.body.userId = 1
+      req.body.bulkLongUrls = urls
+      const res = httpMocks.createResponse() as any
+      const next = jest.fn()
+
+      mockUrlThreatScanService.isThreatBulk.mockRejectedValue(false)
+      res.serverError = badRequest
+
+      await controller.externalBulkUrlCheck(req, res, next)
+
+      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
+      expect(badRequest).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('rejects on bad URLs', async () => {
+      const req = createRequestWithUser(undefined)
+      req.body.userId = 1
+      req.body.bulkLongUrls = urls
+      const res = httpMocks.createResponse() as any
+      const next = jest.fn()
+
+      mockUrlThreatScanService.isThreatBulk.mockResolvedValue(true)
+      res.badRequest = badRequest
+
+      await controller.externalBulkUrlCheck(req, res, next)
+
+      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
+      expect(badRequest).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('passes through on good URLs', async () => {
+      const req = createRequestWithUser(undefined)
+      req.body.userId = 1
+      req.body.bulkLongUrls = urls
+      const res = httpMocks.createResponse() as any
+      const next = jest.fn()
+
+      mockUrlThreatScanService.isThreatBulk.mockResolvedValue(false)
+      res.badRequest = badRequest
+      res.serverError = badRequest
+
+      await controller.externalBulkUrlCheck(req, res, next)
+
+      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
+      expect(badRequest).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    })
+  })
 })

--- a/src/server/modules/threat/__tests__/UrlCheckController.test.ts
+++ b/src/server/modules/threat/__tests__/UrlCheckController.test.ts
@@ -149,6 +149,26 @@ describe('UrlCheckController test', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
+    it('rejects external bulk requests on bad URLs', async () => {
+      const req = createRequestWithUser(undefined)
+      req.body.userId = 1
+      req.body.urls = urls
+      req.body.longUrls = urls
+      const res = httpMocks.createResponse() as any
+      const next = jest.fn()
+
+      mockUrlThreatScanService.isThreatBulk.mockResolvedValue(true)
+      res.badRequest = badRequest
+
+      await controller.bulkUrlCheck(req, res, next)
+
+      expect(badRequest).toHaveBeenCalledWith({
+        message:
+          'Link is likely to be malicious, please contact us for further assistance',
+      })
+      expect(next).not.toHaveBeenCalled()
+    })
+
     it('passes through on good URLs', async () => {
       const req = createRequestWithUser(undefined)
       req.body.longUrls = urls
@@ -160,81 +180,6 @@ describe('UrlCheckController test', () => {
       res.serverError = badRequest
 
       await controller.bulkUrlCheck(req, res, next)
-
-      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
-      expect(badRequest).not.toHaveBeenCalled()
-      expect(next).toHaveBeenCalled()
-    })
-  })
-
-  describe('externalBulkUrlCheck tests', () => {
-    const urls = ['https://example.com', 'https://example1.com']
-    const controller = new UrlCheckController(mockUrlThreatScanService)
-    const badRequest = jest.fn()
-
-    beforeEach(() => {
-      mockUrlThreatScanService.isThreatBulk.mockClear()
-      badRequest.mockClear()
-    })
-
-    it('does not invoke checks if no urls', async () => {
-      const req = createRequestWithUser(undefined)
-      req.body.userId = 1
-      const res = httpMocks.createResponse()
-      const next = jest.fn()
-
-      await controller.externalBulkUrlCheck(req, res, next)
-
-      expect(mockUrlThreatScanService.isThreatBulk).not.toHaveBeenCalled()
-      expect(next).toHaveBeenCalled()
-    })
-
-    it('reports on server error', async () => {
-      const req = createRequestWithUser(undefined)
-      req.body.userId = 1
-      req.body.bulkLongUrls = urls
-      const res = httpMocks.createResponse() as any
-      const next = jest.fn()
-
-      mockUrlThreatScanService.isThreatBulk.mockRejectedValue(false)
-      res.serverError = badRequest
-
-      await controller.externalBulkUrlCheck(req, res, next)
-
-      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
-      expect(badRequest).toHaveBeenCalled()
-      expect(next).not.toHaveBeenCalled()
-    })
-
-    it('rejects on bad URLs', async () => {
-      const req = createRequestWithUser(undefined)
-      req.body.userId = 1
-      req.body.bulkLongUrls = urls
-      const res = httpMocks.createResponse() as any
-      const next = jest.fn()
-
-      mockUrlThreatScanService.isThreatBulk.mockResolvedValue(true)
-      res.badRequest = badRequest
-
-      await controller.externalBulkUrlCheck(req, res, next)
-
-      expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
-      expect(badRequest).toHaveBeenCalled()
-      expect(next).not.toHaveBeenCalled()
-    })
-
-    it('passes through on good URLs', async () => {
-      const req = createRequestWithUser(undefined)
-      req.body.userId = 1
-      req.body.bulkLongUrls = urls
-      const res = httpMocks.createResponse() as any
-      const next = jest.fn()
-
-      mockUrlThreatScanService.isThreatBulk.mockResolvedValue(false)
-      res.badRequest = badRequest
-      res.serverError = badRequest
-
-      await controller.externalBulkUrlCheck(req, res, next)
 
       expect(mockUrlThreatScanService.isThreatBulk).toHaveBeenCalled()
       expect(badRequest).not.toHaveBeenCalled()

--- a/test/integration/api/external-v1/Urls.test.ts
+++ b/test/integration/api/external-v1/Urls.test.ts
@@ -1,9 +1,5 @@
 import FormData from 'form-data'
-import {
-  API_EXTERNAL_V1_URLS,
-  API_EXTERNAL_V1_URLS_BULK,
-  SMALL_TEXT_FILE_PATH,
-} from '../../config'
+import { API_EXTERNAL_V1_URLS, SMALL_TEXT_FILE_PATH } from '../../config'
 import {
   DATETIME_REGEX,
   createIntegrationTestUser,
@@ -13,21 +9,7 @@ import {
 } from '../../util/helpers'
 import { get, patch, postFormData, postJson } from '../../util/requests'
 
-async function createBulkLinkUrls(
-  urls: {
-    shortUrl?: string
-    longUrl?: string
-  }[],
-  apiKey: string,
-) {
-  const res = await postJson(
-    API_EXTERNAL_V1_URLS_BULK,
-    { urls },
-    undefined,
-    apiKey,
-  )
-  return res
-}
+const API_EXTERNAL_V1_URLS_BULK = `${API_EXTERNAL_V1_URLS}/bulk`
 
 async function createLinkUrl(
   link: {
@@ -290,50 +272,44 @@ describe('Url integration tests', () => {
       message: 'ValidationError: "state" must be one of [ACTIVE, INACTIVE]',
     })
   })
-})
-
-describe('Bulk URL integration tests', () => {
-  let email: string
-  let apiKey: string
-  const longUrl = 'https://example.com'
-
-  beforeEach(async () => {
-    ;({ email, apiKey } = await createIntegrationTestUser())
-  })
-
-  afterEach(async () => {
-    await deleteIntegrationTestUser(email)
-  })
 
   it('should not be able to bulk create urls without API key header', async () => {
     const res = await postJson(API_EXTERNAL_V1_URLS_BULK, {
       urls: [{ longUrl }],
     })
     expect(res.status).toBe(401)
-    const json = await res.json()
-    expect(json).toEqual({
+    expect(await res.json()).toEqual({
       message: 'Authorization header is missing',
     })
   })
 
   it('should not be able to bulk create urls with empty urls array', async () => {
-    const res = await createBulkLinkUrls([], apiKey)
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      { urls: [] },
+      undefined,
+      apiKey,
+    )
     expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.message).toMatch(/"urls" must contain at least 1 items/)
+    expect((await res.json()).message).toMatch(
+      /"urls" must contain at least 1 items/,
+    )
   })
 
   it('should not be able to bulk create urls without urls field', async () => {
     const res = await postJson(API_EXTERNAL_V1_URLS_BULK, {}, undefined, apiKey)
     expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.message).toMatch(/"urls" is required/)
+    expect((await res.json()).message).toMatch(/"urls" is required/)
   })
 
-  it('should create all valid rows', async () => {
+  it('should create all valid rows in bulk', async () => {
     const shortUrl = await generateRandomString(6)
-    const res = await createBulkLinkUrls(
-      [{ shortUrl, longUrl }, { longUrl: 'https://example.org' }],
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      {
+        urls: [{ shortUrl, longUrl }, { longUrl: 'https://example.org' }],
+      },
+      undefined,
       apiKey,
     )
     expect(res.status).toBe(200)
@@ -348,20 +324,17 @@ describe('Bulk URL integration tests', () => {
       createdAt: expect.stringMatching(DATETIME_REGEX),
       updatedAt: expect.stringMatching(DATETIME_REGEX),
     })
-    expect(body.created[1]).toEqual({
-      shortUrl: expect.stringMatching(/^[a-z0-9]{8}$/),
-      longUrl: 'https://example.org',
-      clicks: 0,
-      state: 'ACTIVE',
-      createdAt: expect.stringMatching(DATETIME_REGEX),
-      updatedAt: expect.stringMatching(DATETIME_REGEX),
-    })
+    expect(body.created[1].shortUrl).toMatch(/^[a-z0-9]{8}$/)
   })
 
-  it('should return partial success for mixed valid and invalid rows', async () => {
+  it('should return partial success for mixed valid and invalid bulk rows', async () => {
     const shortUrl = await generateRandomString(6)
-    const res = await createBulkLinkUrls(
-      [{ shortUrl, longUrl }, { longUrl: 'this-is-an-invalid-url' }],
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      {
+        urls: [{ shortUrl, longUrl }, { longUrl: 'this-is-an-invalid-url' }],
+      },
+      undefined,
       apiKey,
     )
     expect(res.status).toBe(200)
@@ -377,9 +350,11 @@ describe('Bulk URL integration tests', () => {
     ])
   })
 
-  it('should return 400 when every row fails validation', async () => {
-    const res = await createBulkLinkUrls(
-      [{ longUrl: 'this-is-an-invalid-url' }],
+  it('should return 400 when every bulk row fails validation', async () => {
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      { urls: [{ longUrl: 'this-is-an-invalid-url' }] },
+      undefined,
       apiKey,
     )
     expect(res.status).toBe(400)
@@ -394,13 +369,17 @@ describe('Bulk URL integration tests', () => {
     ])
   })
 
-  it('should error on duplicate shortUrl within the same request', async () => {
+  it('should error on duplicate shortUrl within the same bulk request', async () => {
     const shortUrl = await generateRandomString(6)
-    const res = await createBulkLinkUrls(
-      [
-        { shortUrl, longUrl },
-        { shortUrl, longUrl: 'https://example.org' },
-      ],
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      {
+        urls: [
+          { shortUrl, longUrl },
+          { shortUrl, longUrl: 'https://example.org' },
+        ],
+      },
+      undefined,
       apiKey,
     )
     expect(res.status).toBe(200)
@@ -415,8 +394,13 @@ describe('Bulk URL integration tests', () => {
     ])
   })
 
-  it('should allow duplicate longUrl values in the same request', async () => {
-    const res = await createBulkLinkUrls([{ longUrl }, { longUrl }], apiKey)
+  it('should allow duplicate longUrl values in the same bulk request', async () => {
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      { urls: [{ longUrl }, { longUrl }] },
+      undefined,
+      apiKey,
+    )
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.errors).toEqual([])
@@ -424,12 +408,14 @@ describe('Bulk URL integration tests', () => {
     expect(body.created[0].shortUrl).not.toBe(body.created[1].shortUrl)
   })
 
-  it('should error when shortUrl is already used in the database', async () => {
+  it('should error when bulk shortUrl is already used in the database', async () => {
     const shortUrl = await generateRandomString(6)
     await createLinkUrl({ shortUrl, longUrl }, apiKey)
 
-    const res = await createBulkLinkUrls(
-      [{ shortUrl, longUrl: 'https://example.org' }],
+    const res = await postJson(
+      API_EXTERNAL_V1_URLS_BULK,
+      { urls: [{ shortUrl, longUrl: 'https://example.org' }] },
+      undefined,
       apiKey,
     )
     expect(res.status).toBe(400)

--- a/test/integration/api/external-v1/Urls.test.ts
+++ b/test/integration/api/external-v1/Urls.test.ts
@@ -1,5 +1,9 @@
 import FormData from 'form-data'
-import { API_EXTERNAL_V1_URLS, SMALL_TEXT_FILE_PATH } from '../../config'
+import {
+  API_EXTERNAL_V1_URLS,
+  API_EXTERNAL_V1_URLS_BULK,
+  SMALL_TEXT_FILE_PATH,
+} from '../../config'
 import {
   DATETIME_REGEX,
   createIntegrationTestUser,
@@ -8,6 +12,22 @@ import {
   readFile,
 } from '../../util/helpers'
 import { get, patch, postFormData, postJson } from '../../util/requests'
+
+async function createBulkLinkUrls(
+  urls: {
+    shortUrl?: string
+    longUrl?: string
+  }[],
+  apiKey: string,
+) {
+  const res = await postJson(
+    API_EXTERNAL_V1_URLS_BULK,
+    { urls },
+    undefined,
+    apiKey,
+  )
+  return res
+}
 
 async function createLinkUrl(
   link: {
@@ -269,5 +289,158 @@ describe('Url integration tests', () => {
     expect(body).toEqual({
       message: 'ValidationError: "state" must be one of [ACTIVE, INACTIVE]',
     })
+  })
+})
+
+describe('Bulk URL integration tests', () => {
+  let email: string
+  let apiKey: string
+  const longUrl = 'https://example.com'
+
+  beforeEach(async () => {
+    ;({ email, apiKey } = await createIntegrationTestUser())
+  })
+
+  afterEach(async () => {
+    await deleteIntegrationTestUser(email)
+  })
+
+  it('should not be able to bulk create urls without API key header', async () => {
+    const res = await postJson(API_EXTERNAL_V1_URLS_BULK, {
+      urls: [{ longUrl }],
+    })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json).toEqual({
+      message: 'Authorization header is missing',
+    })
+  })
+
+  it('should not be able to bulk create urls with empty urls array', async () => {
+    const res = await createBulkLinkUrls([], apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toMatch(/"urls" must contain at least 1 items/)
+  })
+
+  it('should not be able to bulk create urls without urls field', async () => {
+    const res = await postJson(API_EXTERNAL_V1_URLS_BULK, {}, undefined, apiKey)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toMatch(/"urls" is required/)
+  })
+
+  it('should create all valid rows', async () => {
+    const shortUrl = await generateRandomString(6)
+    const res = await createBulkLinkUrls(
+      [{ shortUrl, longUrl }, { longUrl: 'https://example.org' }],
+      apiKey,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.errors).toEqual([])
+    expect(body.created).toHaveLength(2)
+    expect(body.created[0]).toEqual({
+      shortUrl,
+      longUrl,
+      clicks: 0,
+      state: 'ACTIVE',
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+    expect(body.created[1]).toEqual({
+      shortUrl: expect.stringMatching(/^[a-z0-9]{8}$/),
+      longUrl: 'https://example.org',
+      clicks: 0,
+      state: 'ACTIVE',
+      createdAt: expect.stringMatching(DATETIME_REGEX),
+      updatedAt: expect.stringMatching(DATETIME_REGEX),
+    })
+  })
+
+  it('should return partial success for mixed valid and invalid rows', async () => {
+    const shortUrl = await generateRandomString(6)
+    const res = await createBulkLinkUrls(
+      [{ shortUrl, longUrl }, { longUrl: 'this-is-an-invalid-url' }],
+      apiKey,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toHaveLength(1)
+    expect(body.created[0].shortUrl).toBe(shortUrl)
+    expect(body.errors).toEqual([
+      {
+        index: 1,
+        message: 'Only HTTPS URLs are allowed.',
+        type: 'LongUrlError',
+      },
+    ])
+  })
+
+  it('should return 400 when every row fails validation', async () => {
+    const res = await createBulkLinkUrls(
+      [{ longUrl: 'this-is-an-invalid-url' }],
+      apiKey,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.created).toEqual([])
+    expect(body.errors).toEqual([
+      {
+        index: 0,
+        message: 'Only HTTPS URLs are allowed.',
+        type: 'LongUrlError',
+      },
+    ])
+  })
+
+  it('should error on duplicate shortUrl within the same request', async () => {
+    const shortUrl = await generateRandomString(6)
+    const res = await createBulkLinkUrls(
+      [
+        { shortUrl, longUrl },
+        { shortUrl, longUrl: 'https://example.org' },
+      ],
+      apiKey,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toHaveLength(1)
+    expect(body.errors).toEqual([
+      {
+        index: 1,
+        message: `Short link "${shortUrl}" is already used.`,
+        type: 'ShortUrlError',
+      },
+    ])
+  })
+
+  it('should allow duplicate longUrl values in the same request', async () => {
+    const res = await createBulkLinkUrls([{ longUrl }, { longUrl }], apiKey)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.errors).toEqual([])
+    expect(body.created).toHaveLength(2)
+    expect(body.created[0].shortUrl).not.toBe(body.created[1].shortUrl)
+  })
+
+  it('should error when shortUrl is already used in the database', async () => {
+    const shortUrl = await generateRandomString(6)
+    await createLinkUrl({ shortUrl, longUrl }, apiKey)
+
+    const res = await createBulkLinkUrls(
+      [{ shortUrl, longUrl: 'https://example.org' }],
+      apiKey,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.created).toEqual([])
+    expect(body.errors).toEqual([
+      {
+        index: 0,
+        message: `Short link "${shortUrl}" is already used.`,
+        type: 'ShortUrlError',
+      },
+    ])
   })
 })

--- a/test/integration/config.ts
+++ b/test/integration/config.ts
@@ -8,6 +8,8 @@ export const IMAGE_FILE_PATH = './test/integration/assets/go-logo.png'
 
 export const API_USER_URL = 'http://localhost:8080/api/user/url'
 export const API_EXTERNAL_V1_URLS = 'http://localhost:8080/api/v1/urls'
+export const API_EXTERNAL_V1_URLS_BULK =
+  'http://localhost:8080/api/v1/urls/bulk'
 export const API_ADMIN_V1_URLS = 'http://localhost:8080/api/v1/admin/urls'
 export const API_LOGIN_OTP = 'http://localhost:8080/api/login/otp'
 export const API_LOGIN_VERIFY = 'http://localhost:8080/api/login/verify'

--- a/test/integration/config.ts
+++ b/test/integration/config.ts
@@ -8,8 +8,6 @@ export const IMAGE_FILE_PATH = './test/integration/assets/go-logo.png'
 
 export const API_USER_URL = 'http://localhost:8080/api/user/url'
 export const API_EXTERNAL_V1_URLS = 'http://localhost:8080/api/v1/urls'
-export const API_EXTERNAL_V1_URLS_BULK =
-  'http://localhost:8080/api/v1/urls/bulk'
 export const API_ADMIN_V1_URLS = 'http://localhost:8080/api/v1/admin/urls'
 export const API_LOGIN_OTP = 'http://localhost:8080/api/login/otp'
 export const API_LOGIN_VERIFY = 'http://localhost:8080/api/login/verify'

--- a/test/server/config.ts
+++ b/test/server/config.ts
@@ -53,6 +53,7 @@ jest.mock('../../src/server/config', () => ({
   gaTrackingId: 'UA-000000-2',
   otpRateLimit: 5,
   ogHostname: 'go.gov.sg',
+  bulkUploadMaxNum: 1000,
   userCount: 1,
   clickCount: 2,
   linkCount: 3,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds JSON-based bulk URL creation for API-key clients at `POST /api/v1/urls/bulk`, gated by `FF_EXTERNAL_API` like the rest of the external API.

Integrators can create up to 1000 links per request without looping single-URL calls or using the console CSV upload flow.

## API

```http
POST /api/v1/urls/bulk
Authorization: Bearer <apiKey>
Content-Type: application/json

{
  "urls": [
    { "longUrl": "https://example.com/a", "shortUrl": "campaign-a" },
    { "longUrl": "https://example.com/b" }
  ]
}
```

```json
{
  "created": [ /* UrlV1DTO[], same shape as POST /api/v1/urls */ ],
  "errors": [
    { "index": 1, "message": "...", "type": "ShortUrlError" }
  ]
}
```

- `shortUrl` is optional per row (auto-generated 8-char slug when omitted)
- Links are persisted with `StorableUrlSource.Api` (not console `BULK`)
- Duplicate `longUrl` values in one request are allowed

## Request pipeline

```
apiKeyAuthMiddleware
  → urlBulkSchema (request-level Joi: urls array 1–1000, known keys only)
  → preprocessExternalBulkRows (per-row urlBulkRowSchema validation)
  → bulkUrlCheck (isThreatBulk on validated longUrls)
  → bulkCreateUrls (createUrl per valid row)
```

## Error semantics

| Failure | Behavior | Status |
|---|---|---|
| Bad request shape (missing `urls`, empty, >1000, unknown keys) | Nothing runs | 400 `{ message }` |
| Malicious URL (Safe Browsing) | Nothing created | 400 `{ message }` |
| Safe Browsing API error | Nothing created | 500 `{ message }` |
| Row validation / DB errors | Partial success | 200 if ≥1 created, else 400 `{ created, errors }` |

Validation and DB failures are per-row. Threat scanning is all-or-nothing (same model as console CSV bulk): one bad URL blocks the entire batch from being created.

## Key implementation notes

- Reuses shared `longUrl`/`shortUrl` validators extracted from single-URL create
- Row creation goes through `UrlManagementService.createUrl` (not `bulkCreate` / `UrlRepository.bulkCreate`)
- `bulkUrlCheck` serves both console CSV bulk and this endpoint; external requests are detected via `req.body.urls` for messaging and `userId` for logging/metrics
- In-batch duplicate `shortUrl` detection before DB insert

## Out of scope

Idempotency, tags, QR generation, CSV/multipart upload, async jobs, rate limiting.

## Testing

- Unit tests: `ApiV1Controller.bulkCreateUrls`, `UrlCheckController.bulkUrlCheck` (external bulk path)
- Integration tests: auth, request-level validation, partial success, duplicate slug handling
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-812ec23a-ecab-4f88-ae1d-7b491a3ba8e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-812ec23a-ecab-4f88-ae1d-7b491a3ba8e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

