### PR TITLE
feat: allow converting short links between Link and File type

### DIFF
--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Button,
   Divider,
@@ -32,6 +32,8 @@ import DownloadButton from './widgets/DownloadButton'
 import LinkStateText from './widgets/LinkStateText'
 import LongUrlEditor from './widgets/LongUrlEditor'
 import TagsEditor from './widgets/TagsEditor'
+import LinkTypeToggle from './widgets/LinkTypeToggle'
+import TypeConversionConfirmDialog from './widgets/TypeConversionConfirmDialog'
 import { SEARCH_PAGE } from '../../../../app/util/types'
 import userActions from '../../../actions'
 
@@ -179,6 +181,36 @@ export default function ControlPanel() {
     Boolean(originalDescription),
   )
 
+  const [editIsFile, setEditIsFile] = useState(Boolean(shortLinkState?.isFile))
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
+  const [pendingSave, setPendingSave] = useState<(() => void) | null>(null)
+
+  useEffect(() => {
+    setEditIsFile(Boolean(shortLinkState?.isFile))
+  }, [shortLinkState?.shortUrl, shortLinkState?.isFile])
+
+  const isTypeConversion = Boolean(shortLinkState?.isFile) !== editIsFile
+
+  const requestSaveWithConfirmation = (saveAction: () => void) => {
+    if (isTypeConversion) {
+      setPendingSave(() => saveAction)
+      setConfirmDialogOpen(true)
+    } else {
+      saveAction()
+    }
+  }
+
+  const handleConfirmTypeConversion = () => {
+    pendingSave?.()
+    setConfirmDialogOpen(false)
+    setPendingSave(null)
+  }
+
+  const handleCancelTypeConversion = () => {
+    setConfirmDialogOpen(false)
+    setPendingSave(null)
+  }
+
   // Disposes any current unsaved changes and closes the modal.
   const handleClose = () => {
     shortLinkDispatch?.setEditDescription(originalDescription)
@@ -217,7 +249,24 @@ export default function ControlPanel() {
               <Hidden mdUp>
                 <Divider className={classes.divider} />
               </Hidden>
-              {shortLinkState?.isFile ? <FileEditor /> : <LongUrlEditor />}
+              <LinkTypeToggle isFile={editIsFile} onChange={setEditIsFile} />
+              {editIsFile ? (
+                <FileEditor
+                  isTypeConversion={isTypeConversion}
+                  requestSaveWithConfirmation={requestSaveWithConfirmation}
+                />
+              ) : (
+                <LongUrlEditor
+                  isTypeConversion={isTypeConversion}
+                  requestSaveWithConfirmation={requestSaveWithConfirmation}
+                />
+              )}
+              <TypeConversionConfirmDialog
+                open={confirmDialogOpen}
+                convertingToFile={editIsFile}
+                onCancel={handleCancelTypeConversion}
+                onConfirm={handleConfirmTypeConversion}
+              />
               <Hidden mdUp>
                 <Divider className={classes.divider} />
               </Hidden>

--- a/src/client/user/components/Drawer/ControlPanel/index.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/index.tsx
@@ -206,12 +206,6 @@ export default function ControlPanel() {
     setPendingSave(null)
   }
 
-  const handleCancelTypeConversion = () => {
-    setConfirmDialogOpen(false)
-    setPendingSave(null)
-  }
-
-  // Disposes any current unsaved changes and closes the modal.
   const handleClose = () => {
     shortLinkDispatch?.setEditDescription(originalDescription)
     shortLinkDispatch?.setEditContactEmail(originalContactEmail)
@@ -264,7 +258,10 @@ export default function ControlPanel() {
               <TypeConversionConfirmDialog
                 open={confirmDialogOpen}
                 convertingToFile={editIsFile}
-                onCancel={handleCancelTypeConversion}
+                onClose={() => {
+                  setConfirmDialogOpen(false)
+                  setPendingSave(null)
+                }}
                 onConfirm={handleConfirmTypeConversion}
               />
               <Hidden mdUp>

--- a/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
@@ -15,6 +15,7 @@ import { useDrawerState } from '../../index'
 import { removeHttpsProtocol } from '../../../../../app/util/url'
 import { MAX_FILE_UPLOAD_SIZE } from '../../../../../../shared/constants'
 import { formatBytes } from '../../../../../app/util/format'
+import TrailingButton from './TrailingButton'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -24,24 +25,19 @@ const useStyles = makeStyles((theme) =>
         marginBottom: 0,
       },
     },
-    regularText: {
-      fontWeight: 400,
-    },
     originalFileLabel: {
       marginBottom: theme.spacing(1),
     },
   }),
 )
 
-import TrailingButton from './TrailingButton'
-
 type FileEditorProps = {
-  isTypeConversion?: boolean
-  requestSaveWithConfirmation?: (saveAction: () => void) => void
+  isTypeConversion: boolean
+  requestSaveWithConfirmation: (saveAction: () => void) => void
 }
 
 export default function FileEditor({
-  isTypeConversion = false,
+  isTypeConversion,
   requestSaveWithConfirmation,
 }: FileEditorProps) {
   const classes = useStyles()
@@ -52,6 +48,7 @@ export default function FileEditor({
   const [uploadFileError, setUploadFileError] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
+  const maxFileSize = formatBytes(MAX_FILE_UPLOAD_SIZE)
 
   const handleFileSelect = (newFile: File | null) => {
     if (!newFile) {
@@ -69,49 +66,36 @@ export default function FileEditor({
     if (!selectedFile) {
       return
     }
-    const saveAction = () =>
-      shortLinkDispatch?.replaceFile(selectedFile, setUploadFileError)
-    if (requestSaveWithConfirmation) {
-      requestSaveWithConfirmation(saveAction)
-    } else {
-      saveAction()
-    }
+    requestSaveWithConfirmation(() =>
+      shortLinkDispatch?.replaceFile(selectedFile, setUploadFileError),
+    )
   }
-
-  const fileNameText = isTypeConversion
-    ? selectedFile?.name || ''
-    : originalLongUrl
-  const buttonText = isTypeConversion ? 'Select file' : 'Replace file'
-
-  const replaceFileHelp = (
-    <div className={classes.originalFileLabel}>
-      {isTypeConversion ? 'Upload file' : 'Original file'}{' '}
-      <Tooltip
-        title={
-          isTypeConversion
-            ? `Select a file to serve through this short link. Maximum file size is ${formatBytes(
-                MAX_FILE_UPLOAD_SIZE,
-              )}.`
-            : `Original file will be replaced after you select file. Maximum file size is ${formatBytes(
-                MAX_FILE_UPLOAD_SIZE,
-              )}.`
-        }
-        imageAltText="Replace file help"
-      />
-    </div>
-  )
 
   return (
     <ConfigOption
-      title={replaceFileHelp}
+      title={
+        <div className={classes.originalFileLabel}>
+          {isTypeConversion ? 'Upload file' : 'Original file'}{' '}
+          <Tooltip
+            title={
+              isTypeConversion
+                ? `Select a file to serve through this short link. Maximum file size is ${maxFileSize}.`
+                : `Original file will be replaced after you select file. Maximum file size is ${maxFileSize}.`
+            }
+            imageAltText="Replace file help"
+          />
+        </div>
+      }
       leading={
         <>
           <FileInputField
             className={classes.fileInputField}
             uploadFileError={uploadFileError}
             textFieldHeight="44px"
-            fileNameText={fileNameText}
-            buttonText={buttonText}
+            fileNameText={
+              isTypeConversion ? selectedFile?.name || '' : originalLongUrl
+            }
+            buttonText={isTypeConversion ? 'Select file' : 'Replace file'}
             isUploading={isUploading}
             setFile={handleFileSelect}
             setUploadFileError={setUploadFileError}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/FileEditor.tsx
@@ -33,22 +33,69 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-export default function FileEditor() {
+import TrailingButton from './TrailingButton'
+
+type FileEditorProps = {
+  isTypeConversion?: boolean
+  requestSaveWithConfirmation?: (saveAction: () => void) => void
+}
+
+export default function FileEditor({
+  isTypeConversion = false,
+  requestSaveWithConfirmation,
+}: FileEditorProps) {
   const classes = useStyles()
   const drawerStates = useDrawerState()
   const { shortLinkDispatch, shortLinkState, isUploading } = useShortLink(
     drawerStates.relevantShortLink!,
   )
   const [uploadFileError, setUploadFileError] = useState<string | null>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
+
+  const handleFileSelect = (newFile: File | null) => {
+    if (!newFile) {
+      return
+    }
+    if (isTypeConversion) {
+      setSelectedFile(newFile)
+      setUploadFileError(null)
+      return
+    }
+    shortLinkDispatch?.replaceFile(newFile, setUploadFileError)
+  }
+
+  const handleSave = () => {
+    if (!selectedFile) {
+      return
+    }
+    const saveAction = () =>
+      shortLinkDispatch?.replaceFile(selectedFile, setUploadFileError)
+    if (requestSaveWithConfirmation) {
+      requestSaveWithConfirmation(saveAction)
+    } else {
+      saveAction()
+    }
+  }
+
+  const fileNameText = isTypeConversion
+    ? selectedFile?.name || ''
+    : originalLongUrl
+  const buttonText = isTypeConversion ? 'Select file' : 'Replace file'
 
   const replaceFileHelp = (
     <div className={classes.originalFileLabel}>
-      Original file{' '}
+      {isTypeConversion ? 'Upload file' : 'Original file'}{' '}
       <Tooltip
-        title={`Original file will be replaced after you select file. Maximum file size is ${formatBytes(
-          MAX_FILE_UPLOAD_SIZE,
-        )}.`}
+        title={
+          isTypeConversion
+            ? `Select a file to serve through this short link. Maximum file size is ${formatBytes(
+                MAX_FILE_UPLOAD_SIZE,
+              )}.`
+            : `Original file will be replaced after you select file. Maximum file size is ${formatBytes(
+                MAX_FILE_UPLOAD_SIZE,
+              )}.`
+        }
         imageAltText="Replace file help"
       />
     </div>
@@ -63,12 +110,10 @@ export default function FileEditor() {
             className={classes.fileInputField}
             uploadFileError={uploadFileError}
             textFieldHeight="44px"
-            fileNameText={originalLongUrl}
-            buttonText="Replace file"
+            fileNameText={fileNameText}
+            buttonText={buttonText}
             isUploading={isUploading}
-            setFile={(newFile) => {
-              shortLinkDispatch?.replaceFile(newFile, setUploadFileError)
-            }}
+            setFile={handleFileSelect}
             setUploadFileError={setUploadFileError}
             maxSize={MAX_FILE_UPLOAD_SIZE}
           />
@@ -81,7 +126,21 @@ export default function FileEditor() {
           </CollapsibleMessage>
         </>
       }
-      trailingPosition={TrailingPosition.none}
+      trailing={
+        isTypeConversion ? (
+          <TrailingButton
+            disabled={!selectedFile || isUploading}
+            onClick={handleSave}
+            fullWidth={false}
+            variant="outlined"
+          >
+            Save
+          </TrailingButton>
+        ) : undefined
+      }
+      trailingPosition={
+        isTypeConversion ? TrailingPosition.end : TrailingPosition.none
+      }
     />
   )
 }

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LinkTypeToggle.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LinkTypeToggle.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import LinkIcon from '../../../../widgets/LinkIcon'
+import FileIcon from '../../../../widgets/FileIcon'
+import CreateTypeButton from '../../../CreateUrlModal/components/CreateTypeButton'
+import useCreateLinkFormStyles from '../../../CreateUrlModal/styles/createLinkForm'
+
+type LinkTypeToggleProps = {
+  isFile: boolean
+  onChange: (isFile: boolean) => void
+}
+
+export default function LinkTypeToggle({
+  isFile,
+  onChange,
+}: LinkTypeToggleProps) {
+  const classes = useCreateLinkFormStyles({
+    textFieldHeight: 44,
+    uploadFileError: null,
+    createShortLinkError: null,
+  })
+
+  return (
+    <div className={classes.linkTypeWrapper}>
+      <CreateTypeButton
+        InputProps={{ classes }}
+        Icon={LinkIcon}
+        isEnabled={isFile}
+        onChange={() => onChange(false)}
+      >
+        To a URL
+      </CreateTypeButton>
+      <CreateTypeButton
+        InputProps={{ classes }}
+        Icon={FileIcon}
+        isEnabled={!isFile}
+        onChange={() => onChange(true)}
+      >
+        To a File
+      </CreateTypeButton>
+    </div>
+  )
+}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useMediaQuery, useTheme } from '@material-ui/core'
 
 import useShortLink from '../util/shortlink'
@@ -11,7 +11,15 @@ import ConfigOption, {
 import PrefixableTextField from '../../../../widgets/PrefixableTextField'
 import TrailingButton from './TrailingButton'
 
-export default function LongUrlEditor() {
+type LongUrlEditorProps = {
+  isTypeConversion?: boolean
+  requestSaveWithConfirmation?: (saveAction: () => void) => void
+}
+
+export default function LongUrlEditor({
+  isTypeConversion = false,
+  requestSaveWithConfirmation,
+}: LongUrlEditorProps) {
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const drawerStates = useDrawerState()
@@ -19,7 +27,26 @@ export default function LongUrlEditor() {
     drawerStates.relevantShortLink!,
   )
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
-  const [editedLongUrl, setEditedLongUrl] = useState<string>(originalLongUrl)
+  const [editedLongUrl, setEditedLongUrl] = useState<string>(
+    isTypeConversion ? '' : originalLongUrl,
+  )
+
+  useEffect(() => {
+    setEditedLongUrl(isTypeConversion ? '' : originalLongUrl)
+  }, [isTypeConversion, originalLongUrl])
+
+  const handleSave = () => {
+    const saveAction = () => shortLinkDispatch?.applyEditLongUrl(editedLongUrl)
+    if (requestSaveWithConfirmation) {
+      requestSaveWithConfirmation(saveAction)
+    } else {
+      saveAction()
+    }
+  }
+
+  const isSaveDisabled = isTypeConversion
+    ? !isValidLongUrl(editedLongUrl, false)
+    : !isValidLongUrl(editedLongUrl, false) || editedLongUrl === originalLongUrl
 
   return (
     <ConfigOption
@@ -42,11 +69,8 @@ export default function LongUrlEditor() {
       }
       trailing={
         <TrailingButton
-          disabled={
-            !isValidLongUrl(editedLongUrl, false) ||
-            editedLongUrl === originalLongUrl
-          }
-          onClick={() => shortLinkDispatch?.applyEditLongUrl(editedLongUrl)}
+          disabled={isSaveDisabled}
+          onClick={handleSave}
           fullWidth={isMobileView}
           variant={isMobileView ? 'contained' : 'outlined'}
         >

--- a/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/LongUrlEditor.tsx
@@ -12,12 +12,12 @@ import PrefixableTextField from '../../../../widgets/PrefixableTextField'
 import TrailingButton from './TrailingButton'
 
 type LongUrlEditorProps = {
-  isTypeConversion?: boolean
-  requestSaveWithConfirmation?: (saveAction: () => void) => void
+  isTypeConversion: boolean
+  requestSaveWithConfirmation: (saveAction: () => void) => void
 }
 
 export default function LongUrlEditor({
-  isTypeConversion = false,
+  isTypeConversion,
   requestSaveWithConfirmation,
 }: LongUrlEditorProps) {
   const theme = useTheme()
@@ -27,7 +27,7 @@ export default function LongUrlEditor({
     drawerStates.relevantShortLink!,
   )
   const originalLongUrl = removeHttpsProtocol(shortLinkState?.longUrl || '')
-  const [editedLongUrl, setEditedLongUrl] = useState<string>(
+  const [editedLongUrl, setEditedLongUrl] = useState(
     isTypeConversion ? '' : originalLongUrl,
   )
 
@@ -35,18 +35,9 @@ export default function LongUrlEditor({
     setEditedLongUrl(isTypeConversion ? '' : originalLongUrl)
   }, [isTypeConversion, originalLongUrl])
 
-  const handleSave = () => {
-    const saveAction = () => shortLinkDispatch?.applyEditLongUrl(editedLongUrl)
-    if (requestSaveWithConfirmation) {
-      requestSaveWithConfirmation(saveAction)
-    } else {
-      saveAction()
-    }
-  }
-
-  const isSaveDisabled = isTypeConversion
-    ? !isValidLongUrl(editedLongUrl, false)
-    : !isValidLongUrl(editedLongUrl, false) || editedLongUrl === originalLongUrl
+  const isSaveDisabled =
+    !isValidLongUrl(editedLongUrl, false) ||
+    (!isTypeConversion && editedLongUrl === originalLongUrl)
 
   return (
     <ConfigOption
@@ -70,7 +61,11 @@ export default function LongUrlEditor({
       trailing={
         <TrailingButton
           disabled={isSaveDisabled}
-          onClick={handleSave}
+          onClick={() =>
+            requestSaveWithConfirmation(() =>
+              shortLinkDispatch?.applyEditLongUrl(editedLongUrl),
+            )
+          }
           fullWidth={isMobileView}
           variant={isMobileView ? 'contained' : 'outlined'}
         >

--- a/src/client/user/components/Drawer/ControlPanel/widgets/TypeConversionConfirmDialog.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/TypeConversionConfirmDialog.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+
+type TypeConversionConfirmDialogProps = {
+  open: boolean
+  convertingToFile: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export default function TypeConversionConfirmDialog({
+  open,
+  convertingToFile,
+  onCancel,
+  onConfirm,
+}: TypeConversionConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel}>
+      <DialogTitle>Change link type?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {convertingToFile
+            ? 'This short link will stop redirecting to its current URL and will instead serve an uploaded file. The previous destination will no longer be reachable through this short link.'
+            : 'This short link will stop serving its current file and will instead redirect to a URL. The previous file will no longer be accessible through this short link or its direct link.'}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={onConfirm} color="primary" variant="contained">
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/client/user/components/Drawer/ControlPanel/widgets/TypeConversionConfirmDialog.tsx
+++ b/src/client/user/components/Drawer/ControlPanel/widgets/TypeConversionConfirmDialog.tsx
@@ -11,18 +11,18 @@ import {
 type TypeConversionConfirmDialogProps = {
   open: boolean
   convertingToFile: boolean
-  onCancel: () => void
+  onClose: () => void
   onConfirm: () => void
 }
 
 export default function TypeConversionConfirmDialog({
   open,
   convertingToFile,
-  onCancel,
+  onClose,
   onConfirm,
 }: TypeConversionConfirmDialogProps) {
   return (
-    <Dialog open={open} onClose={onCancel}>
+    <Dialog open={open} onClose={onClose}>
       <DialogTitle>Change link type?</DialogTitle>
       <DialogContent>
         <DialogContentText>
@@ -32,7 +32,7 @@ export default function TypeConversionConfirmDialog({
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} color="primary">
+        <Button onClick={onClose} color="primary">
           Cancel
         </Button>
         <Button onClick={onConfirm} color="primary" variant="contained">

--- a/src/server/api/user/index.ts
+++ b/src/server/api/user/index.ts
@@ -134,9 +134,10 @@ router.patch(
 /**
  * Endpoint for user to edit a file or a longUrl.
  *
- * If editing a file link, only the file can be changed and not
- * the long URL. This is to ensure a one-to-one mapping between
- * the short URL and S3 object key.
+ * The link type (file vs URL redirect) can be changed by supplying
+ * the new content: a destination URL (`longUrl`) or an uploaded file.
+ * Type is inferred from which field is present, same as creation.
+ * The S3 object key remains derived from `shortUrl`.
  */
 router.patch(
   '/url',

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -19,11 +19,11 @@ import dogstatsd, {
   SHORTLINK_CREATE,
   SHORTLINK_CREATE_TAG_IS_FILE,
   SHORTLINK_CREATE_TAG_SOURCE,
+  SHORTLINK_TYPE_CONVERTED,
 } from '../../../util/dogstatsd'
 import {
   AlreadyExistsError,
   AlreadyOwnLinkError,
-  InvalidUrlUpdateError,
   NotFoundError,
 } from '../../../util/error'
 import { addFileExtension, getFileExtension } from '../../../util/fileFormat'
@@ -132,11 +132,16 @@ export class UrlManagementService implements interfaces.UrlManagementService {
 
     if (!url) {
       throw new NotFoundError(`Short link "${shortUrl}" not found for user.`)
-    } else if (url.isFile && options.longUrl) {
-      throw new InvalidUrlUpdateError(`Cannot update longUrl for file.`)
-    } else if (!url.isFile && options.file) {
-      throw new InvalidUrlUpdateError(`Cannot update file for link.`)
     }
+
+    const wasFile = url.isFile
+    let isFile: boolean | undefined
+    if (file) {
+      isFile = true
+    } else if (longUrl !== undefined) {
+      isFile = false
+    }
+    const typeChanged = isFile !== undefined && isFile !== wasFile
 
     const storableFile: StorableFile | undefined = file
       ? {
@@ -156,7 +161,7 @@ export class UrlManagementService implements interfaces.UrlManagementService {
         }).toISOString()
       : undefined
 
-    return this.urlRepository.update(
+    const result = await this.urlRepository.update(
       url,
       {
         longUrl,
@@ -165,9 +170,18 @@ export class UrlManagementService implements interfaces.UrlManagementService {
         contactEmail,
         tags,
         safeBrowsingExpiry,
+        ...(isFile !== undefined ? { isFile } : {}),
       },
       storableFile,
     )
+
+    if (typeChanged) {
+      dogstatsd.increment(SHORTLINK_TYPE_CONVERTED, 1, 1, [
+        `direction:${wasFile ? 'file_to_link' : 'link_to_file'}`,
+      ])
+    }
+
+    return result
   }
 
   changeOwnership: (

--- a/src/server/modules/user/services/UrlManagementService.ts
+++ b/src/server/modules/user/services/UrlManagementService.ts
@@ -170,7 +170,7 @@ export class UrlManagementService implements interfaces.UrlManagementService {
         contactEmail,
         tags,
         safeBrowsingExpiry,
-        ...(isFile !== undefined ? { isFile } : {}),
+        ...(typeChanged && isFile !== undefined ? { isFile } : {}),
       },
       storableFile,
     )

--- a/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
+++ b/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
@@ -219,15 +219,11 @@ describe('UrlManagementService', () => {
       ).resolves.toStrictEqual({ ...fileUrl, isFile: false })
       expect(urlRepository.update).toHaveBeenCalledWith(
         fileUrl,
-        {
+        expect.objectContaining({
           longUrl: 'https://example.com',
-          state: undefined,
-          description: undefined,
-          contactEmail: undefined,
-          tags: undefined,
-          safeBrowsingExpiry: expect.stringMatching(DATETIME_REGEX),
           isFile: false,
-        },
+          safeBrowsingExpiry: expect.stringMatching(DATETIME_REGEX),
+        }),
         undefined,
       )
       expect(dogstatsd.increment).toHaveBeenCalledWith(
@@ -246,15 +242,7 @@ describe('UrlManagementService', () => {
       ).resolves.toStrictEqual({ ...linkUrl, isFile: true })
       expect(urlRepository.update).toHaveBeenCalledWith(
         linkUrl,
-        {
-          longUrl: undefined,
-          state: undefined,
-          description: undefined,
-          contactEmail: undefined,
-          tags: undefined,
-          safeBrowsingExpiry: undefined,
-          isFile: true,
-        },
+        expect.objectContaining({ isFile: true }),
         {
           data: file.data,
           key: `${linkUrl.shortUrl}.json`,
@@ -311,7 +299,7 @@ describe('UrlManagementService', () => {
       )
       expect(urlRepository.update).toHaveBeenCalledWith(
         linkUrl,
-        { ...options, isFile: false },
+        options,
         undefined,
       )
     })
@@ -330,7 +318,7 @@ describe('UrlManagementService', () => {
       )
       expect(urlRepository.update).toHaveBeenCalledWith(
         fileUrl,
-        { isFile: true },
+        {},
         {
           data: file.data,
           key: `${fileUrl.shortUrl}.json`,

--- a/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
+++ b/src/server/modules/user/services/__tests__/UrlManagementService.test.ts
@@ -6,6 +6,7 @@ import {
   NotFoundError,
 } from '../../../../util/error'
 import { DATETIME_REGEX } from '../../../../../../test/integration/util/helpers'
+import dogstatsd, { SHORTLINK_TYPE_CONVERTED } from '../../../../util/dogstatsd'
 
 describe('UrlManagementService', () => {
   const userRepository = {
@@ -189,6 +190,11 @@ describe('UrlManagementService', () => {
     beforeEach(() => {
       userRepository.findOneUrlForUser.mockReset()
       urlRepository.update.mockReset()
+      jest.spyOn(dogstatsd, 'increment').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
     })
 
     it('throws NotFoundError on no url', async () => {
@@ -203,30 +209,91 @@ describe('UrlManagementService', () => {
       expect(urlRepository.update).not.toHaveBeenCalled()
     })
 
-    it('throws Error when updating file with longUrl', async () => {
+    it('converts a file to a link with longUrl', async () => {
       userRepository.findOneUrlForUser.mockResolvedValue(fileUrl)
+      urlRepository.update.mockResolvedValue({ ...fileUrl, isFile: false })
       await expect(
         service.updateUrl(userId, fileUrl.shortUrl, {
           longUrl: 'https://example.com',
         }),
-      ).rejects.toBeInstanceOf(Error)
-      expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
-        userId,
-        fileUrl.shortUrl,
+      ).resolves.toStrictEqual({ ...fileUrl, isFile: false })
+      expect(urlRepository.update).toHaveBeenCalledWith(
+        fileUrl,
+        {
+          longUrl: 'https://example.com',
+          state: undefined,
+          description: undefined,
+          contactEmail: undefined,
+          tags: undefined,
+          safeBrowsingExpiry: expect.stringMatching(DATETIME_REGEX),
+          isFile: false,
+        },
+        undefined,
       )
-      expect(urlRepository.update).not.toHaveBeenCalled()
+      expect(dogstatsd.increment).toHaveBeenCalledWith(
+        SHORTLINK_TYPE_CONVERTED,
+        1,
+        1,
+        ['direction:file_to_link'],
+      )
     })
 
-    it('throws Error when updating link with file', async () => {
+    it('converts a link to a file', async () => {
       userRepository.findOneUrlForUser.mockResolvedValue(linkUrl)
+      urlRepository.update.mockResolvedValue({ ...linkUrl, isFile: true })
       await expect(
         service.updateUrl(userId, linkUrl.shortUrl, { file }),
-      ).rejects.toBeInstanceOf(Error)
-      expect(userRepository.findOneUrlForUser).toHaveBeenCalledWith(
-        userId,
-        linkUrl.shortUrl,
+      ).resolves.toStrictEqual({ ...linkUrl, isFile: true })
+      expect(urlRepository.update).toHaveBeenCalledWith(
+        linkUrl,
+        {
+          longUrl: undefined,
+          state: undefined,
+          description: undefined,
+          contactEmail: undefined,
+          tags: undefined,
+          safeBrowsingExpiry: undefined,
+          isFile: true,
+        },
+        {
+          data: file.data,
+          key: `${linkUrl.shortUrl}.json`,
+          mimetype: file.mimetype,
+        },
       )
-      expect(urlRepository.update).not.toHaveBeenCalled()
+      expect(dogstatsd.increment).toHaveBeenCalledWith(
+        SHORTLINK_TYPE_CONVERTED,
+        1,
+        1,
+        ['direction:link_to_file'],
+      )
+    })
+
+    it('does not fire conversion metric on same-type link edit', async () => {
+      userRepository.findOneUrlForUser.mockResolvedValue(linkUrl)
+      urlRepository.update.mockResolvedValue(linkUrl)
+      await service.updateUrl(userId, linkUrl.shortUrl, {
+        ...options,
+        file: undefined,
+      })
+      expect(dogstatsd.increment).not.toHaveBeenCalledWith(
+        SHORTLINK_TYPE_CONVERTED,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('does not fire conversion metric on same-type file replace', async () => {
+      userRepository.findOneUrlForUser.mockResolvedValue(fileUrl)
+      urlRepository.update.mockResolvedValue(fileUrl)
+      await service.updateUrl(userId, fileUrl.shortUrl, { file })
+      expect(dogstatsd.increment).not.toHaveBeenCalledWith(
+        SHORTLINK_TYPE_CONVERTED,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
     })
 
     it('updates a non-file url', async () => {
@@ -244,7 +311,7 @@ describe('UrlManagementService', () => {
       )
       expect(urlRepository.update).toHaveBeenCalledWith(
         linkUrl,
-        options,
+        { ...options, isFile: false },
         undefined,
       )
     })
@@ -263,7 +330,7 @@ describe('UrlManagementService', () => {
       )
       expect(urlRepository.update).toHaveBeenCalledWith(
         fileUrl,
-        {},
+        { isFile: true },
         {
           data: file.data,
           key: `${fileUrl.shortUrl}.json`,

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -157,6 +157,10 @@ export class UrlRepository implements UrlRepositoryInterface {
       } else if (isConvertingToFile) {
         const newKey = file.key
         await this.fileBucket.uploadFileToS3(file.data, newKey, file.mimetype)
+        const resultingState = updateParams.state ?? url.state
+        if (resultingState === StorableUrlState.Inactive) {
+          await this.fileBucket.setS3ObjectACL(newKey, Private)
+        }
         await url.update(
           {
             ...updateParams,

--- a/src/server/repositories/UrlRepository.ts
+++ b/src/server/repositories/UrlRepository.ts
@@ -147,7 +147,25 @@ export class UrlRepository implements UrlRepositoryInterface {
           tagStrings: updateParams.tags.join(TAG_SEPARATOR),
         }
       }
-      if (!url.isFile) {
+      const isConvertingToLink = url.isFile && updateParams.isFile === false
+      const isConvertingToFile = !url.isFile && file
+
+      if (isConvertingToLink) {
+        const currentKey = this.fileBucket.getKeyFromLongUrl(url.longUrl)
+        await this.fileBucket.setS3ObjectACL(currentKey, Private)
+        await url.update(updateParams, { transaction: t })
+      } else if (isConvertingToFile) {
+        const newKey = file.key
+        await this.fileBucket.uploadFileToS3(file.data, newKey, file.mimetype)
+        await url.update(
+          {
+            ...updateParams,
+            longUrl: this.fileBucket.buildFileLongUrl(newKey),
+            isFile: true,
+          },
+          { transaction: t },
+        )
+      } else if (!url.isFile) {
         await url.update(updateParams, { transaction: t })
       } else {
         let currentKey = this.fileBucket.getKeyFromLongUrl(url.longUrl)

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -21,6 +21,7 @@ export const SHORTLINK_CLICKS = 'shortlink.clicks'
 export const SHORTLINK_CREATE = 'shortlink.create'
 export const SHORTLINK_CREATE_TAG_IS_FILE = 'isfile'
 export const SHORTLINK_CREATE_TAG_SOURCE = 'source'
+export const SHORTLINK_TYPE_CONVERTED = 'shortlink.type_converted'
 export const USER_NEW = 'user.new'
 
 export const BULK_VALIDATION_ERROR = 'bulk.validation.error'

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -637,103 +637,66 @@ describe('UrlRepository', () => {
       )
     })
 
-    it('should convert a URL link to a file link', async () => {
-      const newKey = `${baseShortUrl}.csv`
-      const newLongUrl = fileBucket.buildFileLongUrl(newKey)
-      const file = {
-        key: newKey,
-        data: Buffer.from(''),
-        mimetype: 'text/csv',
-      }
-      const update = jest.fn()
-      const setTags = jest.fn()
-      const url = {
-        ...baseUrl,
-        isFile: false,
-        update: update.mockImplementationOnce((params) => {
-          Object.assign(url, params)
-        }),
-        setTags,
-      }
-      const expectedUrl = {
-        ...baseStorableUrl,
-        isFile: true,
-        longUrl: newLongUrl,
-        tags: [],
-      }
+    it.each([
+      ['active', StorableUrlState.Active, false],
+      ['inactive', StorableUrlState.Inactive, true],
+    ])(
+      'should convert a %s URL link to a file link',
+      async (_label, state, expectPrivateAcl) => {
+        const newKey = `${baseShortUrl}.csv`
+        const newLongUrl = fileBucket.buildFileLongUrl(newKey)
+        const file = {
+          key: newKey,
+          data: Buffer.from(''),
+          mimetype: 'text/csv',
+        }
+        const update = jest.fn()
+        const setTags = jest.fn()
+        const url = {
+          ...baseUrl,
+          isFile: false,
+          state,
+          update: update.mockImplementationOnce((params) => {
+            Object.assign(url, params)
+          }),
+          setTags,
+        }
 
-      scope.mockImplementation(() => urlModelMock)
-      findOne.mockResolvedValue(url)
+        scope.mockImplementation(() => urlModelMock)
+        findOne.mockResolvedValue(url)
 
-      await expect(
-        repository.update({ shortUrl: baseShortUrl }, { isFile: true }, file),
-      ).resolves.toEqual(expectedUrl)
-      expect(putObject).toHaveBeenCalledWith({
-        ContentType: file.mimetype,
-        Bucket: s3Bucket,
-        Body: file.data,
-        Key: file.key,
-        ACL: FileVisibility.Public,
-        CacheControl: 'no-cache',
-      })
-      expect(putObjectAcl).not.toHaveBeenCalled()
-      expect(update).toHaveBeenCalledWith(
-        { isFile: true, longUrl: newLongUrl },
-        expect.anything(),
-      )
-    })
-
-    it('should convert an inactive URL link to a file link with private S3 ACL', async () => {
-      const newKey = `${baseShortUrl}.csv`
-      const newLongUrl = fileBucket.buildFileLongUrl(newKey)
-      const file = {
-        key: newKey,
-        data: Buffer.from(''),
-        mimetype: 'text/csv',
-      }
-      const update = jest.fn()
-      const setTags = jest.fn()
-      const url = {
-        ...baseUrl,
-        isFile: false,
-        state: StorableUrlState.Inactive,
-        update: update.mockImplementationOnce((params) => {
-          Object.assign(url, params)
-        }),
-        setTags,
-      }
-      const expectedUrl = {
-        ...baseStorableUrl,
-        isFile: true,
-        longUrl: newLongUrl,
-        state: StorableUrlState.Inactive,
-        tags: [],
-      }
-
-      scope.mockImplementation(() => urlModelMock)
-      findOne.mockResolvedValue(url)
-
-      await expect(
-        repository.update({ shortUrl: baseShortUrl }, { isFile: true }, file),
-      ).resolves.toEqual(expectedUrl)
-      expect(putObject).toHaveBeenCalledWith({
-        ContentType: file.mimetype,
-        Bucket: s3Bucket,
-        Body: file.data,
-        Key: file.key,
-        ACL: FileVisibility.Public,
-        CacheControl: 'no-cache',
-      })
-      expect(putObjectAcl).toHaveBeenCalledWith({
-        Bucket: s3Bucket,
-        Key: newKey,
-        ACL: FileVisibility.Private,
-      })
-      expect(update).toHaveBeenCalledWith(
-        { isFile: true, longUrl: newLongUrl },
-        expect.anything(),
-      )
-    })
+        await expect(
+          repository.update({ shortUrl: baseShortUrl }, { isFile: true }, file),
+        ).resolves.toEqual({
+          ...baseStorableUrl,
+          isFile: true,
+          longUrl: newLongUrl,
+          state,
+          tags: [],
+        })
+        expect(putObject).toHaveBeenCalledWith({
+          ContentType: file.mimetype,
+          Bucket: s3Bucket,
+          Body: file.data,
+          Key: file.key,
+          ACL: FileVisibility.Public,
+          CacheControl: 'no-cache',
+        })
+        if (expectPrivateAcl) {
+          expect(putObjectAcl).toHaveBeenCalledWith({
+            Bucket: s3Bucket,
+            Key: newKey,
+            ACL: FileVisibility.Private,
+          })
+        } else {
+          expect(putObjectAcl).not.toHaveBeenCalled()
+        }
+        expect(update).toHaveBeenCalledWith(
+          { isFile: true, longUrl: newLongUrl },
+          expect.anything(),
+        )
+      },
+    )
   })
 
   describe('getLongUrl', () => {

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -682,6 +682,58 @@ describe('UrlRepository', () => {
         expect.anything(),
       )
     })
+
+    it('should convert an inactive URL link to a file link with private S3 ACL', async () => {
+      const newKey = `${baseShortUrl}.csv`
+      const newLongUrl = fileBucket.buildFileLongUrl(newKey)
+      const file = {
+        key: newKey,
+        data: Buffer.from(''),
+        mimetype: 'text/csv',
+      }
+      const update = jest.fn()
+      const setTags = jest.fn()
+      const url = {
+        ...baseUrl,
+        isFile: false,
+        state: StorableUrlState.Inactive,
+        update: update.mockImplementationOnce((params) => {
+          Object.assign(url, params)
+        }),
+        setTags,
+      }
+      const expectedUrl = {
+        ...baseStorableUrl,
+        isFile: true,
+        longUrl: newLongUrl,
+        state: StorableUrlState.Inactive,
+        tags: [],
+      }
+
+      scope.mockImplementation(() => urlModelMock)
+      findOne.mockResolvedValue(url)
+
+      await expect(
+        repository.update({ shortUrl: baseShortUrl }, { isFile: true }, file),
+      ).resolves.toEqual(expectedUrl)
+      expect(putObject).toHaveBeenCalledWith({
+        ContentType: file.mimetype,
+        Bucket: s3Bucket,
+        Body: file.data,
+        Key: file.key,
+        ACL: FileVisibility.Public,
+        CacheControl: 'no-cache',
+      })
+      expect(putObjectAcl).toHaveBeenCalledWith({
+        Bucket: s3Bucket,
+        Key: newKey,
+        ACL: FileVisibility.Private,
+      })
+      expect(update).toHaveBeenCalledWith(
+        { isFile: true, longUrl: newLongUrl },
+        expect.anything(),
+      )
+    })
   })
 
   describe('getLongUrl', () => {

--- a/test/server/repositories/UrlRepository.test.ts
+++ b/test/server/repositories/UrlRepository.test.ts
@@ -593,6 +593,95 @@ describe('UrlRepository', () => {
         CacheControl: 'no-cache',
       })
     })
+
+    it('should convert a file link to a URL link', async () => {
+      const oldKey = 'old-key'
+      const longUrl = fileBucket.buildFileLongUrl(oldKey)
+      const newLongUrl = 'https://www.example.gov.sg'
+      const update = jest.fn()
+      const setTags = jest.fn()
+      const url = {
+        ...baseUrl,
+        isFile: true,
+        longUrl,
+        update: update.mockImplementationOnce((params) => {
+          Object.assign(url, params)
+        }),
+        setTags,
+      }
+      const expectedUrl = {
+        ...baseStorableUrl,
+        isFile: false,
+        longUrl: newLongUrl,
+        tags: [],
+      }
+
+      scope.mockImplementation(() => urlModelMock)
+      findOne.mockResolvedValue(url)
+
+      await expect(
+        repository.update(
+          { shortUrl: baseShortUrl },
+          { longUrl: newLongUrl, isFile: false },
+        ),
+      ).resolves.toEqual(expectedUrl)
+      expect(putObjectAcl).toHaveBeenCalledWith({
+        Bucket: s3Bucket,
+        Key: oldKey,
+        ACL: FileVisibility.Private,
+      })
+      expect(putObject).not.toHaveBeenCalled()
+      expect(update).toHaveBeenCalledWith(
+        { longUrl: newLongUrl, isFile: false },
+        expect.anything(),
+      )
+    })
+
+    it('should convert a URL link to a file link', async () => {
+      const newKey = `${baseShortUrl}.csv`
+      const newLongUrl = fileBucket.buildFileLongUrl(newKey)
+      const file = {
+        key: newKey,
+        data: Buffer.from(''),
+        mimetype: 'text/csv',
+      }
+      const update = jest.fn()
+      const setTags = jest.fn()
+      const url = {
+        ...baseUrl,
+        isFile: false,
+        update: update.mockImplementationOnce((params) => {
+          Object.assign(url, params)
+        }),
+        setTags,
+      }
+      const expectedUrl = {
+        ...baseStorableUrl,
+        isFile: true,
+        longUrl: newLongUrl,
+        tags: [],
+      }
+
+      scope.mockImplementation(() => urlModelMock)
+      findOne.mockResolvedValue(url)
+
+      await expect(
+        repository.update({ shortUrl: baseShortUrl }, { isFile: true }, file),
+      ).resolves.toEqual(expectedUrl)
+      expect(putObject).toHaveBeenCalledWith({
+        ContentType: file.mimetype,
+        Bucket: s3Bucket,
+        Body: file.data,
+        Key: file.key,
+        ACL: FileVisibility.Public,
+        CacheControl: 'no-cache',
+      })
+      expect(putObjectAcl).not.toHaveBeenCalled()
+      expect(update).toHaveBeenCalledWith(
+        { isFile: true, longUrl: newLongUrl },
+        expect.anything(),
+      )
+    })
   })
 
   describe('getLongUrl', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Short links are fixed as either a **Link** (`isFile: false`, redirects to `longUrl`) or a **File** (`isFile: true`, serves an uploaded S3 object) at creation time. Owners who want to change type must delete and recreate the short link, losing the same `shortUrl` and any associated click history.

## Solution

Let owners flip an existing short link's type from the edit drawer, supplying the new content (destination URL or uploaded file) in the same save. Type is inferred implicitly from whichever of `longUrl` / `file` is present in the request — same as creation. No new API field.

**Features**:

- Link/File toggle in the edit drawer, matching the create-flow selector
- Confirmation dialog shown only when the type is actually changed at save time
- Backend support for both directions: Link→File and File→Link
- `SHORTLINK_TYPE_CONVERTED` dogstatsd counter, tagged with conversion direction

**Improvements**:

- Relaxed `UrlManagementService` immutability guards; `isFile` is written only when the type actually changes
- `UrlRepository` handles conversion as distinct branches alongside existing same-type edit paths

**Bug Fixes**:

- Link→File conversion on an inactive link now sets S3 ACL to `Private`, matching existing deactivate-file-link behaviour

## S3 ACL revoke, not delete

On File→Link conversion, the outgoing file's S3 ACL is set to `Private` via `setS3ObjectACL` — the same mechanism used when replacing a file. The object is **not** deleted from the bucket. This reuses an existing, tested pattern; hard-delete / orphan cleanup is out of scope.

## Scope

- Console-only (`PATCH /api/user/url`); external v1 API untouched
- No DB migration — `isFile` and `longUrl` columns already exist
- Click statistics and `UrlHistory` carry over unchanged (same `shortUrl` row)

## Tests

- `UrlManagementService`: conversion both directions, metric only on actual type change, same-type edits unchanged
- `UrlRepository`: File→Link ACL revoke, Link→File upload, inactive Link→File gets private ACL

## Deploy Notes

**New metrics**:

- `go.shortlink.type_converted` — tagged `direction:file_to_link` or `direction:link_to_file`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bae823a-fee2-479b-88d0-7097c434f871?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bae823a-fee2-479b-88d0-7097c434f871&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

