### PR TITLE
feat: support optional custom short URL in CSV bulk upload

### DIFF
--- a/src/client/app/util/download.ts
+++ b/src/client/app/util/download.ts
@@ -5,7 +5,10 @@ import useIsIE from '../components/BaseLayout/util/ie'
 import { GAEvent } from './ga'
 import { UrlTableConfig } from '../../user/reducers/types'
 import queryObjFromTableConfig from '../helpers/urlQueryHelper'
-import { BULK_UPLOAD_HEADER } from '../../../shared/constants'
+import {
+  BULK_UPLOAD_HEADER,
+  BULK_UPLOAD_SHORTURL_HEADER,
+} from '../../../shared/constants'
 
 export const downloadCsv = (csvString: string, filename: string) => {
   const blob = new Blob([csvString], {
@@ -21,8 +24,11 @@ export const downloadCsv = (csvString: string, filename: string) => {
 }
 
 export const downloadSampleBulkCsv = () => {
-  const headers = BULK_UPLOAD_HEADER
-  const body = ['https://www.link1.com', 'https://www.link2.com']
+  const headers = `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}`
+  const body = [
+    'https://www.link1.com,my-custom-link',
+    'https://www.link2.com,',
+  ]
   const content = [headers, ...body].join('\r\n')
   downloadCsv(content, 'sample_bulk.csv')
   GAEvent('modal page', 'downloaded bulk sample', 'successful')

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -40,8 +40,10 @@ export class BulkController {
     }
 
     try {
-      const longUrls = await this.bulkService.parseCsv(file)
-      req.body.longUrls = longUrls
+      const urlRows = await this.bulkService.parseCsv(file)
+      // longUrls kept as string[] for UrlCheckController.bulkUrlCheck
+      req.body.urlRows = urlRows
+      req.body.longUrls = urlRows.map((row) => row.longUrl)
       next()
     } catch (error) {
       res.badRequest(
@@ -56,9 +58,9 @@ export class BulkController {
     res: Response,
     next: NextFunction,
   ) => Promise<void> = async (req, res, next) => {
-    const { userId, longUrls, tags } = req.body
+    const { userId, urlRows, tags } = req.body
     // generate url mappings
-    const urlMappings = await this.bulkService.generateUrlMappings(longUrls)
+    const urlMappings = await this.bulkService.generateUrlMappings(urlRows)
 
     // bulk create
     try {

--- a/src/server/modules/bulk/BulkController.ts
+++ b/src/server/modules/bulk/BulkController.ts
@@ -41,7 +41,6 @@ export class BulkController {
 
     try {
       const urlRows = await this.bulkService.parseCsv(file)
-      // longUrls kept as string[] for UrlCheckController.bulkUrlCheck
       req.body.urlRows = urlRows
       req.body.longUrls = urlRows.map((row) => row.longUrl)
       next()

--- a/src/server/modules/bulk/__tests__/BulkController.test.ts
+++ b/src/server/modules/bulk/__tests__/BulkController.test.ts
@@ -60,20 +60,21 @@ describe('BulkController unit test', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('validateAndParseCsv should add longUrls to request body if csv is valid', async () => {
+    it('validateAndParseCsv should add urlRows and longUrls to request body if csv is valid', async () => {
       const file = { data: Buffer.from('data'), name: 'file.csv' }
       const req = createRequestWithFile(file) as any
       const res = httpMocks.createResponse() as any
       const next = jest.fn() as unknown as express.NextFunction
-      const longUrls = ['https://google.com']
+      const urlRows = [{ longUrl: 'https://google.com' }]
 
       res.badRequest = badRequest
-      mockBulkService.parseCsv.mockReturnValue(longUrls)
+      mockBulkService.parseCsv.mockReturnValue(urlRows)
 
       await controller.validateAndParseCsv(req, res, next)
 
       expect(mockBulkService.parseCsv).toHaveBeenCalled()
-      expect(req.body.longUrls).toEqual(longUrls)
+      expect(req.body.urlRows).toEqual(urlRows)
+      expect(req.body.longUrls).toEqual(['https://google.com'])
       expect(res.badRequest).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalled()
     })
@@ -105,6 +106,7 @@ describe('BulkController unit test', () => {
 
       const userId = 1
       const longUrl = 'https://google.com'
+      const urlRows = [{ longUrl }]
       const urlMappings = [
         {
           shortUrl: 'n2io3n12',
@@ -113,7 +115,7 @@ describe('BulkController unit test', () => {
       ]
 
       const req = httpMocks.createRequest({
-        body: { userId, longUrls: [longUrl] },
+        body: { userId, urlRows },
       })
       const res = httpMocks.createResponse() as any
       res.ok = ok
@@ -148,6 +150,7 @@ describe('BulkController unit test', () => {
 
       const userId = 1
       const longUrl = 'https://google.com'
+      const urlRows = [{ longUrl }]
       const urlMappings = [
         {
           shortUrl: 'n2io3n12',
@@ -156,7 +159,7 @@ describe('BulkController unit test', () => {
       ]
 
       const req = httpMocks.createRequest({
-        body: { userId, longUrls: [longUrl] },
+        body: { userId, urlRows },
       })
       const res = httpMocks.createResponse() as any
       res.ok = ok
@@ -185,6 +188,7 @@ describe('BulkController unit test', () => {
     it('bulkCreate without tags should return success if urls are created', async () => {
       const userId = 1
       const longUrl = 'https://google.com'
+      const urlRows = [{ longUrl }]
       const urlMappings = [
         {
           shortUrl: 'n2io3n12',
@@ -193,7 +197,7 @@ describe('BulkController unit test', () => {
       ]
 
       const req = httpMocks.createRequest({
-        body: { userId, longUrls: [longUrl] },
+        body: { userId, urlRows },
       })
       const res = httpMocks.createResponse() as any
       const next = jest.fn() as unknown as express.NextFunction
@@ -205,7 +209,7 @@ describe('BulkController unit test', () => {
 
       await controller.bulkCreate(req, res, next)
 
-      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalledWith(urlRows)
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,
@@ -222,9 +226,9 @@ describe('BulkController unit test', () => {
         longUrl,
       }
       const urlMappings = [urlMapping, urlMapping]
-      const longUrls = [longUrl, longUrl]
+      const urlRows = [{ longUrl }, { longUrl }]
 
-      const req = httpMocks.createRequest({ body: { userId, longUrls } })
+      const req = httpMocks.createRequest({ body: { userId, urlRows } })
       const res = httpMocks.createResponse() as any
       const next = jest.fn() as unknown as express.NextFunction
 
@@ -235,7 +239,7 @@ describe('BulkController unit test', () => {
 
       await controller.bulkCreate(req, res, next)
 
-      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalledWith(urlRows)
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,
@@ -247,6 +251,7 @@ describe('BulkController unit test', () => {
     it('bulkCreate with tags should return success if urls are created', async () => {
       const userId = 1
       const longUrl = 'https://google.com'
+      const urlRows = [{ longUrl }]
       const urlMappings = [
         {
           shortUrl: 'n2io3n12',
@@ -256,7 +261,7 @@ describe('BulkController unit test', () => {
       const tags = ['a', 'b']
 
       const req = httpMocks.createRequest({
-        body: { userId, longUrls: [longUrl], tags },
+        body: { userId, urlRows, tags },
       })
       const res = httpMocks.createResponse() as any
       const next = jest.fn() as unknown as express.NextFunction
@@ -268,7 +273,7 @@ describe('BulkController unit test', () => {
 
       await controller.bulkCreate(req, res, next)
 
-      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalledWith(urlRows)
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,
@@ -285,10 +290,10 @@ describe('BulkController unit test', () => {
         longUrl,
       }
       const urlMappings = [urlMapping, urlMapping]
-      const longUrls = [longUrl, longUrl]
+      const urlRows = [{ longUrl }, { longUrl }]
       const tags = ['a', 'b']
 
-      const req = httpMocks.createRequest({ body: { userId, longUrls, tags } })
+      const req = httpMocks.createRequest({ body: { userId, urlRows, tags } })
       const res = httpMocks.createResponse() as any
       const next = jest.fn() as unknown as express.NextFunction
 
@@ -299,7 +304,7 @@ describe('BulkController unit test', () => {
 
       await controller.bulkCreate(req, res, next)
 
-      expect(mockBulkService.generateUrlMappings).toHaveBeenCalled()
+      expect(mockBulkService.generateUrlMappings).toHaveBeenCalledWith(urlRows)
       expect(mockUrlManagementService.bulkCreate).toHaveBeenCalledWith(
         userId,
         urlMappings,

--- a/src/server/modules/bulk/interfaces/BulkService.ts
+++ b/src/server/modules/bulk/interfaces/BulkService.ts
@@ -1,8 +1,13 @@
 import { UploadedFile } from 'express-fileupload'
 import { BulkUrlMapping } from '../../../repositories/types'
 
-export interface BulkService {
-  parseCsv(file: UploadedFile): Promise<string[]>
+export type BulkCsvRow = {
+  longUrl: string
+  shortUrl?: string
+}
 
-  generateUrlMappings(longUrls: string[]): Promise<BulkUrlMapping[]>
+export interface BulkService {
+  parseCsv(file: UploadedFile): Promise<BulkCsvRow[]>
+
+  generateUrlMappings(rows: BulkCsvRow[]): Promise<BulkUrlMapping[]>
 }

--- a/src/server/modules/bulk/interfaces/index.ts
+++ b/src/server/modules/bulk/interfaces/index.ts
@@ -1,1 +1,2 @@
 export { BulkService, BulkService as default } from './BulkService'
+export type { BulkCsvRow } from './BulkService'

--- a/src/server/modules/bulk/services/BulkService.ts
+++ b/src/server/modules/bulk/services/BulkService.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
 import * as Papa from 'papaparse'
 import { UploadedFile } from 'express-fileupload'
 import * as interfaces from '../interfaces/BulkService'
@@ -8,8 +8,13 @@ import {
   bulkUploadRandomStrLength,
   ogHostname,
 } from '../../../config'
-import { BULK_UPLOAD_HEADER } from '../../../../shared/constants'
+import {
+  BULK_UPLOAD_HEADER,
+  BULK_UPLOAD_SHORTURL_HEADER,
+} from '../../../../shared/constants'
 import { BulkUrlMapping } from '../../../repositories/types'
+import { UrlRepositoryInterface } from '../../../repositories/interfaces/UrlRepositoryInterface'
+import { DependencyIds } from '../../../constants'
 import * as validators from '../../../../shared/util/validation'
 import generateShortUrl from '../../../util/url'
 import dogstatsd, {
@@ -22,16 +27,29 @@ const BULK_UPLOAD_MAX_NUM = bulkUploadMaxNum
 
 @injectable()
 export class BulkService implements interfaces.BulkService {
-  parseCsv: (file: UploadedFile) => Promise<string[]> = async (file) => {
+  private urlRepository: UrlRepositoryInterface
+
+  public constructor(
+    @inject(DependencyIds.urlRepository)
+    urlRepository: UrlRepositoryInterface,
+  ) {
+    this.urlRepository = urlRepository
+  }
+
+  parseCsv: (file: UploadedFile) => Promise<interfaces.BulkCsvRow[]> = async (
+    file,
+  ) => {
     const dataString = file.data?.toString()
 
-    const longUrls: string[] = []
+    const rows: interfaces.BulkCsvRow[] = []
+    const claimedShortUrls = new Set<string>()
 
     if (!dataString) {
       throw new Error('csv file is empty')
     }
 
     let counter = 0
+    let hasShortUrlColumn = false
 
     return new Promise((resolve, reject) => {
       Papa.parse(dataString, {
@@ -39,23 +57,56 @@ export class BulkService implements interfaces.BulkService {
         delimiter: ',',
         complete: () => {
           // check for empty file
-          if (longUrls.length === 0) {
+          if (rows.length === 0) {
             dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
               `${BULK_VALIDATION_ERROR_TAGS.hasUrls}`,
             ])
             reject(new Error('csv file is empty'))
+            return
           }
-          resolve(longUrls)
+
+          // Validate custom short URL availability against the DB after
+          // format/within-file checks. Fail fast on the first taken slug.
+          ;(async () => {
+            for (let i = 0; i < rows.length; i += 1) {
+              const { shortUrl } = rows[i]
+              if (!shortUrl) {
+                // eslint-disable-next-line no-continue
+                continue
+              }
+              // eslint-disable-next-line no-await-in-loop
+              const isAvailable = await this.urlRepository.isShortUrlAvailable(
+                shortUrl,
+              )
+              if (!isAvailable) {
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isShortUrlAvailable}`,
+                ])
+                throw new Error(`Row ${i + 2}: ${shortUrl} is already taken`)
+              }
+            }
+            resolve(rows)
+          })().catch(reject)
         },
         error: (error: Error) => {
           reject(error)
         },
-        step(step) {
+        step: (step) => {
           const rowData = step.data as string[]
-          const stringData = rowData[0].trim()
 
           if (counter === 0) {
-            if (stringData !== BULK_UPLOAD_HEADER) {
+            const firstHeader = (rowData[0] || '').trim()
+            const secondHeader =
+              rowData.length > 1 ? (rowData[1] || '').trim() : undefined
+
+            const isValidOneColumnHeader =
+              rowData.length === 1 && firstHeader === BULK_UPLOAD_HEADER
+            const isValidTwoColumnHeader =
+              rowData.length === 2 &&
+              firstHeader === BULK_UPLOAD_HEADER &&
+              secondHeader === BULK_UPLOAD_SHORTURL_HEADER
+
+            if (!isValidOneColumnHeader && !isValidTwoColumnHeader) {
               dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                 `${BULK_VALIDATION_ERROR_TAGS.validHeader}`,
               ])
@@ -63,17 +114,31 @@ export class BulkService implements interfaces.BulkService {
                 `Row ${counter + 1}: bulk upload header is invalid`,
               )
             }
+            hasShortUrlColumn = isValidTwoColumnHeader
           } else {
+            const longUrl = (rowData[0] || '').trim()
+            const rawShortUrl =
+              hasShortUrlColumn && rowData.length > 1
+                ? (rowData[1] || '').trim()
+                : ''
+            const shortUrl = rawShortUrl.length > 0 ? rawShortUrl : undefined
+
             const acceptableLinkCount = counter <= BULK_UPLOAD_MAX_NUM // rows include header
-            const onlyOneColumn = rowData.length === 1
-            const isNotBlacklisted = !validators.isBlacklisted(stringData)
-            const isEmpty = stringData.length === 0
-            const isValidUrl = validators.isValidUrl(stringData)
+            const acceptableColumnCount = hasShortUrlColumn
+              ? rowData.length <= 2
+              : rowData.length === 1
+            const isNotBlacklisted = !validators.isBlacklisted(longUrl)
+            const isEmpty = longUrl.length === 0
+            const isValidUrl = validators.isValidUrl(longUrl)
             const isNotCircularRedirect = !validators.isCircularRedirects(
-              stringData,
+              longUrl,
               ogHostname,
             )
             const noParsingError = step.errors.length === 0
+            const isValidShortUrl =
+              shortUrl === undefined || validators.isValidShortUrl(shortUrl)
+            const isShortUrlNotClaimed =
+              shortUrl === undefined || !claimedShortUrls.has(shortUrl)
 
             switch (true) {
               case !acceptableLinkCount:
@@ -83,7 +148,7 @@ export class BulkService implements interfaces.BulkService {
                 throw new Error(
                   `File exceeded ${BULK_UPLOAD_MAX_NUM} original URLs to shorten`,
                 )
-              case !onlyOneColumn:
+              case !acceptableColumnCount:
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                   `${BULK_VALIDATION_ERROR_TAGS.onlyOneColumn}`,
                 ])
@@ -101,16 +166,12 @@ export class BulkService implements interfaces.BulkService {
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                   `${BULK_VALIDATION_ERROR_TAGS.isValidUrl}`,
                 ])
-                throw new Error(
-                  `Row ${counter + 1}: ${stringData} is not valid`,
-                )
+                throw new Error(`Row ${counter + 1}: ${longUrl} is not valid`)
               case !isNotBlacklisted:
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                   `${BULK_VALIDATION_ERROR_TAGS.isNotBlacklisted}`,
                 ])
-                throw new Error(
-                  `Row ${counter + 1}: ${stringData} is blacklisted`,
-                )
+                throw new Error(`Row ${counter + 1}: ${longUrl} is blacklisted`)
               case !isNotCircularRedirect:
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                   `${BULK_VALIDATION_ERROR_TAGS.isNotCircularRedirect}`,
@@ -118,7 +179,21 @@ export class BulkService implements interfaces.BulkService {
                 throw new Error(
                   `Row ${
                     counter + 1
-                  }: ${stringData} redirects back to ${ogHostname}`,
+                  }: ${longUrl} redirects back to ${ogHostname}`,
+                )
+              case !isValidShortUrl:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isValidShortUrl}`,
+                ])
+                throw new Error(
+                  `Row ${counter + 1}: ${shortUrl} is not a valid short link`,
+                )
+              case !isShortUrlNotClaimed:
+                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+                  `${BULK_VALIDATION_ERROR_TAGS.isShortUrlAvailable}`,
+                ])
+                throw new Error(
+                  `Row ${counter + 1}: ${shortUrl} is already taken`,
                 )
               case !noParsingError:
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
@@ -128,7 +203,12 @@ export class BulkService implements interfaces.BulkService {
               default:
               // no error, do nothing
             }
-            longUrls.push(stringData)
+            if (shortUrl) {
+              claimedShortUrls.add(shortUrl)
+              rows.push({ longUrl, shortUrl })
+            } else {
+              rows.push({ longUrl })
+            }
           }
           counter += 1
         },
@@ -136,17 +216,19 @@ export class BulkService implements interfaces.BulkService {
     })
   }
 
-  generateUrlMappings: (longUrls: string[]) => Promise<BulkUrlMapping[]> =
-    async (longUrls) => {
-      return Promise.all(
-        longUrls.map(async (longUrl) => {
-          return {
-            longUrl,
-            shortUrl: await generateShortUrl(BULK_UPLOAD_RANDOM_STR_LENGTH),
-          }
-        }),
-      )
-    }
+  generateUrlMappings: (
+    rows: interfaces.BulkCsvRow[],
+  ) => Promise<BulkUrlMapping[]> = async (rows) => {
+    return Promise.all(
+      rows.map(async ({ longUrl, shortUrl }) => {
+        return {
+          longUrl,
+          shortUrl:
+            shortUrl ?? (await generateShortUrl(BULK_UPLOAD_RANDOM_STR_LENGTH)),
+        }
+      }),
+    )
+  }
 }
 
 export default BulkService

--- a/src/server/modules/bulk/services/BulkService.ts
+++ b/src/server/modules/bulk/services/BulkService.ts
@@ -36,6 +36,26 @@ export class BulkService implements interfaces.BulkService {
     this.urlRepository = urlRepository
   }
 
+  private validateShortUrlAvailability = async (
+    rows: interfaces.BulkCsvRow[],
+  ): Promise<void> => {
+    for (let i = 0; i < rows.length; i += 1) {
+      const { shortUrl } = rows[i]
+      if (shortUrl) {
+        // eslint-disable-next-line no-await-in-loop
+        const isAvailable = await this.urlRepository.isShortUrlAvailable(
+          shortUrl,
+        )
+        if (!isAvailable) {
+          dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
+            `${BULK_VALIDATION_ERROR_TAGS.isShortUrlAvailable}`,
+          ])
+          throw new Error(`Row ${i + 2}: ${shortUrl} is already taken`)
+        }
+      }
+    }
+  }
+
   parseCsv: (file: UploadedFile) => Promise<interfaces.BulkCsvRow[]> = async (
     file,
   ) => {
@@ -55,7 +75,7 @@ export class BulkService implements interfaces.BulkService {
       Papa.parse(dataString, {
         skipEmptyLines: 'greedy',
         delimiter: ',',
-        complete: () => {
+        complete: async () => {
           // check for empty file
           if (rows.length === 0) {
             dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
@@ -64,29 +84,12 @@ export class BulkService implements interfaces.BulkService {
             reject(new Error('csv file is empty'))
             return
           }
-
-          // Validate custom short URL availability against the DB after
-          // format/within-file checks. Fail fast on the first taken slug.
-          ;(async () => {
-            for (let i = 0; i < rows.length; i += 1) {
-              const { shortUrl } = rows[i]
-              if (!shortUrl) {
-                // eslint-disable-next-line no-continue
-                continue
-              }
-              // eslint-disable-next-line no-await-in-loop
-              const isAvailable = await this.urlRepository.isShortUrlAvailable(
-                shortUrl,
-              )
-              if (!isAvailable) {
-                dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
-                  `${BULK_VALIDATION_ERROR_TAGS.isShortUrlAvailable}`,
-                ])
-                throw new Error(`Row ${i + 2}: ${shortUrl} is already taken`)
-              }
-            }
+          try {
+            await this.validateShortUrlAvailability(rows)
             resolve(rows)
-          })().catch(reject)
+          } catch (error) {
+            reject(error)
+          }
         },
         error: (error: Error) => {
           reject(error)
@@ -95,10 +98,8 @@ export class BulkService implements interfaces.BulkService {
           const rowData = step.data as string[]
 
           if (counter === 0) {
-            const firstHeader = (rowData[0] || '').trim()
-            const secondHeader =
-              rowData.length > 1 ? (rowData[1] || '').trim() : undefined
-
+            const firstHeader = rowData[0]?.trim()
+            const secondHeader = rowData[1]?.trim()
             const isValidOneColumnHeader =
               rowData.length === 1 && firstHeader === BULK_UPLOAD_HEADER
             const isValidTwoColumnHeader =
@@ -116,12 +117,10 @@ export class BulkService implements interfaces.BulkService {
             }
             hasShortUrlColumn = isValidTwoColumnHeader
           } else {
-            const longUrl = (rowData[0] || '').trim()
-            const rawShortUrl =
-              hasShortUrlColumn && rowData.length > 1
-                ? (rowData[1] || '').trim()
-                : ''
-            const shortUrl = rawShortUrl.length > 0 ? rawShortUrl : undefined
+            const longUrl = rowData[0].trim()
+            const shortUrl = hasShortUrlColumn
+              ? rowData[1]?.trim() || undefined
+              : undefined
 
             const acceptableLinkCount = counter <= BULK_UPLOAD_MAX_NUM // rows include header
             const acceptableColumnCount = hasShortUrlColumn
@@ -136,9 +135,9 @@ export class BulkService implements interfaces.BulkService {
             )
             const noParsingError = step.errors.length === 0
             const isValidShortUrl =
-              shortUrl === undefined || validators.isValidShortUrl(shortUrl)
-            const isShortUrlNotClaimed =
-              shortUrl === undefined || !claimedShortUrls.has(shortUrl)
+              !shortUrl || validators.isValidShortUrl(shortUrl)
+            const isDuplicateShortUrl =
+              !!shortUrl && claimedShortUrls.has(shortUrl)
 
             switch (true) {
               case !acceptableLinkCount:
@@ -188,7 +187,7 @@ export class BulkService implements interfaces.BulkService {
                 throw new Error(
                   `Row ${counter + 1}: ${shortUrl} is not a valid short link`,
                 )
-              case !isShortUrlNotClaimed:
+              case isDuplicateShortUrl:
                 dogstatsd.increment(BULK_VALIDATION_ERROR, 1, 1, [
                   `${BULK_VALIDATION_ERROR_TAGS.isShortUrlAvailable}`,
                 ])
@@ -205,10 +204,8 @@ export class BulkService implements interfaces.BulkService {
             }
             if (shortUrl) {
               claimedShortUrls.add(shortUrl)
-              rows.push({ longUrl, shortUrl })
-            } else {
-              rows.push({ longUrl })
             }
+            rows.push(shortUrl ? { longUrl, shortUrl } : { longUrl })
           }
           counter += 1
         },

--- a/src/server/modules/bulk/services/__tests__/BulkService.test.ts
+++ b/src/server/modules/bulk/services/__tests__/BulkService.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable global-require */
 import { UploadedFile } from 'express-fileupload'
-import { BULK_UPLOAD_HEADER } from '../../../../../shared/constants'
+import {
+  BULK_UPLOAD_HEADER,
+  BULK_UPLOAD_SHORTURL_HEADER,
+} from '../../../../../shared/constants'
 import blackListedSites from '../../../../resources/blacklist'
 
 /**
@@ -63,6 +66,10 @@ const validUrlTests: UrlTest[] = [
   },
 ]
 
+const mockUrlRepository = {
+  isShortUrlAvailable: jest.fn(),
+}
+
 describe('BulkService tests', () => {
   afterAll(jest.resetModules)
 
@@ -73,7 +80,12 @@ describe('BulkService tests', () => {
       ogHostname: OG_HOST_NAME,
     }))
     const { BulkService } = require('..')
-    const service = new BulkService()
+    const service = new BulkService(mockUrlRepository)
+
+    beforeEach(() => {
+      mockUrlRepository.isShortUrlAvailable.mockReset()
+      mockUrlRepository.isShortUrlAvailable.mockResolvedValue(true)
+    })
 
     it('fails if file data string is empty', async () => {
       await expect(service.parseCsv({})).rejects.toThrowError()
@@ -108,6 +120,135 @@ describe('BulkService tests', () => {
         await expect(service.parseCsv(file)).rejects.toThrowError()
       })
     })
+
+    it('returns longUrl rows for single-column CSV without shortUrl', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER}\nhttps://example.com/a\nhttps://example.com/b`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).resolves.toEqual([
+        { longUrl: 'https://example.com/a' },
+        { longUrl: 'https://example.com/b' },
+      ])
+    })
+
+    it('accepts two-column header with blank custom short links', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,\nhttps://example.com/b,`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).resolves.toEqual([
+        { longUrl: 'https://example.com/a' },
+        { longUrl: 'https://example.com/b' },
+      ])
+    })
+
+    it('accepts two-column CSV with valid custom short links', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,my-campaign-link\nhttps://example.com/b,another-slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).resolves.toEqual([
+        { longUrl: 'https://example.com/a', shortUrl: 'my-campaign-link' },
+        { longUrl: 'https://example.com/b', shortUrl: 'another-slug' },
+      ])
+      expect(mockUrlRepository.isShortUrlAvailable).toHaveBeenCalledWith(
+        'my-campaign-link',
+      )
+      expect(mockUrlRepository.isShortUrlAvailable).toHaveBeenCalledWith(
+        'another-slug',
+      )
+    })
+
+    it('accepts mixed blank and filled custom short links', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,my-campaign-link\nhttps://example.com/b,\nhttps://example.com/c,another-slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).resolves.toEqual([
+        { longUrl: 'https://example.com/a', shortUrl: 'my-campaign-link' },
+        { longUrl: 'https://example.com/b' },
+        { longUrl: 'https://example.com/c', shortUrl: 'another-slug' },
+      ])
+    })
+
+    it('rejects invalid custom short link format', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,Invalid_Slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).rejects.toThrow(
+        'Row 2: Invalid_Slug is not a valid short link',
+      )
+    })
+
+    it('rejects custom short link already taken in the database', async () => {
+      mockUrlRepository.isShortUrlAvailable.mockResolvedValue(false)
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,taken-slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).rejects.toThrow(
+        'Row 2: taken-slug is already taken',
+      )
+    })
+
+    it('rejects duplicate custom short links within the same file', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER}\nhttps://example.com/a,same-slug\nhttps://example.com/b,same-slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).rejects.toThrow(
+        'Row 3: same-slug is already taken',
+      )
+    })
+
+    it('rejects typoed second header', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},Custom Short Link\nhttps://example.com/a,my-slug`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).rejects.toThrow(
+        'Row 1: bulk upload header is invalid',
+      )
+    })
+
+    it('rejects header with more than two columns', async () => {
+      const file = {
+        data: Buffer.from(
+          `${BULK_UPLOAD_HEADER},${BULK_UPLOAD_SHORTURL_HEADER},Extra\nhttps://example.com/a,my-slug,x`,
+        ),
+        name: 'file.csv',
+      } as UploadedFile
+
+      await expect(service.parseCsv(file)).rejects.toThrow(
+        'Row 1: bulk upload header is invalid',
+      )
+    })
   })
 
   describe('generateUrlMappings tests', () => {
@@ -116,13 +257,36 @@ describe('BulkService tests', () => {
       bulkUploadRandomStrLength: BULK_UPLOAD_RANDOM_STR_LENGTH,
     }))
     const { BulkService } = require('..')
-    const service = new BulkService()
+    const service = new BulkService(mockUrlRepository)
 
     it('generateUrlMappings should return shortUrls of specified length', async () => {
       const [urlMapping] = await service.generateUrlMappings([
-        'https://google.com',
+        { longUrl: 'https://google.com' },
       ])
       expect(urlMapping.shortUrl).toHaveLength(BULK_UPLOAD_RANDOM_STR_LENGTH)
+    })
+
+    it('generateUrlMappings uses provided custom shortUrl', async () => {
+      const [urlMapping] = await service.generateUrlMappings([
+        { longUrl: 'https://google.com', shortUrl: 'custom-slug' },
+      ])
+      expect(urlMapping).toEqual({
+        longUrl: 'https://google.com',
+        shortUrl: 'custom-slug',
+      })
+    })
+
+    it('generateUrlMappings mixes custom and generated shortUrls', async () => {
+      const mappings = await service.generateUrlMappings([
+        { longUrl: 'https://a.com', shortUrl: 'custom-a' },
+        { longUrl: 'https://b.com' },
+      ])
+      expect(mappings[0]).toEqual({
+        longUrl: 'https://a.com',
+        shortUrl: 'custom-a',
+      })
+      expect(mappings[1].longUrl).toBe('https://b.com')
+      expect(mappings[1].shortUrl).toHaveLength(BULK_UPLOAD_RANDOM_STR_LENGTH)
     })
   })
 })

--- a/src/server/util/dogstatsd.ts
+++ b/src/server/util/dogstatsd.ts
@@ -33,6 +33,8 @@ export const BULK_VALIDATION_ERROR_TAGS = {
   isValidUrl: 'error_type:is_valid_url',
   isNotBlacklisted: 'error_type:is_not_blacklisted',
   isNotCircularRedirect: 'error_type:is_not_circular_redirect',
+  isValidShortUrl: 'error_type:is_valid_short_url',
+  isShortUrlAvailable: 'error_type:is_short_url_available',
   noParsingError: 'error_type:no_parsing_error',
 }
 export const BULK_CREATE_SUCCESS = 'bulk.hash.success'

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,7 @@ export const MAX_CSV_UPLOAD_SIZE = 5 * 1024 * 1024 // 5 MB
 export const MAX_FILE_UPLOAD_SIZE = 20 * 1024 * 1024 // 20 MB
 export const LINK_DESCRIPTION_MAX_LENGTH = 200
 export const BULK_UPLOAD_HEADER = 'Original links to be shortened'
+export const BULK_UPLOAD_SHORTURL_HEADER = 'Custom short link'
 export const TAG_SEPARATOR = ';'
 export const MAX_NUM_TAGS_PER_LINK = 3
 export const MIN_TAG_SEARCH_LENGTH = 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CSV bulk upload (`POST /api/user/url/bulk`) only accepts a long URL per row and always auto-generates the short slug. Single-link creation already lets users choose a custom `shortUrl`, so bulk upload is missing that parity.

## Solution

Add an optional second CSV column, `Custom short link`. A blank cell keeps today's auto-generate behavior; a non-blank cell uses that slug for the row.

**Features**:

- Optional `Custom short link` column in bulk CSV uploads
- Reuses single-link validation: `isValidShortUrl` format check and `isShortUrlAvailable` uniqueness check
- Detects duplicate custom slugs within the same file (fail-fast, all-or-nothing)
- Updated sample CSV template with filled and blank custom-slug examples

**Improvements**:

- `parseCsv` now returns `{ longUrl, shortUrl? }[]` instead of `string[]`
- `req.body.longUrls` remains a `string[]` for existing threat-scan middleware

**Backward compatibility**:

- Existing single-column CSVs continue to work unchanged
- Two-column CSVs with all blank custom slugs behave the same as single-column uploads

## Before & After Screenshots

N/A — server-side CSV parsing and sample template download only.

## Tests

- `src/server/modules/bulk/services/__tests__/BulkService.test.ts` — single/two-column CSVs, mixed blank/filled rows, invalid format, DB-taken slug, in-file duplicates, header validation
- `src/server/modules/bulk/__tests__/BulkController.test.ts` — `urlRows` / `longUrls` wiring through bulk create flow

```bash
npx jest src/server/modules/bulk --no-coverage
```

## Deploy Notes

No new environment variables, scripts, or dependencies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb81e46d-afb6-4875-bb21-e40e62410d75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb81e46d-afb6-4875-bb21-e40e62410d75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

